### PR TITLE
feat: add render package export

### DIFF
--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -55,6 +55,7 @@ class WorkflowRunResponse(BaseModel):
     steps: List[StepResult]
     outputs: Dict[str, Any] = Field(default_factory=dict)
     session_memory_summary: Dict[str, Any] = Field(default_factory=dict)
+    render_package: Dict[str, Any] = Field(default_factory=dict)
     timestamp: str
 
     @staticmethod

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -46,6 +46,9 @@ class WorkflowRunner:
     Phase 1 session/history:
     - keep minimal in-memory session store
     - return session memory summary in response
+
+    Phase 1 render package:
+    - export a structured delivery package for downstream rendering/editing/publishing
     """
 
     def __init__(self) -> None:
@@ -92,6 +95,7 @@ class WorkflowRunner:
             aggregated_outputs,
         )
         self._save_session_data(req, aggregated_outputs)
+        render_package = self._build_render_package(ctx, aggregated_outputs)
 
         return WorkflowRunResponse(
             workflow_id=req.workflow_id,
@@ -101,6 +105,7 @@ class WorkflowRunner:
             steps=step_results,
             outputs=aggregated_outputs,
             session_memory_summary=session_memory_summary,
+            render_package=render_package,
             timestamp=WorkflowRunResponse.now_timestamp(),
         )
 
@@ -503,6 +508,44 @@ class WorkflowRunner:
                 "visual_style": ctx.input.visual_style,
                 "adapter_status": "pending_api_integration",
                 "next_step": "connect jimeng video generation api",
+            },
+        }
+
+    def _build_render_package(
+        self, ctx: StepContext, outputs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        story = outputs.get("story") or {}
+        storyboard = outputs.get("storyboard") or {}
+        image_prompts = outputs.get("image_prompts") or {}
+        video_prompts = outputs.get("video_prompts") or {}
+        narration = outputs.get("narration") or {}
+        subtitles = outputs.get("subtitles") or {}
+        render_plan = outputs.get("render_plan") or {}
+
+        publish_manifest = {
+            "topic": ctx.input.topic,
+            "session_id": ctx.session_id,
+            "video_provider": self._normalized_video_provider(ctx.input.video_provider),
+            "output_mode": ctx.input.output_mode,
+            "language": ctx.input.language,
+            "voice_style": ctx.input.voice_style,
+            "subtitle_enabled": ctx.input.subtitle_enabled,
+            "scene_count": storyboard.get("scene_count"),
+            "story_title": story.get("title"),
+        }
+
+        return {
+            "format": "render_package_v1",
+            "package_name": f"{ctx.workflow_id}_{ctx.run_id}",
+            "files": {
+                "story.json": story,
+                "storyboard.json": storyboard,
+                "image_prompts.json": image_prompts,
+                "video_prompts.json": video_prompts,
+                "narration.txt": narration.get("full_text", ""),
+                "subtitles.srt": subtitles.get("srt_preview", ""),
+                "render_plan.json": render_plan,
+                "publish_manifest.json": publish_manifest,
             },
         }
 

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -105,6 +105,27 @@ def main() -> None:
     if memory1.get("has_previous_session") is not False:
         _fail(f"first request should have no previous session: {memory1}")
 
+    render_package1 = resp1.get("render_package") or {}
+    files1 = render_package1.get("files") or {}
+    expected_package_keys = [
+        "story.json",
+        "storyboard.json",
+        "image_prompts.json",
+        "video_prompts.json",
+        "narration.txt",
+        "subtitles.srt",
+        "render_plan.json",
+        "publish_manifest.json",
+    ]
+    for key in expected_package_keys:
+        if key not in files1:
+            _fail(f"missing render package file: {key}")
+
+    if not files1.get("narration.txt"):
+        _fail("render_package narration.txt empty")
+    if not files1.get("subtitles.srt"):
+        _fail("render_package subtitles.srt empty")
+
     # 3) second run with same session id
     resp2 = _run_request(base_url, "acceptance-session-001", "小兔子的新冒险")
     memory2 = resp2.get("session_memory_summary") or {}
@@ -117,6 +138,14 @@ def main() -> None:
         _fail(f"previous_topic mismatch: {memory2}")
     if memory2.get("previous_scene_count") != 4:
         _fail(f"previous_scene_count mismatch: {memory2}")
+
+    render_package2 = resp2.get("render_package") or {}
+    files2 = render_package2.get("files") or {}
+    manifest2 = files2.get("publish_manifest.json") or {}
+    if manifest2.get("topic") != "小兔子的新冒险":
+        _fail(f"publish_manifest topic mismatch: {manifest2}")
+    if manifest2.get("video_provider") != "mock":
+        _fail(f"publish_manifest video_provider mismatch: {manifest2}")
 
     _ok("/v1/workflow/run")
     print(json.dumps(resp2, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## Summary

Add render package export support for the multimodal workflow system.

This PR introduces a structured `render_package` in workflow responses so the system can export a delivery-ready content package for downstream rendering, editing, and publishing.

## Changes

- add `render_package` to `WorkflowRunResponse`
- build `render_package_v1` in workflow runner
- include structured package files:
  - `story.json`
  - `storyboard.json`
  - `image_prompts.json`
  - `video_prompts.json`
  - `narration.txt`
  - `subtitles.srt`
  - `render_plan.json`
  - `publish_manifest.json`
- extend acceptance script to validate render package output
- keep session memory validation working with the new response structure

## Why

This change moves project four from returning raw generation results only to exporting a reusable production package, making it easier to connect downstream video generation, editing, and publishing workflows.

## Validation

- `python scripts/acceptance.py` passed
- verified `render_package.files` contains all expected package entries
- verified `publish_manifest.json` reflects the latest request topic and provider