### PR TITLE
feat: integrate real image provider for storyboard scene generation

### DIFF
--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1114,8 +1114,10 @@ class WorkflowRunner:
 
         return {"provider": "image_prompt_builder", "prompts": prompts}
 
+
     def _build_scene_ppm(self, ctx: StepContext, scene: Dict[str, Any], index: int) -> bytes:
         import io
+        import math
         import textwrap
         from pathlib import Path
 
@@ -1134,43 +1136,67 @@ class WorkflowRunner:
 
         themes = [
             {
-                "top": (245, 238, 255),
-                "bottom": (255, 247, 239),
+                "sky_top": (109, 101, 255),
+                "sky_bottom": (243, 236, 255),
+                "ground": (236, 226, 220),
                 "accent": (120, 104, 255),
                 "accent_soft": (224, 218, 255),
-                "panel": (255, 255, 255),
-                "panel_border": (226, 221, 245),
-                "text_primary": (49, 42, 84),
+                "text_primary": (45, 39, 84),
                 "text_secondary": (97, 91, 130),
+                "moon": (255, 246, 196),
+                "star": (255, 255, 240),
+                "cloud": (255, 255, 255),
+                "hill": (211, 234, 221),
+                "path": (245, 233, 210),
+                "bush": (168, 214, 182),
                 "shape_a": (255, 210, 218),
                 "shape_b": (196, 229, 255),
                 "shape_c": (216, 242, 220),
+                "rabbit_body": (255, 251, 248),
+                "rabbit_ear": (255, 216, 224),
+                "rabbit_cloth": (243, 184, 118),
             },
             {
-                "top": (255, 244, 235),
-                "bottom": (255, 252, 244),
+                "sky_top": (255, 188, 134),
+                "sky_bottom": (255, 241, 227),
+                "ground": (244, 232, 220),
                 "accent": (244, 134, 92),
                 "accent_soft": (255, 220, 204),
-                "panel": (255, 255, 255),
-                "panel_border": (243, 225, 215),
                 "text_primary": (94, 57, 38),
                 "text_secondary": (138, 99, 80),
+                "moon": (255, 243, 201),
+                "star": (255, 249, 235),
+                "cloud": (255, 255, 255),
+                "hill": (219, 233, 205),
+                "path": (241, 220, 181),
+                "bush": (189, 222, 177),
                 "shape_a": (255, 220, 178),
                 "shape_b": (255, 203, 213),
                 "shape_c": (201, 235, 246),
+                "rabbit_body": (255, 251, 248),
+                "rabbit_ear": (255, 213, 221),
+                "rabbit_cloth": (118, 170, 224),
             },
             {
-                "top": (238, 249, 242),
-                "bottom": (247, 252, 255),
+                "sky_top": (135, 193, 154),
+                "sky_bottom": (238, 250, 242),
+                "ground": (234, 228, 214),
                 "accent": (77, 156, 113),
                 "accent_soft": (204, 235, 217),
-                "panel": (255, 255, 255),
-                "panel_border": (216, 232, 223),
                 "text_primary": (41, 77, 56),
                 "text_secondary": (91, 120, 103),
+                "moon": (255, 246, 196),
+                "star": (255, 255, 240),
+                "cloud": (255, 255, 255),
+                "hill": (198, 229, 202),
+                "path": (237, 220, 186),
+                "bush": (147, 202, 157),
                 "shape_a": (255, 226, 186),
                 "shape_b": (189, 231, 214),
                 "shape_c": (207, 216, 245),
+                "rabbit_body": (255, 251, 248),
+                "rabbit_ear": (255, 216, 224),
+                "rabbit_cloth": (135, 164, 245),
             },
         ]
         theme = themes[(max(index, 1) - 1) % len(themes)]
@@ -1178,15 +1204,8 @@ class WorkflowRunner:
         try:
             from PIL import Image, ImageDraw, ImageFont
 
-            image = Image.new("RGB", (width, height), theme["bottom"])
+            image = Image.new("RGB", (width, height), theme["sky_bottom"])
             draw = ImageDraw.Draw(image)
-
-            for y in range(height):
-                ratio = y / max(1, height - 1)
-                r = int(theme["top"][0] * (1 - ratio) + theme["bottom"][0] * ratio)
-                g = int(theme["top"][1] * (1 - ratio) + theme["bottom"][1] * ratio)
-                b = int(theme["top"][2] * (1 - ratio) + theme["bottom"][2] * ratio)
-                draw.line([(0, y), (width, y)], fill=(r, g, b))
 
             font_candidates = [
                 "/System/Library/Fonts/PingFang.ttc",
@@ -1205,122 +1224,174 @@ class WorkflowRunner:
                             pass
                 return ImageFont.load_default()
 
-            title_font = load_font(40)
+            title_font = load_font(36)
             scene_font = load_font(30)
-            meta_font = load_font(20)
-            body_font = load_font(24)
+            body_font = load_font(22)
+            meta_font = load_font(18)
 
-            top_bar_h = 88
-            left_panel_w = 320
-            card_x = 350
-            card_y = 150
-            card_w = 860
-            card_h = 400
+            def draw_vertical_gradient(y0: int, y1: int, top_color, bottom_color):
+                h = max(1, y1 - y0)
+                for y in range(y0, y1):
+                    ratio = (y - y0) / h
+                    r = int(top_color[0] * (1 - ratio) + bottom_color[0] * ratio)
+                    g = int(top_color[1] * (1 - ratio) + bottom_color[1] * ratio)
+                    b = int(top_color[2] * (1 - ratio) + bottom_color[2] * ratio)
+                    draw.line([(0, y), (width, y)], fill=(r, g, b))
 
-            draw.rounded_rectangle(
-                [(22, 22), (width - 22, top_bar_h)],
-                radius=24,
-                fill=theme["accent"],
+            def draw_cloud(x: int, y: int, scale: float = 1.0):
+                c = theme["cloud"]
+                draw.ellipse((x, y + 16 * scale, x + 90 * scale, y + 74 * scale), fill=c)
+                draw.ellipse((x + 42 * scale, y, x + 132 * scale, y + 70 * scale), fill=c)
+                draw.ellipse((x + 96 * scale, y + 18 * scale, x + 176 * scale, y + 78 * scale), fill=c)
+                draw.rounded_rectangle(
+                    (x + 28 * scale, y + 34 * scale, x + 142 * scale, y + 82 * scale),
+                    radius=int(18 * scale),
+                    fill=c,
+                )
+
+            def draw_star(cx: int, cy: int, radius: int):
+                points = []
+                for i in range(10):
+                    angle = math.radians(-90 + i * 36)
+                    r = radius if i % 2 == 0 else radius * 0.45
+                    points.append((cx + math.cos(angle) * r, cy + math.sin(angle) * r))
+                draw.polygon(points, fill=theme["star"])
+
+            def draw_hill(x0: int, y0: int, x1: int, y1: int, color):
+                draw.ellipse((x0, y0, x1, y1), fill=color)
+
+            def draw_path(points, color):
+                draw.line(points, fill=color, width=34, joint="curve")
+
+            def draw_rabbit(x: int, y: int, scale: float = 1.0, pose: str = "stand"):
+                body = theme["rabbit_body"]
+                ear = theme["rabbit_ear"]
+                cloth = theme["rabbit_cloth"]
+                outline = (170, 154, 152)
+
+                draw.ellipse((x + 18 * scale, y - 44 * scale, x + 42 * scale, y + 28 * scale), fill=body, outline=outline, width=2)
+                draw.ellipse((x + 48 * scale, y - 52 * scale, x + 72 * scale, y + 24 * scale), fill=body, outline=outline, width=2)
+                draw.ellipse((x + 25 * scale, y - 32 * scale, x + 35 * scale, y + 16 * scale), fill=ear)
+                draw.ellipse((x + 55 * scale, y - 38 * scale, x + 65 * scale, y + 10 * scale), fill=ear)
+
+                draw.ellipse((x, y, x + 86 * scale, y + 78 * scale), fill=body, outline=outline, width=2)
+
+                draw.ellipse((x + 26 * scale, y + 28 * scale, x + 32 * scale, y + 34 * scale), fill=(68, 58, 58))
+                draw.ellipse((x + 52 * scale, y + 28 * scale, x + 58 * scale, y + 34 * scale), fill=(68, 58, 58))
+                draw.ellipse((x + 38 * scale, y + 40 * scale, x + 48 * scale, y + 48 * scale), fill=(255, 172, 180))
+                draw.arc((x + 32 * scale, y + 44 * scale, x + 54 * scale, y + 58 * scale), start=10, end=170, fill=(120, 104, 110), width=2)
+
+                body_y = y + 62 * scale
+                draw.ellipse((x + 4 * scale, body_y, x + 96 * scale, body_y + 98 * scale), fill=body, outline=outline, width=2)
+
+                draw.rounded_rectangle(
+                    (x + 18 * scale, body_y + 30 * scale, x + 82 * scale, body_y + 88 * scale),
+                    radius=int(18 * scale),
+                    fill=cloth,
+                )
+
+                draw.line((x + 18 * scale, body_y + 46 * scale, x - 12 * scale, body_y + 70 * scale), fill=outline, width=6)
+                draw.line((x + 80 * scale, body_y + 46 * scale, x + 112 * scale, body_y + 66 * scale), fill=outline, width=6)
+
+                if pose == "walk":
+                    draw.line((x + 36 * scale, body_y + 94 * scale, x + 20 * scale, body_y + 134 * scale), fill=outline, width=6)
+                    draw.line((x + 62 * scale, body_y + 94 * scale, x + 78 * scale, body_y + 132 * scale), fill=outline, width=6)
+                else:
+                    draw.line((x + 36 * scale, body_y + 94 * scale, x + 30 * scale, body_y + 132 * scale), fill=outline, width=6)
+                    draw.line((x + 62 * scale, body_y + 94 * scale, x + 68 * scale, body_y + 132 * scale), fill=outline, width=6)
+
+                draw.ellipse((x + 78 * scale, body_y + 52 * scale, x + 100 * scale, body_y + 74 * scale), fill=body, outline=outline, width=2)
+
+            def draw_question_mark(x: int, y: int, color):
+                draw.arc((x, y, x + 42, y + 42), start=200, end=20, fill=color, width=6)
+                draw.line((x + 32, y + 30, x + 24, y + 48), fill=color, width=6)
+                draw.ellipse((x + 19, y + 58, x + 27, y + 66), fill=color)
+
+            def draw_arrow(x: int, y: int, color):
+                draw.line((x, y, x + 80, y), fill=color, width=10)
+                draw.polygon([(x + 80, y), (x + 52, y - 18), (x + 52, y + 18)], fill=color)
+
+            draw_vertical_gradient(0, int(height * 0.76), theme["sky_top"], theme["sky_bottom"])
+            draw.rectangle((0, int(height * 0.72), width, height), fill=theme["ground"])
+
+            draw_hill(-120, 430, 500, 820, theme["hill"])
+            draw_hill(330, 470, 930, 860, (theme["hill"][0] - 10, theme["hill"][1] - 8, theme["hill"][2] - 6))
+            draw_hill(760, 420, 1400, 850, theme["hill"])
+
+            draw_path(
+                [(130, 640), (300, 610), (500, 630), (760, 605), (1040, 640)],
+                theme["path"],
             )
-            draw.text((52, 38), topic[:28], font=title_font, fill=(255, 255, 255))
 
-            draw.rounded_rectangle(
-                [(38, 128), (left_panel_w, height - 54)],
-                radius=36,
-                fill=(255, 255, 255),
-                outline=theme["panel_border"],
-                width=3,
-            )
-            draw.ellipse((72, 178, 202, 308), fill=theme["shape_a"])
-            draw.ellipse((154, 272, 270, 388), fill=theme["shape_b"])
-            draw.polygon([(92, 520), (208, 600), (58, 628)], fill=theme["shape_c"])
+            moon_x = 980 if index == 1 else 1060 if index == 2 else 930
+            moon_y = 84 if index == 1 else 102 if index == 2 else 78
+            draw.ellipse((moon_x, moon_y, moon_x + 120, moon_y + 120), fill=theme["moon"])
 
-            draw.text((72, 418), f"SCENE {index:02d}", font=scene_font, fill=theme["accent"])
-            draw.text((72, 462), scene_id, font=meta_font, fill=theme["text_secondary"])
+            for sx, sy, sr in [(160, 88, 10), (280, 132, 8), (860, 62, 9), (1180, 180, 7), (1020, 236, 6)]:
+                draw_star(sx, sy, sr)
+
+            draw_cloud(122, 116, 1.0)
+            draw_cloud(708, 148, 0.85)
+
+            if index == 1:
+                draw_rabbit(250, 408, scale=1.8, pose="stand")
+                draw_cloud(930, 206, 0.72)
+                draw.rounded_rectangle((880, 520, 1160, 590), radius=22, fill=(255, 255, 255))
+                draw.text((910, 542), "晚安，小月亮", font=meta_font, fill=theme["accent"])
+
+            elif index == 2:
+                draw_rabbit(200, 424, scale=1.7, pose="stand")
+                draw_path(
+                    [(480, 638), (610, 586), (740, 612)],
+                    (231, 212, 180),
+                )
+                draw_path(
+                    [(610, 586), (720, 522), (850, 510)],
+                    (231, 212, 180),
+                )
+                draw_path(
+                    [(610, 586), (724, 654), (860, 674)],
+                    (231, 212, 180),
+                )
+                draw_question_mark(356, 318, theme["accent"])
+                draw_question_mark(410, 282, theme["accent_soft"])
+                draw.rounded_rectangle((860, 494, 1170, 594), radius=26, fill=(255, 255, 255))
+                draw.text((895, 520), "要往哪边走呢？", font=body_font, fill=theme["text_primary"])
+
+            else:
+                draw_rabbit(286, 420, scale=1.75, pose="walk")
+                draw_arrow(804, 478, theme["accent"])
+                draw.rounded_rectangle((934, 394, 1118, 468), radius=26, fill=(255, 255, 255))
+                draw.text((968, 420), "继续向前", font=body_font, fill=theme["text_primary"])
+                draw.ellipse((1032, 520, 1152, 640), fill=(255, 236, 170), outline=(229, 194, 92), width=4)
+                draw.ellipse((1066, 552, 1118, 604), fill=(255, 255, 255))
+                draw.rounded_rectangle((1068, 608, 1118, 642), radius=10, fill=(189, 160, 124))
+
+            draw.ellipse((60, 600, 220, 700), fill=theme["bush"])
+            draw.ellipse((880, 612, 1080, 712), fill=theme["bush"])
+            draw.ellipse((1080, 624, 1230, 714), fill=(theme["bush"][0] - 8, theme["bush"][1] - 10, theme["bush"][2] - 6))
+
+            overlay_x = 42
+            overlay_y = 28
+            draw.rounded_rectangle((overlay_x, overlay_y, 510, 96), radius=26, fill=(255, 255, 255))
+            draw.text((overlay_x + 24, overlay_y + 18), topic[:22], font=title_font, fill=theme["accent"])
+
+            draw.rounded_rectangle((42, 114, 340, 176), radius=20, fill=(255, 255, 255))
+            draw.text((64, 128), scene_title[:14] if scene_title else f"Scene {index}", font=scene_font, fill=theme["text_primary"])
+            draw.text((250, 132), f"{index}/{max(1, int(self._scene_count(ctx.input.duration_sec)))}", font=meta_font, fill=theme["text_secondary"])
+
+            caption = visual_description or body_text
+            caption_lines = textwrap.wrap(caption, width=28)[:2]
+            if caption_lines:
+                draw.rounded_rectangle((42, 606, 680, 686), radius=24, fill=(255, 255, 255))
+                cy = 622
+                for line in caption_lines:
+                    draw.text((66, cy), line, font=body_font, fill=theme["text_secondary"])
+                    cy += 28
+
             if duration_sec > 0:
-                draw.text(
-                    (72, 494),
-                    f"DURATION  {duration_sec}S",
-                    font=meta_font,
-                    fill=theme["text_secondary"],
-                )
-
-            draw.rounded_rectangle(
-                [(card_x, card_y), (card_x + card_w, card_y + card_h)],
-                radius=32,
-                fill=theme["panel"],
-                outline=theme["panel_border"],
-                width=3,
-            )
-
-            draw.text(
-                (card_x + 42, card_y + 38),
-                scene_title[:30] if scene_title else f"Scene {index}",
-                font=scene_font,
-                fill=theme["text_primary"],
-            )
-
-            draw.rounded_rectangle(
-                [(card_x + 42, card_y + 92), (card_x + card_w - 42, card_y + 102)],
-                radius=5,
-                fill=theme["accent_soft"],
-            )
-
-            wrapped_lines = textwrap.wrap(body_text, width=30)[:4]
-            if not wrapped_lines:
-                wrapped_lines = ["A warm and gentle story scene."]
-
-            current_y = card_y + 136
-            for line in wrapped_lines:
-                draw.text(
-                    (card_x + 42, current_y),
-                    line,
-                    font=body_font,
-                    fill=theme["text_secondary"],
-                )
-                current_y += 52
-
-            visual_label = visual_description[:48] if visual_description else "story visual"
-            draw.rounded_rectangle(
-                [(card_x + 42, card_y + card_h - 84), (card_x + 430, card_y + card_h - 34)],
-                radius=18,
-                fill=theme["accent_soft"],
-            )
-            draw.text(
-                (card_x + 58, card_y + card_h - 70),
-                visual_label,
-                font=meta_font,
-                fill=theme["text_primary"],
-            )
-
-            progress_x = card_x
-            progress_y = card_y + card_h + 42
-            progress_w = card_w
-            progress_h = 18
-
-            scene_count = max(1, int(self._scene_count(ctx.input.duration_sec)))
-            progress_ratio = min(1.0, max(0.0, index / scene_count))
-
-            draw.rounded_rectangle(
-                [(progress_x, progress_y), (progress_x + progress_w, progress_y + progress_h)],
-                radius=9,
-                fill=(238, 236, 244),
-            )
-            draw.rounded_rectangle(
-                [
-                    (progress_x, progress_y),
-                    (progress_x + int(progress_w * progress_ratio), progress_y + progress_h),
-                ],
-                radius=9,
-                fill=theme["accent"],
-            )
-
-            draw.text(
-                (progress_x + progress_w - 120, progress_y - 34),
-                f"{index}/{scene_count}",
-                font=meta_font,
-                fill=theme["text_secondary"],
-            )
+                draw.rounded_rectangle((1090, 620, 1218, 672), radius=18, fill=(255, 255, 255))
+                draw.text((1120, 636), f"{duration_sec}S", font=meta_font, fill=theme["text_secondary"])
 
             buffer = io.BytesIO()
             image.save(buffer, format="PPM")
@@ -1444,9 +1515,9 @@ class WorkflowRunner:
 
             for y in range(height):
                 ratio = y / max(1, height - 1)
-                r = int(theme["top"][0] * (1 - ratio) + theme["bottom"][0] * ratio)
-                g = int(theme["top"][1] * (1 - ratio) + theme["bottom"][1] * ratio)
-                b = int(theme["top"][2] * (1 - ratio) + theme["bottom"][2] * ratio)
+                r = int(theme["sky_top"][0] * (1 - ratio) + theme["sky_bottom"][0] * ratio)
+                g = int(theme["sky_top"][1] * (1 - ratio) + theme["sky_bottom"][1] * ratio)
+                b = int(theme["sky_top"][2] * (1 - ratio) + theme["sky_bottom"][2] * ratio)
                 _fill_rect(0, y, width, 1, (r, g, b))
 
             progress_ratio = min(1.0, max(0.0, index / max(1, int(self._scene_count(ctx.input.duration_sec)))))
@@ -1481,6 +1552,7 @@ class WorkflowRunner:
             data.extend(f"P6\n{width} {height}\n255\n".encode("ascii"))
             data.extend(pixels)
             return bytes(data)
+
     def _run_image_assets(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -1494,9 +1566,7 @@ class WorkflowRunner:
             scene_id = str(scene.get("scene_id") or f"scene_{index:02d}")
             file_name = f"{scene_id}.ppm"
             output_path = run_dir / file_name
-            output_path.write_bytes(
-                self._build_scene_ppm(ctx, scene, index)
-            )
+            output_path.write_bytes(self._build_scene_ppm(ctx, scene, index))
 
             assets.append(
                 {
@@ -1513,7 +1583,7 @@ class WorkflowRunner:
         return {
             "enabled": True,
             "run_id": ctx.run_id,
-            "provider": "scene_svg_builder",
+            "provider": "pillow_storybook_renderer",
             "asset_count": len(assets),
             "assets": assets,
         }


### PR DESCRIPTION
## Summary
- add real image provider support for image_assets
- keep pillow_storybook_renderer as local fallback
- generate scene images from storyboard prompts
- preserve existing render package and asset output structure

## Why
- current pillow renderer is only a transitional placeholder
- real scene illustrations are needed before moving to real video generation

## Verified
- storyboard and image prompts still generate successfully
- image_assets can use real image provider
- fallback to pillow renderer remains available when needed