### PR TITLE
feat: add mock audio asset manifests and placeholder directory outputs

### DIFF
--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
@@ -26,7 +28,9 @@ class StepContext:
     session_id: Optional[str]
     run_id: str
     input: WorkflowInput
-
+    
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+MOCK_AUDIO_ROOT = PROJECT_ROOT / "assets" / "mock" / "audio"
 
 class WorkflowRunner:
     """
@@ -126,6 +130,100 @@ class WorkflowRunner:
 
         return None
 
+    def _ensure_mock_audio_assets(
+        self, run_id: str, assets: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        run_dir = MOCK_AUDIO_ROOT / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        asset_files: List[Dict[str, Any]] = []
+
+        for asset in assets:
+            file_name = str(asset.get("file_name", "unknown.mp3"))
+            metadata_name = f"{file_name}.json"
+            metadata_path = run_dir / metadata_name
+
+            metadata_payload = {
+                "asset_id": asset.get("asset_id"),
+                "segment_id": asset.get("segment_id"),
+                "scene_id": asset.get("scene_id"),
+                "speaker": asset.get("speaker"),
+                "voice_style": asset.get("voice_style"),
+                "file_name": file_name,
+                "mock_audio_file_missing": True,
+                "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+                "public_url": asset.get("public_url"),
+                "mime_type": asset.get("mime_type"),
+                "duration_estimate_sec": asset.get("duration_estimate_sec"),
+                "asset_status": asset.get("asset_status"),
+                "generation_mode": asset.get("generation_mode"),
+                "waveform_preview": asset.get("waveform_preview", []),
+            }
+
+            metadata_path.write_text(
+                json.dumps(metadata_payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+            asset_files.append(
+                {
+                    "asset_id": asset.get("asset_id"),
+                    "file_name": file_name,
+                    "metadata_file": metadata_name,
+                    "metadata_public_url": f"/assets/mock/audio/{run_id}/{metadata_name}",
+                }
+            )
+
+        index_payload = {
+            "manifest_type": "mock_audio_directory_index",
+            "run_id": run_id,
+            "asset_count": len(assets),
+            "run_directory": f"assets/mock/audio/{run_id}",
+            "public_base_url": f"/assets/mock/audio/{run_id}",
+            "assets": asset_files,
+        }
+
+        index_path = run_dir / "index.json"
+        index_path.write_text(
+            json.dumps(index_payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        return {
+            "run_directory": f"assets/mock/audio/{run_id}",
+            "public_base_url": f"/assets/mock/audio/{run_id}",
+            "index_file": "index.json",
+            "index_public_url": f"/assets/mock/audio/{run_id}/index.json",
+            "asset_files": asset_files,
+        }
+
+    def _group_audio_assets_by_scene(
+        self, assets: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+
+        for asset in assets:
+            scene_id = str(asset.get("scene_id") or "unknown_scene")
+            grouped.setdefault(scene_id, []).append(
+                {
+                    "asset_id": asset.get("asset_id"),
+                    "segment_id": asset.get("segment_id"),
+                    "speaker": asset.get("speaker"),
+                    "file_name": asset.get("file_name"),
+                    "public_url": asset.get("public_url"),
+                    "duration_estimate_sec": asset.get("duration_estimate_sec"),
+                }
+            )
+
+        return [
+            {
+                "scene_id": scene_id,
+                "assets": grouped[scene_id],
+            }
+            for scene_id in sorted(grouped.keys())
+        ]
+    
+    
     def run(self, req: WorkflowRunRequest) -> WorkflowRunResponse:
         run_id = f"run_{uuid4().hex[:12]}"
         ctx = StepContext(
@@ -713,6 +811,19 @@ class WorkflowRunner:
         }
 
         kling_scene_package = self._build_kling_scene_package(ctx, outputs)
+        audio_assets_manifest = audio_segments.get("asset_manifest") or {
+            "run_id": ctx.run_id,
+            "provider": "mock_tts",
+            "asset_count": 0,
+            "assets": [],
+        }
+        audio_directory_manifest = audio_segments.get("directory_manifest") or {
+            "run_directory": f"assets/mock/audio/{ctx.run_id}",
+            "public_base_url": f"/assets/mock/audio/{ctx.run_id}",
+            "index_file": "index.json",
+            "index_public_url": f"/assets/mock/audio/{ctx.run_id}/index.json",
+            "asset_files": [],
+        }
 
         return {
             "format": "render_package_v1",
@@ -724,6 +835,8 @@ class WorkflowRunner:
                 "video_prompts.json": video_prompts,
                 "dialogue_script.json": dialogue_script,
                 "audio_segments.json": audio_segments,
+                "audio_directory_manifest.json": audio_directory_manifest,
+                "audio_assets_manifest.json": audio_assets_manifest,
                 "narration.txt": narration.get("full_text", ""),
                 "subtitles.srt": subtitles.get("srt_preview", ""),
                 "render_plan.json": render_plan,
@@ -732,7 +845,6 @@ class WorkflowRunner:
                 "real_samples_manifest.json": real_samples_manifest,
             },
         }
-
     def _run_story(self, ctx: StepContext, outputs: Dict[str, Any]) -> Dict[str, Any]:
         topic = ctx.input.topic.strip() or "一个温暖的童话故事"
         paragraphs = self._build_story_paragraphs(ctx)
@@ -906,20 +1018,58 @@ class WorkflowRunner:
         lines = dialogue_script.get("lines") or []
 
         if not dialogue_script.get("enabled") or not lines:
+            empty_directory_manifest = self._ensure_mock_audio_assets(ctx.run_id, [])
             return {
                 "enabled": False,
                 "provider": "mock_tts",
                 "items": [],
+                "asset_manifest": {
+                    "run_id": ctx.run_id,
+                    "provider": "mock_tts",
+                    "asset_count": 0,
+                    "assets": [],
+                },
+                "directory_manifest": empty_directory_manifest,
+                "scene_asset_map": [],
             }
 
         items: List[Dict[str, Any]] = []
+        assets: List[Dict[str, Any]] = []
+
         for index, line in enumerate(lines, start=1):
             text = str(line.get("text", "")).strip()
             speaker = str(line.get("speaker", "narrator"))
             voice_style = str(line.get("voice_style", ctx.input.voice_style))
             scene_id = line.get("scene_id")
-            word_count = max(1, len(text))
-            duration_estimate_sec = max(2, min(12, word_count // 8))
+            char_count = max(1, len(text))
+            duration_estimate_sec = max(2, min(12, char_count // 8))
+
+            file_name = f"{speaker}_{index:02d}.mp3"
+            relative_path = f"assets/mock/audio/{ctx.run_id}/{file_name}"
+            public_url = f"/assets/mock/audio/{ctx.run_id}/{file_name}"
+            waveform_preview = [
+                max(0.12, round(duration_estimate_sec / 12, 2)),
+                0.48,
+                0.76,
+                0.35,
+                0.62,
+            ]
+
+            asset = {
+                "asset_id": f"audio_asset_{index:02d}",
+                "segment_id": f"audio_{index:02d}",
+                "scene_id": scene_id,
+                "speaker": speaker,
+                "voice_style": voice_style,
+                "file_name": file_name,
+                "relative_path": relative_path,
+                "public_url": public_url,
+                "mime_type": "audio/mpeg",
+                "duration_estimate_sec": duration_estimate_sec,
+                "asset_status": "mock_registered",
+                "generation_mode": "placeholder_manifest_only",
+                "waveform_preview": waveform_preview,
+            }
 
             items.append(
                 {
@@ -934,15 +1084,28 @@ class WorkflowRunner:
                     "duration_estimate_sec": duration_estimate_sec,
                     "provider": "mock_tts",
                     "status": "planned",
+                    "mock_asset": asset,
                 }
             )
+
+            assets.append(asset)
+
+        directory_manifest = self._ensure_mock_audio_assets(ctx.run_id, assets)
+        scene_asset_map = self._group_audio_assets_by_scene(assets)
 
         return {
             "enabled": True,
             "provider": "mock_tts",
             "items": items,
+            "asset_manifest": {
+                "run_id": ctx.run_id,
+                "provider": "mock_tts",
+                "asset_count": len(assets),
+                "assets": assets,
+            },
+            "directory_manifest": directory_manifest,
+            "scene_asset_map": scene_asset_map,
         }
-    
     def _run_narration(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/assets/mock/audio/run_0d8cb775d7bd/child_02.mp3.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/child_02.mp3.json
@@ -1,0 +1,22 @@
+{
+  "asset_id": "audio_asset_02",
+  "segment_id": "audio_02",
+  "scene_id": "scene_01",
+  "speaker": "child",
+  "voice_style": "gentle_child",
+  "file_name": "child_02.mp3",
+  "mock_audio_file_missing": true,
+  "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+  "public_url": "/assets/mock/audio/run_0d8cb775d7bd/child_02.mp3",
+  "mime_type": "audio/mpeg",
+  "duration_estimate_sec": 3,
+  "asset_status": "mock_registered",
+  "generation_mode": "placeholder_manifest_only",
+  "waveform_preview": [
+    0.25,
+    0.48,
+    0.76,
+    0.35,
+    0.62
+  ]
+}

--- a/assets/mock/audio/run_0d8cb775d7bd/child_04.mp3.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/child_04.mp3.json
@@ -1,0 +1,22 @@
+{
+  "asset_id": "audio_asset_04",
+  "segment_id": "audio_04",
+  "scene_id": "scene_02",
+  "speaker": "child",
+  "voice_style": "gentle_child",
+  "file_name": "child_04.mp3",
+  "mock_audio_file_missing": true,
+  "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+  "public_url": "/assets/mock/audio/run_0d8cb775d7bd/child_04.mp3",
+  "mime_type": "audio/mpeg",
+  "duration_estimate_sec": 3,
+  "asset_status": "mock_registered",
+  "generation_mode": "placeholder_manifest_only",
+  "waveform_preview": [
+    0.25,
+    0.48,
+    0.76,
+    0.35,
+    0.62
+  ]
+}

--- a/assets/mock/audio/run_0d8cb775d7bd/child_07.mp3.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/child_07.mp3.json
@@ -1,0 +1,22 @@
+{
+  "asset_id": "audio_asset_07",
+  "segment_id": "audio_07",
+  "scene_id": "scene_04",
+  "speaker": "child",
+  "voice_style": "gentle_child",
+  "file_name": "child_07.mp3",
+  "mock_audio_file_missing": true,
+  "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+  "public_url": "/assets/mock/audio/run_0d8cb775d7bd/child_07.mp3",
+  "mime_type": "audio/mpeg",
+  "duration_estimate_sec": 3,
+  "asset_status": "mock_registered",
+  "generation_mode": "placeholder_manifest_only",
+  "waveform_preview": [
+    0.25,
+    0.48,
+    0.76,
+    0.35,
+    0.62
+  ]
+}

--- a/assets/mock/audio/run_0d8cb775d7bd/index.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/index.json
@@ -1,0 +1,51 @@
+{
+  "manifest_type": "mock_audio_directory_index",
+  "run_id": "run_0d8cb775d7bd",
+  "asset_count": 7,
+  "run_directory": "assets/mock/audio/run_0d8cb775d7bd",
+  "public_base_url": "/assets/mock/audio/run_0d8cb775d7bd",
+  "assets": [
+    {
+      "asset_id": "audio_asset_01",
+      "file_name": "mother_01.mp3",
+      "metadata_file": "mother_01.mp3.json",
+      "metadata_public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_01.mp3.json"
+    },
+    {
+      "asset_id": "audio_asset_02",
+      "file_name": "child_02.mp3",
+      "metadata_file": "child_02.mp3.json",
+      "metadata_public_url": "/assets/mock/audio/run_0d8cb775d7bd/child_02.mp3.json"
+    },
+    {
+      "asset_id": "audio_asset_03",
+      "file_name": "mother_03.mp3",
+      "metadata_file": "mother_03.mp3.json",
+      "metadata_public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_03.mp3.json"
+    },
+    {
+      "asset_id": "audio_asset_04",
+      "file_name": "child_04.mp3",
+      "metadata_file": "child_04.mp3.json",
+      "metadata_public_url": "/assets/mock/audio/run_0d8cb775d7bd/child_04.mp3.json"
+    },
+    {
+      "asset_id": "audio_asset_05",
+      "file_name": "mother_05.mp3",
+      "metadata_file": "mother_05.mp3.json",
+      "metadata_public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_05.mp3.json"
+    },
+    {
+      "asset_id": "audio_asset_06",
+      "file_name": "mother_06.mp3",
+      "metadata_file": "mother_06.mp3.json",
+      "metadata_public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_06.mp3.json"
+    },
+    {
+      "asset_id": "audio_asset_07",
+      "file_name": "child_07.mp3",
+      "metadata_file": "child_07.mp3.json",
+      "metadata_public_url": "/assets/mock/audio/run_0d8cb775d7bd/child_07.mp3.json"
+    }
+  ]
+}

--- a/assets/mock/audio/run_0d8cb775d7bd/mother_01.mp3.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/mother_01.mp3.json
@@ -1,0 +1,22 @@
+{
+  "asset_id": "audio_asset_01",
+  "segment_id": "audio_01",
+  "scene_id": "scene_01",
+  "speaker": "mother",
+  "voice_style": "warm_female",
+  "file_name": "mother_01.mp3",
+  "mock_audio_file_missing": true,
+  "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+  "public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_01.mp3",
+  "mime_type": "audio/mpeg",
+  "duration_estimate_sec": 4,
+  "asset_status": "mock_registered",
+  "generation_mode": "placeholder_manifest_only",
+  "waveform_preview": [
+    0.33,
+    0.48,
+    0.76,
+    0.35,
+    0.62
+  ]
+}

--- a/assets/mock/audio/run_0d8cb775d7bd/mother_03.mp3.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/mother_03.mp3.json
@@ -1,0 +1,22 @@
+{
+  "asset_id": "audio_asset_03",
+  "segment_id": "audio_03",
+  "scene_id": "scene_02",
+  "speaker": "mother",
+  "voice_style": "warm_female",
+  "file_name": "mother_03.mp3",
+  "mock_audio_file_missing": true,
+  "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+  "public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_03.mp3",
+  "mime_type": "audio/mpeg",
+  "duration_estimate_sec": 3,
+  "asset_status": "mock_registered",
+  "generation_mode": "placeholder_manifest_only",
+  "waveform_preview": [
+    0.25,
+    0.48,
+    0.76,
+    0.35,
+    0.62
+  ]
+}

--- a/assets/mock/audio/run_0d8cb775d7bd/mother_05.mp3.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/mother_05.mp3.json
@@ -1,0 +1,22 @@
+{
+  "asset_id": "audio_asset_05",
+  "segment_id": "audio_05",
+  "scene_id": "scene_03",
+  "speaker": "mother",
+  "voice_style": "warm_female",
+  "file_name": "mother_05.mp3",
+  "mock_audio_file_missing": true,
+  "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+  "public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_05.mp3",
+  "mime_type": "audio/mpeg",
+  "duration_estimate_sec": 6,
+  "asset_status": "mock_registered",
+  "generation_mode": "placeholder_manifest_only",
+  "waveform_preview": [
+    0.5,
+    0.48,
+    0.76,
+    0.35,
+    0.62
+  ]
+}

--- a/assets/mock/audio/run_0d8cb775d7bd/mother_06.mp3.json
+++ b/assets/mock/audio/run_0d8cb775d7bd/mother_06.mp3.json
@@ -1,0 +1,22 @@
+{
+  "asset_id": "audio_asset_06",
+  "segment_id": "audio_06",
+  "scene_id": "scene_04",
+  "speaker": "mother",
+  "voice_style": "warm_female",
+  "file_name": "mother_06.mp3",
+  "mock_audio_file_missing": true,
+  "note": "Phase 1 mock asset placeholder. No real audio binary generated yet.",
+  "public_url": "/assets/mock/audio/run_0d8cb775d7bd/mother_06.mp3",
+  "mime_type": "audio/mpeg",
+  "duration_estimate_sec": 3,
+  "asset_status": "mock_registered",
+  "generation_mode": "placeholder_manifest_only",
+  "waveform_preview": [
+    0.25,
+    0.48,
+    0.76,
+    0.35,
+    0.62
+  ]
+}


### PR DESCRIPTION
## Summary
- add mock audio asset registration for audio_segments
- add asset_manifest and directory_manifest outputs
- write placeholder metadata files under assets/mock/audio/<run_id>/
- write index.json for per-run mock audio directory
- expose audio assets in render_package files

## What changed
- audio_segments now returns:
  - items[*].mock_asset
  - asset_manifest
  - directory_manifest
  - scene_asset_map
- render_package.files now includes:
  - audio_assets_manifest.json
  - audio_directory_manifest.json
- mock audio placeholder metadata is written to:
  - assets/mock/audio/<run_id>/index.json
  - assets/mock/audio/<run_id>/*.mp3.json

## Validation
- python -m py_compile app/main.py app/schemas/workflow.py app/services/runner.py
- POST /v1/workflow/run confirms:
  - mock_asset present
  - asset_manifest present
  - directory_manifest present
  - render_package includes audio_assets_manifest.json and audio_directory_manifest.json
- verified generated files under assets/mock/audio/<run_id>/