### PR TITLE
feat: add multi-speaker dialogue script workflow skeleton

### DIFF
--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -12,7 +12,7 @@ class StepSpec(BaseModel):
         description=(
             "Step name, e.g. "
             "story/storyboard/image_prompts/video_prompts/"
-            "narration/subtitles/render_plan"
+            "dialogue_script/narration/subtitles/render_plan"
         ),
     )
 
@@ -24,6 +24,15 @@ class WorkflowInput(BaseModel):
     visual_style: str = Field(default="storybook")
     character_style: str = Field(default="animal")
     voice_style: str = Field(default="warm_female")
+    voiceover_enabled: bool = Field(default=False)
+    voice_mode: str = Field(default="single")
+    speaker_profiles: Dict[str, str] = Field(
+        default_factory=lambda: {
+            "narrator": "warm_female",
+            "mother": "warm_female",
+            "child": "gentle_child",
+        }
+    )
     duration_sec: int = Field(default=60, ge=15, le=300)
     language: str = Field(default="zh-CN")
     subtitle_enabled: bool = Field(default=True)

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -60,6 +60,7 @@ class WorkflowRunner:
             "storyboard": self._run_storyboard,
             "image_prompts": self._run_image_prompts,
             "video_prompts": self._run_video_prompts,
+            "dialogue_script": self._run_dialogue_script,
             "narration": self._run_narration,
             "subtitles": self._run_subtitles,
             "render_plan": self._run_render_plan,
@@ -275,6 +276,20 @@ class WorkflowRunner:
             return "mock"
         return value
 
+    def _normalized_voice_mode(self, voice_mode: str) -> str:
+        value = voice_mode.strip().lower()
+        if value in {"single", "multi"}:
+            return value
+        return "single"
+
+    def _speaker_profiles(self, ctx: StepContext) -> Dict[str, str]:
+        profiles = dict(ctx.input.speaker_profiles or {})
+        return {
+            "narrator": profiles.get("narrator", ctx.input.voice_style),
+            "mother": profiles.get("mother", "warm_female"),
+            "child": profiles.get("child", "gentle_child"),
+        }
+        
     def _build_story_paragraphs(self, ctx: StepContext) -> List[str]:
         topic = ctx.input.topic.strip() or "一个温暖的童话故事"
         audience_label = self._audience_label(ctx.input.audience)
@@ -671,6 +686,7 @@ class WorkflowRunner:
         storyboard = outputs.get("storyboard") or {}
         image_prompts = outputs.get("image_prompts") or {}
         video_prompts = outputs.get("video_prompts") or {}
+        dialogue_script = outputs.get("dialogue_script") or {}
         narration = outputs.get("narration") or {}
         subtitles = outputs.get("subtitles") or {}
         render_plan = outputs.get("render_plan") or {}
@@ -704,6 +720,7 @@ class WorkflowRunner:
                 "storyboard.json": storyboard,
                 "image_prompts.json": image_prompts,
                 "video_prompts.json": video_prompts,
+                "dialogue_script.json": dialogue_script,
                 "narration.txt": narration.get("full_text", ""),
                 "subtitles.srt": subtitles.get("srt_preview", ""),
                 "render_plan.json": render_plan,
@@ -806,10 +823,114 @@ class WorkflowRunner:
         storyboard = outputs.get("storyboard") or {}
         scenes = storyboard.get("scenes") or []
         return self._build_video_provider_prompts(ctx, scenes)
+    
+    def _run_dialogue_script(
+        self, ctx: StepContext, outputs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        storyboard = outputs.get("storyboard") or {}
+        scenes = storyboard.get("scenes") or []
+        voice_mode = self._normalized_voice_mode(ctx.input.voice_mode)
+        speaker_profiles = self._speaker_profiles(ctx)
+
+        if not ctx.input.voiceover_enabled:
+            return {
+                "enabled": False,
+                "voice_mode": voice_mode,
+                "speaker_profiles": speaker_profiles,
+                "lines": [],
+            }
+
+        lines: List[Dict[str, Any]] = []
+
+        if voice_mode == "single":
+            for index, scene in enumerate(scenes, start=1):
+                text = str(scene.get("narration", "")).strip()
+                if not text:
+                    continue
+
+                lines.append(
+                    {
+                        "line_id": f"line_{index:02d}",
+                        "scene_id": scene.get("scene_id"),
+                        "speaker": "narrator",
+                        "voice_style": speaker_profiles["narrator"],
+                        "text": text,
+                    }
+                )
+
+            return {
+                "enabled": True,
+                "voice_mode": "single",
+                "speaker_profiles": speaker_profiles,
+                "lines": lines,
+            }
+
+        alternating_speakers = ["mother", "child"]
+
+        for index, scene in enumerate(scenes, start=1):
+            text = str(scene.get("narration", "")).strip()
+            if not text:
+                continue
+
+            segments = [part.strip() for part in text.split("。") if part.strip()]
+            if not segments:
+                segments = [text]
+
+            for seg_index, segment in enumerate(segments, start=1):
+                speaker = alternating_speakers[(seg_index - 1) % len(alternating_speakers)]
+                final_text = f"{segment}。"
+                lines.append(
+                    {
+                        "line_id": f"line_{index:02d}_{seg_index:02d}",
+                        "scene_id": scene.get("scene_id"),
+                        "speaker": speaker,
+                        "voice_style": speaker_profiles[speaker],
+                        "text": final_text,
+                    }
+                )
+
+        return {
+            "enabled": True,
+            "voice_mode": "multi",
+            "speaker_profiles": speaker_profiles,
+            "lines": lines,
+        }
 
     def _run_narration(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:
+        dialogue_script = outputs.get("dialogue_script") or {}
+        dialogue_lines = dialogue_script.get("lines") or []
+
+        if dialogue_script.get("enabled") and dialogue_lines:
+            segments: List[Dict[str, Any]] = []
+            full_text_parts: List[str] = []
+
+            for line in dialogue_lines:
+                text = str(line.get("text", ""))
+                speaker = str(line.get("speaker", "narrator"))
+                voice_style = str(line.get("voice_style", ctx.input.voice_style))
+                scene_id = line.get("scene_id")
+
+                full_text_parts.append(f"[{speaker}] {text}")
+                segments.append(
+                    {
+                        "scene_id": scene_id,
+                        "speaker": speaker,
+                        "text": text,
+                        "voice_style": voice_style,
+                    }
+                )
+
+            return {
+                "voice_style": ctx.input.voice_style,
+                "language": ctx.input.language,
+                "voiceover_enabled": True,
+                "voice_mode": dialogue_script.get("voice_mode", "single"),
+                "full_text": "\n".join(full_text_parts),
+                "segments": segments,
+            }
+
         storyboard = outputs.get("storyboard") or {}
         scenes = storyboard.get("scenes") or []
 
@@ -821,6 +942,7 @@ class WorkflowRunner:
             segments.append(
                 {
                     "scene_id": scene.get("scene_id"),
+                    "speaker": "narrator",
                     "text": text,
                     "voice_style": ctx.input.voice_style,
                 }
@@ -829,6 +951,8 @@ class WorkflowRunner:
         return {
             "voice_style": ctx.input.voice_style,
             "language": ctx.input.language,
+            "voiceover_enabled": False,
+            "voice_mode": "single",
             "full_text": "\n".join(full_text_parts),
             "segments": segments,
         }

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -31,6 +31,13 @@ def _run_request(
             "visual_style": "storybook",
             "character_style": "animal",
             "voice_style": "warm_female",
+            "voiceover_enabled": True,
+            "voice_mode": "multi",
+            "speaker_profiles": {
+                "narrator": "warm_female",
+                "mother": "warm_female",
+                "child": "gentle_child",
+            },
             "duration_sec": 60,
             "language": "zh-CN",
             "subtitle_enabled": True,
@@ -42,12 +49,12 @@ def _run_request(
             {"name": "storyboard"},
             {"name": "image_prompts"},
             {"name": "video_prompts"},
+            {"name": "dialogue_script"},
             {"name": "narration"},
             {"name": "subtitles"},
             {"name": "render_plan"},
         ],
     }
-
     r = requests.post(f"{base_url}/v1/workflow/run", json=payload, timeout=15)
     if r.status_code != 200:
         _fail(f"/v1/workflow/run http_status={r.status_code}, body={r.text}")
@@ -192,7 +199,7 @@ def main() -> None:
         _fail(f"status != COMPLETED: {resp1.get('status')}")
 
     steps = resp1.get("steps")
-    if not isinstance(steps, list) or len(steps) != 7:
+    if not isinstance(steps, list) or len(steps) != 8:
         _fail(f"steps invalid len: {steps}")
 
     expected_names = [
@@ -200,6 +207,7 @@ def main() -> None:
         "storyboard",
         "image_prompts",
         "video_prompts",
+        "dialogue_script",
         "narration",
         "subtitles",
         "render_plan",
@@ -226,6 +234,7 @@ def main() -> None:
         "storyboard.json",
         "image_prompts.json",
         "video_prompts.json",
+        "dialogue_script.json",
         "narration.txt",
         "subtitles.srt",
         "render_plan.json",
@@ -259,6 +268,32 @@ def main() -> None:
     if not isinstance(samples1, list) or len(samples1) != 1:
         _fail(f"real_samples_manifest samples invalid: {real_manifest1}")
 
+    dialogue_script1 = files1.get("dialogue_script.json") or {}
+    if dialogue_script1.get("enabled") is not True:
+        _fail(f"dialogue_script enabled mismatch: {dialogue_script1}")
+    if dialogue_script1.get("voice_mode") != "multi":
+        _fail(f"dialogue_script voice_mode mismatch: {dialogue_script1}")
+
+    lines1 = dialogue_script1.get("lines") or []
+    if not isinstance(lines1, list) or len(lines1) == 0:
+        _fail(f"dialogue_script lines invalid: {dialogue_script1}")
+
+    speakers1 = {line.get("speaker") for line in lines1}
+    if "mother" not in speakers1 or "child" not in speakers1:
+        _fail(f"dialogue_script speakers invalid: {dialogue_script1}")
+
+    narration1 = outputs.get("narration") or {}
+    if narration1.get("voice_mode") != "multi":
+        _fail(f"narration voice_mode mismatch: {narration1}")
+
+    narration_segments1 = narration1.get("segments") or []
+    if not isinstance(narration_segments1, list) or len(narration_segments1) == 0:
+        _fail(f"narration segments invalid: {narration1}")
+
+    narration_speakers1 = {segment.get("speaker") for segment in narration_segments1}
+    if "mother" not in narration_speakers1 or "child" not in narration_speakers1:
+        _fail(f"narration speakers invalid: {narration1}")
+        
     sample1 = samples1[0]
     if sample1.get("scene_id") != "scene-01":
         _fail(f"real sample scene_id mismatch: {sample1}")


### PR DESCRIPTION
## What

* add multi-speaker dialogue script workflow skeleton
* extend workflow input with `voiceover_enabled`, `voice_mode`, and `speaker_profiles`
* add `dialogue_script` step to workflow execution and render package export
* upgrade narration generation to support multi-speaker aggregation
* extend acceptance coverage for sample query APIs and multi-speaker workflow output

## Why

* prepare project four for parent-child co-reading story generation
* establish the protocol layer before real TTS/audio mixing integration
* keep current implementation lightweight and verifiable

## Included

* sample viewer preview enhancement already on this branch
* inline notes preview for sample viewer
* multi-speaker dialogue script backend skeleton
* render package export for `dialogue_script.json`
* acceptance validation for:

  * `/v1/samples/summary`
  * `/v1/samples/kling/real`
  * `/v1/samples/kling/real/{sample_id}`
  * `/v1/workflow/run` with multi-speaker output

## Current status

* multi-speaker script generation works
* narration output supports `mother` / `child` roles
* subtitles are generated from multi-speaker segments
* real TTS generation is not included yet
* final audio/video composition is not included yet

## Next

* add frontend controls for single/multi speaker mode
* add optional speaker profile configuration
* introduce TTS placeholder/output layer
* later connect audio track generation and final composition
