### PR TITLE
feat: add audio segment planning step for multi-speaker workflow

### DIFF
--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -12,7 +12,7 @@ class StepSpec(BaseModel):
         description=(
             "Step name, e.g. "
             "story/storyboard/image_prompts/video_prompts/"
-            "dialogue_script/narration/subtitles/render_plan"
+            "dialogue_script/audio_segments/narration/subtitles/render_plan"
         ),
     )
 

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -61,6 +61,7 @@ class WorkflowRunner:
             "image_prompts": self._run_image_prompts,
             "video_prompts": self._run_video_prompts,
             "dialogue_script": self._run_dialogue_script,
+            "audio_segments": self._run_audio_segments,
             "narration": self._run_narration,
             "subtitles": self._run_subtitles,
             "render_plan": self._run_render_plan,
@@ -687,6 +688,7 @@ class WorkflowRunner:
         image_prompts = outputs.get("image_prompts") or {}
         video_prompts = outputs.get("video_prompts") or {}
         dialogue_script = outputs.get("dialogue_script") or {}
+        audio_segments = outputs.get("audio_segments") or {}
         narration = outputs.get("narration") or {}
         subtitles = outputs.get("subtitles") or {}
         render_plan = outputs.get("render_plan") or {}
@@ -721,6 +723,7 @@ class WorkflowRunner:
                 "image_prompts.json": image_prompts,
                 "video_prompts.json": video_prompts,
                 "dialogue_script.json": dialogue_script,
+                "audio_segments.json": audio_segments,
                 "narration.txt": narration.get("full_text", ""),
                 "subtitles.srt": subtitles.get("srt_preview", ""),
                 "render_plan.json": render_plan,
@@ -896,6 +899,50 @@ class WorkflowRunner:
             "lines": lines,
         }
 
+    def _run_audio_segments(
+        self, ctx: StepContext, outputs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        dialogue_script = outputs.get("dialogue_script") or {}
+        lines = dialogue_script.get("lines") or []
+
+        if not dialogue_script.get("enabled") or not lines:
+            return {
+                "enabled": False,
+                "provider": "mock_tts",
+                "items": [],
+            }
+
+        items: List[Dict[str, Any]] = []
+        for index, line in enumerate(lines, start=1):
+            text = str(line.get("text", "")).strip()
+            speaker = str(line.get("speaker", "narrator"))
+            voice_style = str(line.get("voice_style", ctx.input.voice_style))
+            scene_id = line.get("scene_id")
+            word_count = max(1, len(text))
+            duration_estimate_sec = max(2, min(12, word_count // 8))
+
+            items.append(
+                {
+                    "segment_id": f"audio_{index:02d}",
+                    "scene_id": scene_id,
+                    "speaker": speaker,
+                    "text": text,
+                    "voice_style": voice_style,
+                    "target_audio_file": (
+                        f"artifacts/audio/{ctx.run_id}/{speaker}_{index:02d}.mp3"
+                    ),
+                    "duration_estimate_sec": duration_estimate_sec,
+                    "provider": "mock_tts",
+                    "status": "planned",
+                }
+            )
+
+        return {
+            "enabled": True,
+            "provider": "mock_tts",
+            "items": items,
+        }
+    
     def _run_narration(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -50,6 +50,7 @@ def _run_request(
             {"name": "image_prompts"},
             {"name": "video_prompts"},
             {"name": "dialogue_script"},
+            {"name": "audio_segments"},
             {"name": "narration"},
             {"name": "subtitles"},
             {"name": "render_plan"},
@@ -199,7 +200,7 @@ def main() -> None:
         _fail(f"status != COMPLETED: {resp1.get('status')}")
 
     steps = resp1.get("steps")
-    if not isinstance(steps, list) or len(steps) != 8:
+    if not isinstance(steps, list) or len(steps) != 9:
         _fail(f"steps invalid len: {steps}")
 
     expected_names = [
@@ -208,6 +209,7 @@ def main() -> None:
         "image_prompts",
         "video_prompts",
         "dialogue_script",
+        "audio_segments",
         "narration",
         "subtitles",
         "render_plan",
@@ -235,6 +237,7 @@ def main() -> None:
         "image_prompts.json",
         "video_prompts.json",
         "dialogue_script.json",
+        "audio_segments.json",
         "narration.txt",
         "subtitles.srt",
         "render_plan.json",
@@ -293,7 +296,23 @@ def main() -> None:
     narration_speakers1 = {segment.get("speaker") for segment in narration_segments1}
     if "mother" not in narration_speakers1 or "child" not in narration_speakers1:
         _fail(f"narration speakers invalid: {narration1}")
-        
+    
+    audio_segments1 = files1.get("audio_segments.json") or {}
+    if audio_segments1.get("enabled") is not True:
+        _fail(f"audio_segments enabled mismatch: {audio_segments1}")
+
+    audio_items1 = audio_segments1.get("items") or []
+    if not isinstance(audio_items1, list) or len(audio_items1) == 0:
+        _fail(f"audio_segments items invalid: {audio_segments1}")
+
+    first_audio_item1 = audio_items1[0]
+    if first_audio_item1.get("provider") != "mock_tts":
+        _fail(f"audio_segments provider mismatch: {audio_segments1}")
+    if first_audio_item1.get("status") != "planned":
+        _fail(f"audio_segments status mismatch: {audio_segments1}")
+    if not first_audio_item1.get("target_audio_file"):
+        _fail(f"audio_segments target_audio_file empty: {audio_segments1}")
+            
     sample1 = samples1[0]
     if sample1.get("scene_id") != "scene-01":
         _fail(f"real sample scene_id mismatch: {sample1}")


### PR DESCRIPTION
## What

* add `audio_segments` step to project four workflow
* generate mock TTS planning items from multi-speaker dialogue script
* export `audio_segments.json` in render package
* extend acceptance coverage for audio segment planning output

## Why

* move project four from dialogue-script layer to audio-planning layer
* prepare for future TTS provider integration without changing workflow protocol
* keep the current phase lightweight and fully verifiable

## Included

* add `audio_segments` to workflow step schema example
* add `audio_segments` handler in runner
* generate planned audio items with:

  * `segment_id`
  * `scene_id`
  * `speaker`
  * `text`
  * `voice_style`
  * `target_audio_file`
  * `duration_estimate_sec`
  * `provider`
  * `status`
* include `audio_segments.json` in render package
* update acceptance to validate audio planning output

## Verified

* `python -m compileall app scripts` passes
* acceptance passes for:

  * `/health`
  * `/v1/samples/summary`
  * `/v1/samples/kling/real`
  * `/v1/samples/kling/real/{sample_id}`
  * `/v1/workflow/run`
* workflow output now includes:

  * `dialogue_script`
  * `audio_segments`
  * `narration`
  * `subtitles`
  * `render_plan`

## Current status

* audio planning layer is complete
* mock TTS output planning is available
* real TTS generation is not included yet
* final audio mixing / video composition is not included yet
