### PR TITLE
feat: support interactive manual image selection flow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,12 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from app.schemas.workflow import WorkflowRunRequest, WorkflowRunResponse
+from app.schemas.workflow import (
+    ImageReviewSelectRequest,
+    ImageReviewSelectResponse,
+    WorkflowRunRequest,
+    WorkflowRunResponse,
+)
 from app.services.runner import UnknownStepError, WorkflowRunner
 
 app = FastAPI(title="jinsie-multimodal-generation-workflow", version="0.1.0")
@@ -64,4 +69,33 @@ def run_workflow(req: WorkflowRunRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         print("[workflow] runtime error", repr(e))
+        raise
+@app.post("/v1/image-review/select", response_model=ImageReviewSelectResponse)
+def select_image_review_asset(req: ImageReviewSelectRequest):
+    print("[image-review] selection request received", req.workflow_id, req.scene_id)
+    try:
+        result = _runner.update_image_review_selection(
+            workflow_id=req.workflow_id,
+            session_id=req.session_id,
+            run_id=req.run_id,
+            scene_id=req.scene_id,
+            selected_asset_ref=req.selected_asset_ref,
+            image_review=req.image_review,
+            video_provider=req.video_provider,
+        )
+        print("[image-review] selection updated", req.run_id, req.scene_id)
+        return ImageReviewSelectResponse(
+            workflow_id=result["workflow_id"],
+            session_id=result.get("session_id"),
+            run_id=result["run_id"],
+            scene_id=result["scene_id"],
+            image_review=result["image_review"],
+            video_prompts=result["video_prompts"],
+            timestamp=ImageReviewSelectResponse.now_timestamp(),
+        )
+    except ValueError as e:
+        print("[image-review] bad request", str(e))
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        print("[image-review] runtime error", repr(e))
         raise

--- a/app/main.py
+++ b/app/main.py
@@ -81,6 +81,8 @@ def select_image_review_asset(req: ImageReviewSelectRequest):
             scene_id=req.scene_id,
             selected_asset_ref=req.selected_asset_ref,
             image_review=req.image_review,
+            storyboard=req.storyboard,
+            workflow_input=req.workflow_input,
             video_provider=req.video_provider,
         )
         print("[image-review] selection updated", req.run_id, req.scene_id)

--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -183,8 +183,9 @@ class ImageReviewSelectRequest(BaseModel):
     scene_id: str
     selected_asset_ref: Dict[str, Any] = Field(default_factory=dict)
     image_review: Dict[str, Any] = Field(default_factory=dict)
+    storyboard: Dict[str, Any] = Field(default_factory=dict)
+    workflow_input: Dict[str, Any] = Field(default_factory=dict)
     video_provider: str = Field(default="mock")
-
 
 class ImageReviewSelectResponse(BaseModel):
     workflow_id: str

--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -176,3 +176,30 @@ class WorkflowRunResponse(BaseModel):
             .isoformat()
             .replace("+00:00", "Z")
         )
+class ImageReviewSelectRequest(BaseModel):
+    workflow_id: str
+    session_id: Optional[str] = None
+    run_id: str
+    scene_id: str
+    selected_asset_ref: Dict[str, Any] = Field(default_factory=dict)
+    image_review: Dict[str, Any] = Field(default_factory=dict)
+    video_provider: str = Field(default="mock")
+
+
+class ImageReviewSelectResponse(BaseModel):
+    workflow_id: str
+    session_id: Optional[str] = None
+    run_id: str
+    scene_id: str
+    image_review: Dict[str, Any] = Field(default_factory=dict)
+    video_prompts: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: str
+
+    @staticmethod
+    def now_timestamp() -> str:
+        return (
+            datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1731,6 +1731,8 @@ class WorkflowRunner:
         scene_id: str,
         selected_asset_ref: Dict[str, Any],
         image_review: Dict[str, Any],
+        storyboard: Dict[str, Any],
+        workflow_input: Dict[str, Any],
         video_provider: str = "mock",
     ) -> Dict[str, Any]:
         updated_image_review = self._apply_manual_image_selection(
@@ -1739,28 +1741,30 @@ class WorkflowRunner:
             selected_asset_ref=selected_asset_ref,
         )
 
-        storyboard_scene_id = str(scene_id or "").strip()
-        storyboard_scenes: List[Dict[str, Any]] = []
+        storyboard_scenes = (storyboard or {}).get("scenes") or []
+        if not isinstance(storyboard_scenes, list) or not storyboard_scenes:
+            raise ValueError("storyboard.scenes is required")
 
-        for item in updated_image_review.get("selected_assets") or []:
-            if not isinstance(item, dict):
-                continue
-            item_scene_id = str(item.get("scene_id") or "").strip()
-            if item_scene_id != storyboard_scene_id:
-                continue
-
-            storyboard_scenes.append(
-                {
-                    "scene_id": item_scene_id,
-                    "scene_title": str(item.get("scene_title") or "").strip(),
-                    "visual_description": "",
-                    "narration": "",
-                    "duration_sec": 0,
-                    "shot_type": "medium",
-                    "transition": "cut",
-                    "characters": item.get("characters") or [],
+        try:
+            normalized_input = WorkflowInput(
+                **{
+                    **(workflow_input or {}),
+                    "video_provider": (
+                        str(video_provider or "").strip()
+                        or str((workflow_input or {}).get("video_provider") or "").strip()
+                        or "mock"
+                    ),
                 }
             )
+        except Exception as e:
+            raise ValueError(f"invalid workflow_input: {e}") from e
+
+        ctx = StepContext(
+            workflow_id=workflow_id,
+            session_id=session_id,
+            run_id=run_id,
+            input=normalized_input,
+        )
 
         outputs = {
             "image_review": updated_image_review,
@@ -1768,16 +1772,6 @@ class WorkflowRunner:
                 "scenes": storyboard_scenes,
             },
         }
-
-        ctx = StepContext(
-            workflow_id=workflow_id,
-            session_id=session_id,
-            run_id=run_id,
-            input=WorkflowInput(
-                topic="manual_selection_update",
-                video_provider=video_provider,
-            ),
-        )
 
         video_prompts = self._build_video_provider_prompts(
             ctx=ctx,

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1651,6 +1651,148 @@ class WorkflowRunner:
             return self._build_jimeng_video_prompts(ctx, scenes, outputs)
 
         raise UnknownVideoProviderError(f"Unknown video provider: {provider}")
+    
+    def _apply_manual_image_selection(
+        self,
+        image_review: Dict[str, Any],
+        scene_id: str,
+        selected_asset_ref: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        updated_review = dict(image_review or {})
+        selected_assets = updated_review.get("selected_assets") or []
+
+        normalized_scene_id = str(scene_id or "").strip()
+        if not normalized_scene_id:
+            raise ValueError("scene_id is required")
+
+        if not isinstance(selected_asset_ref, dict) or not selected_asset_ref:
+            raise ValueError("selected_asset_ref is required")
+
+        updated_items: List[Dict[str, Any]] = []
+        found = False
+
+        for item in selected_assets:
+            if not isinstance(item, dict):
+                updated_items.append(item)
+                continue
+
+            item_scene_id = str(item.get("scene_id") or "").strip()
+            if item_scene_id != normalized_scene_id:
+                updated_items.append(item)
+                continue
+
+            updated_item = dict(item)
+            updated_item["selected_asset_ref"] = dict(selected_asset_ref)
+            updated_item["selection_source"] = "manual_selection"
+            updated_item["selection_mode"] = "manual_click_override"
+            updated_item["review_status"] = "manually_selected"
+            updated_item["selection_reason"] = "selected_by_user_click"
+
+            candidate_asset_refs = updated_item.get("candidate_asset_refs") or []
+            if isinstance(candidate_asset_refs, list):
+                already_exists = False
+                for candidate in candidate_asset_refs:
+                    if not isinstance(candidate, dict):
+                        continue
+                    if (
+                        str(candidate.get("relative_path") or "").strip()
+                        == str(selected_asset_ref.get("relative_path") or "").strip()
+                        and str(candidate.get("file_name") or "").strip()
+                        == str(selected_asset_ref.get("file_name") or "").strip()
+                    ):
+                        already_exists = True
+                        break
+
+                if not already_exists:
+                    updated_item["candidate_asset_refs"] = candidate_asset_refs + [
+                        dict(selected_asset_ref)
+                    ]
+            else:
+                updated_item["candidate_asset_refs"] = [dict(selected_asset_ref)]
+
+            updated_items.append(updated_item)
+            found = True
+
+        if not found:
+            raise ValueError(f"scene_id not found in image_review: {normalized_scene_id}")
+
+        updated_review["selected_assets"] = updated_items
+        updated_review["selected_count"] = len(
+            [item for item in updated_items if isinstance(item, dict)]
+        )
+        updated_review["mode"] = "selection_contract"
+        return updated_review
+
+    def update_image_review_selection(
+        self,
+        workflow_id: str,
+        session_id: Optional[str],
+        run_id: str,
+        scene_id: str,
+        selected_asset_ref: Dict[str, Any],
+        image_review: Dict[str, Any],
+        video_provider: str = "mock",
+    ) -> Dict[str, Any]:
+        updated_image_review = self._apply_manual_image_selection(
+            image_review=image_review,
+            scene_id=scene_id,
+            selected_asset_ref=selected_asset_ref,
+        )
+
+        storyboard_scene_id = str(scene_id or "").strip()
+        storyboard_scenes: List[Dict[str, Any]] = []
+
+        for item in updated_image_review.get("selected_assets") or []:
+            if not isinstance(item, dict):
+                continue
+            item_scene_id = str(item.get("scene_id") or "").strip()
+            if item_scene_id != storyboard_scene_id:
+                continue
+
+            storyboard_scenes.append(
+                {
+                    "scene_id": item_scene_id,
+                    "scene_title": str(item.get("scene_title") or "").strip(),
+                    "visual_description": "",
+                    "narration": "",
+                    "duration_sec": 0,
+                    "shot_type": "medium",
+                    "transition": "cut",
+                    "characters": item.get("characters") or [],
+                }
+            )
+
+        outputs = {
+            "image_review": updated_image_review,
+            "storyboard": {
+                "scenes": storyboard_scenes,
+            },
+        }
+
+        ctx = StepContext(
+            workflow_id=workflow_id,
+            session_id=session_id,
+            run_id=run_id,
+            input=WorkflowInput(
+                topic="manual_selection_update",
+                video_provider=video_provider,
+            ),
+        )
+
+        video_prompts = self._build_video_provider_prompts(
+            ctx=ctx,
+            scenes=storyboard_scenes,
+            outputs=outputs,
+        )
+
+        return {
+            "workflow_id": workflow_id,
+            "session_id": session_id,
+            "run_id": run_id,
+            "scene_id": scene_id,
+            "image_review": updated_image_review,
+            "video_prompts": video_prompts,
+        }
     def _build_mock_video_prompts(
         self,
         ctx: StepContext,

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -484,7 +484,9 @@ class WorkflowRunner:
             aggregated_outputs[name] = output
 
             if name == "image_assets" and isinstance(output, dict):
-                aggregated_outputs["image_review"] = self._build_default_image_review(output)
+                aggregated_outputs["image_review"] = self._build_image_review_from_assets(
+                    aggregated_outputs
+                )
 
         session_memory_summary = self._build_session_memory_summary(
             req.session_id,
@@ -1451,27 +1453,25 @@ class WorkflowRunner:
                 mapping[scene_id] = item
         return mapping
 
-    def _selected_asset_ref_by_scene_id(
-        self, outputs: Dict[str, Any]
-    ) -> Dict[str, Dict[str, Any]]:
-        image_review = outputs.get("image_review") or {}
-        selected_assets = image_review.get("selected_assets") or []
-
-        mapping: Dict[str, Dict[str, Any]] = {}
-        for item in selected_assets:
-            if not isinstance(item, dict):
-                continue
-            scene_id = str(item.get("scene_id") or "").strip()
-            selected_asset_ref = item.get("selected_asset_ref") or {}
-            if scene_id and isinstance(selected_asset_ref, dict) and selected_asset_ref:
-                mapping[scene_id] = selected_asset_ref
-
-        return mapping
-
-    def _build_default_image_review(
+    def _image_asset_ref_from_item(
         self,
-        image_assets_output: Dict[str, Any],
+        item: Dict[str, Any],
+        provider: str,
     ) -> Dict[str, Any]:
+        return {
+            "scene_id": item.get("scene_id"),
+            "file_name": item.get("file_name"),
+            "relative_path": item.get("relative_path"),
+            "public_url": item.get("public_url"),
+            "mime_type": item.get("mime_type"),
+            "provider": provider,
+        }
+
+    def _build_image_review_from_assets(
+        self,
+        outputs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        image_assets_output = outputs.get("image_assets") or {}
         assets = image_assets_output.get("assets") or []
         provider = str(image_assets_output.get("provider") or "").strip()
 
@@ -1482,16 +1482,11 @@ class WorkflowRunner:
                 continue
 
             scene_id = str(item.get("scene_id") or "").strip()
-            scene_title = str(item.get("scene_title") or "").strip()
+            if not scene_id:
+                continue
 
-            selected_asset_ref = {
-                "scene_id": item.get("scene_id"),
-                "file_name": item.get("file_name"),
-                "relative_path": item.get("relative_path"),
-                "public_url": item.get("public_url"),
-                "mime_type": item.get("mime_type"),
-                "provider": provider,
-            }
+            scene_title = str(item.get("scene_title") or "").strip()
+            selected_asset_ref = self._image_asset_ref_from_item(item, provider)
 
             selected_assets.append(
                 {
@@ -1499,7 +1494,10 @@ class WorkflowRunner:
                     "scene_title": scene_title,
                     "review_status": "auto_selected",
                     "selection_mode": "default_first_pass",
+                    "selection_source": "default_auto_selection",
+                    "selection_reason": "default_selected_from_image_assets",
                     "selected_asset_ref": selected_asset_ref,
+                    "candidate_asset_refs": [selected_asset_ref],
                     "characters": item.get("characters") or [],
                     "character_ids": item.get("character_ids") or [],
                     "prompt": str(item.get("prompt") or "").strip(),
@@ -1508,12 +1506,47 @@ class WorkflowRunner:
 
         return {
             "enabled": True,
-            "mode": "default_auto_selection",
+            "mode": "selection_contract",
             "provider": provider,
             "asset_count": len(assets),
             "selected_count": len(selected_assets),
             "selected_assets": selected_assets,
         }
+    def _selection_item_by_scene_id(
+        self, outputs: Dict[str, Any]
+    ) -> Dict[str, Dict[str, Any]]:
+        image_review = outputs.get("image_review") or {}
+        selected_assets = image_review.get("selected_assets") or []
+
+        mapping: Dict[str, Dict[str, Any]] = {}
+        for item in selected_assets:
+            if not isinstance(item, dict):
+                continue
+
+            scene_id = str(item.get("scene_id") or "").strip()
+            if scene_id:
+                mapping[scene_id] = item
+
+        return mapping
+    def _selected_asset_ref_by_scene_id(
+        self, outputs: Dict[str, Any]
+    ) -> Dict[str, Dict[str, Any]]:
+        selection_items = self._selection_item_by_scene_id(outputs)
+
+        mapping: Dict[str, Dict[str, Any]] = {}
+        for scene_id, item in selection_items.items():
+            selected_asset_ref = item.get("selected_asset_ref") or {}
+            if isinstance(selected_asset_ref, dict) and selected_asset_ref:
+                mapping[scene_id] = selected_asset_ref
+
+        return mapping
+    def _build_default_image_review(
+        self,
+        image_assets_output: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return self._build_image_review_from_assets(
+            {"image_assets": image_assets_output}
+        )
     def _video_prompt_scene_metadata(
         self,
         scene: Dict[str, Any],
@@ -1534,19 +1567,23 @@ class WorkflowRunner:
                 seen.add(character_id)
 
         scene_id = str(scene.get("scene_id") or "").strip()
-
-        image_asset = self._image_asset_by_scene_id(outputs).get(scene_id) or {}
-        selected_asset = self._selected_asset_ref_by_scene_id(outputs).get(scene_id) or {}
-
-        effective_asset_ref = selected_asset or image_asset
-        selection_source = "image_review" if selected_asset else "image_assets"
+        selection_item = self._selection_item_by_scene_id(outputs).get(scene_id) or {}
+        selected_asset_ref = selection_item.get("selected_asset_ref") or {}
 
         return {
             "characters": characters,
             "character_ids": character_ids,
-            "selected_asset_ref": selected_asset,
-            "image_asset_ref": effective_asset_ref,
-            "selection_source": selection_source,
+            "selected_asset_ref": selected_asset_ref,
+            "image_asset_ref": selected_asset_ref,
+            "selection_source": str(
+                selection_item.get("selection_source") or "unknown"
+            ).strip(),
+            "selection_mode": str(
+                selection_item.get("selection_mode") or "unknown"
+            ).strip(),
+            "review_status": str(
+                selection_item.get("review_status") or "unreviewed"
+            ).strip(),
         }
     def _attach_video_prompt_contract(
         self,
@@ -1561,6 +1598,8 @@ class WorkflowRunner:
         enriched["selected_asset_ref"] = meta["selected_asset_ref"]
         enriched["image_asset_ref"] = meta["image_asset_ref"]
         enriched["selection_source"] = meta["selection_source"]
+        enriched["selection_mode"] = meta["selection_mode"]
+        enriched["review_status"] = meta["review_status"]
         return enriched
     def _build_video_prompt_base(
         self,

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import json
 import os
 import subprocess
@@ -1466,7 +1467,73 @@ class WorkflowRunner:
             "mime_type": item.get("mime_type"),
             "provider": provider,
         }
+    def _build_mock_candidate_asset_refs(
+        self,
+        item: Dict[str, Any],
+        provider: str,
+    ) -> List[Dict[str, Any]]:
+        primary_ref = self._image_asset_ref_from_item(item, provider)
 
+        relative_path = str(item.get("relative_path") or "").strip()
+        public_url = str(item.get("public_url") or "").strip()
+        file_name = str(item.get("file_name") or "").strip()
+        scene_id = item.get("scene_id")
+        mime_type = item.get("mime_type")
+
+        if not relative_path or not public_url or not file_name:
+            return [primary_ref]
+
+        if "." in file_name:
+            file_stem, file_ext = file_name.rsplit(".", 1)
+            mock_file_name = f"{file_stem}__candidate_b.{file_ext}"
+        else:
+            mock_file_name = f"{file_name}__candidate_b"
+
+        if "." in relative_path:
+            relative_stem, relative_ext = relative_path.rsplit(".", 1)
+            mock_relative_path = f"{relative_stem}__candidate_b.{relative_ext}"
+        else:
+            mock_relative_path = f"{relative_path}__candidate_b"
+
+        if "." in public_url:
+            public_stem, public_ext = public_url.rsplit(".", 1)
+            mock_public_url = f"{public_stem}__candidate_b.{public_ext}"
+        else:
+            mock_public_url = f"{public_url}__candidate_b"
+
+        mock_ref = {
+            "scene_id": scene_id,
+            "file_name": mock_file_name,
+            "relative_path": mock_relative_path,
+            "public_url": mock_public_url,
+            "mime_type": mime_type,
+            "provider": f"{provider}_mock_candidate",
+        }
+
+        self._ensure_mock_candidate_asset_file(primary_ref, mock_ref)
+
+        return [primary_ref, mock_ref]
+    def _ensure_mock_candidate_asset_file(
+        self,
+        primary_ref: Dict[str, Any],
+        candidate_ref: Dict[str, Any],
+    ) -> None:
+        primary_relative_path = str(primary_ref.get("relative_path") or "").strip()
+        candidate_relative_path = str(candidate_ref.get("relative_path") or "").strip()
+
+        if not primary_relative_path or not candidate_relative_path:
+            return
+
+        source_path = PROJECT_ROOT / primary_relative_path
+        target_path = PROJECT_ROOT / candidate_relative_path
+
+        if not source_path.exists():
+            return
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if not target_path.exists():
+            shutil.copyfile(source_path, target_path)
     def _build_image_review_from_assets(
         self,
         outputs: Dict[str, Any],
@@ -1486,7 +1553,8 @@ class WorkflowRunner:
                 continue
 
             scene_title = str(item.get("scene_title") or "").strip()
-            selected_asset_ref = self._image_asset_ref_from_item(item, provider)
+            candidate_asset_refs = self._build_mock_candidate_asset_refs(item, provider)
+            selected_asset_ref = candidate_asset_refs[0]
 
             selected_assets.append(
                 {
@@ -1497,7 +1565,7 @@ class WorkflowRunner:
                     "selection_source": "default_auto_selection",
                     "selection_reason": "default_selected_from_image_assets",
                     "selected_asset_ref": selected_asset_ref,
-                    "candidate_asset_refs": [selected_asset_ref],
+                    "candidate_asset_refs": candidate_asset_refs,
                     "characters": item.get("characters") or [],
                     "character_ids": item.get("character_ids") or [],
                     "prompt": str(item.get("prompt") or "").strip(),

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -29,6 +29,46 @@ type WorkflowRunResponse = {
   [key: string]: unknown
 }
 
+type WorkflowRunPayload = {
+  workflow_id: string
+  session_id: string
+  input: Record<string, unknown>
+  steps: Array<{ name: StepName }>
+}
+
+type ImageAssetRef = {
+  scene_id?: string
+  file_name?: string
+  relative_path?: string
+  public_url?: string
+  mime_type?: string
+  provider?: string
+}
+
+type ImageReviewSelectedAsset = {
+  scene_id?: string
+  scene_title?: string
+  review_status?: string
+  selection_mode?: string
+  selection_source?: string
+  selection_reason?: string
+  selected_asset_ref?: ImageAssetRef
+  candidate_asset_refs?: ImageAssetRef[]
+  characters?: Array<Record<string, unknown>>
+  character_ids?: string[]
+  prompt?: string
+}
+
+type ImageReviewSelectResponse = {
+  workflow_id?: string
+  session_id?: string
+  run_id?: string
+  scene_id?: string
+  image_review?: Record<string, unknown>
+  video_prompts?: Record<string, unknown>
+  timestamp?: string
+}
+
 type StructuredCharacterInput = {
   display_name: string
   species: string
@@ -189,7 +229,9 @@ const selectedSteps = ref<StepName[]>([...DEFAULT_STEPS])
 const stepSummaries = ref<Array<{ name: string; status: string; preview: string }>>(
   []
 )
-
+const currentWorkflowResponse = ref<WorkflowRunResponse | null>(null)
+const currentWorkflowPayload = ref<WorkflowRunPayload | null>(null)
+const selectingSceneId = ref('')
 const apiBaseUrl =
   (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim() ||
   'http://127.0.0.1:8004'
@@ -205,16 +247,54 @@ const providerStatsText = computed(() => {
   return stringifyPretty(samplesSummary.value.provider_stats)
 })
 
+const imageReviewSelectedAssets = computed<ImageReviewSelectedAsset[]>(() => {
+  const value = currentWorkflowResponse.value?.outputs?.image_review
+  if (!value || typeof value !== 'object') {
+    return []
+  }
+
+  const selectedAssets = (value as Record<string, unknown>).selected_assets
+  return Array.isArray(selectedAssets) ? (selectedAssets as ImageReviewSelectedAsset[]) : []
+})
+
+function assetRefPath(assetRef?: ImageAssetRef): string {
+  if (!assetRef) {
+    return ''
+  }
+  return assetRef.public_url || assetRef.relative_path || ''
+}
+
+function isSameAssetRef(a?: ImageAssetRef, b?: ImageAssetRef): boolean {
+  if (!a || !b) {
+    return false
+  }
+
+  const aRelativePath = (a.relative_path || '').trim()
+  const bRelativePath = (b.relative_path || '').trim()
+  const aFileName = (a.file_name || '').trim()
+  const bFileName = (b.file_name || '').trim()
+
+  return aRelativePath === bRelativePath && aFileName === bFileName
+}
+
 function toAssetHref(path?: string): string {
   if (!path) {
     return ''
   }
 
-  if (path.startsWith('http://') || path.startsWith('https://')) {
-    return path
+  const trimmed = path.trim()
+  if (!trimmed) {
+    return ''
   }
 
-  return `${apiBaseUrl}/${path}`
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed
+  }
+
+  const normalizedBase = apiBaseUrl.replace(/\/+$/, '')
+  const normalizedPath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+
+  return `${normalizedBase}${normalizedPath}`
 }
 
 function hasAssetLink(path?: string): boolean {
@@ -415,6 +495,24 @@ function buildStepSummaries(data: WorkflowRunResponse): Array<{
   }))
 }
 
+function applyWorkflowResponse(data: WorkflowRunResponse) {
+  storyText.value = extractStoryText(data)
+  storyboardText.value = extractStoryboardText(data)
+  imagePromptsText.value = extractImagePromptsText(data)
+  imageAssetsText.value = extractImageAssetsText(data)
+  imageReviewText.value = extractImageReviewText(data)
+  videoPromptsText.value = extractVideoPromptsText(data)
+  narrationText.value = extractNarrationText(data)
+  subtitlesText.value = extractSubtitlesText(data)
+  renderPlanText.value = extractRenderPlanText(data)
+  extractMockAudioState(data)
+  stepSummaries.value = buildStepSummaries(data)
+  characterCandidatesText.value = extractCharacterCandidatesText(data)
+  characterManifestText.value = extractCharacterManifestText(data)
+  resultText.value = stringifyPretty(data)
+  currentWorkflowResponse.value = data
+}
+
 async function fetchSamplesSummary() {
   const response = await fetch(`${apiBaseUrl}/v1/samples/summary`)
   if (!response.ok) {
@@ -513,10 +611,91 @@ async function selectSample(sampleId: string) {
   }
 }
 
+async function selectImageAsset(sceneId: string, assetRef: ImageAssetRef) {
+  if (!sceneId || !assetRefPath(assetRef)) {
+    return
+  }
+
+  if (!currentWorkflowResponse.value || !currentWorkflowPayload.value) {
+    errorMessage.value = '请先运行一次 workflow，再进行手动选图。'
+    return
+  }
+
+  const outputs = currentWorkflowResponse.value.outputs || {}
+  const imageReview = outputs.image_review
+  const storyboard = outputs.storyboard
+
+  if (!imageReview || typeof imageReview !== 'object') {
+    errorMessage.value = '当前缺少 image_review 数据。'
+    return
+  }
+
+  if (!storyboard || typeof storyboard !== 'object') {
+    errorMessage.value = '当前缺少 storyboard 数据。'
+    return
+  }
+
+  selectingSceneId.value = sceneId
+  errorMessage.value = ''
+
+  const payload = {
+    workflow_id: currentWorkflowResponse.value.workflow_id || currentWorkflowPayload.value.workflow_id,
+    session_id:
+      currentWorkflowResponse.value.session_id || currentWorkflowPayload.value.session_id,
+    run_id: currentWorkflowResponse.value.run_id || '',
+    scene_id: sceneId,
+    selected_asset_ref: assetRef,
+    image_review: imageReview,
+    storyboard,
+    workflow_input: currentWorkflowPayload.value.input,
+    video_provider:
+      typeof currentWorkflowPayload.value.input?.video_provider === 'string'
+        ? currentWorkflowPayload.value.input.video_provider
+        : videoProvider.value,
+  }
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/v1/image-review/select`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+
+    const data: ImageReviewSelectResponse = await response.json()
+
+    const mergedResponse: WorkflowRunResponse = {
+      ...(currentWorkflowResponse.value || {}),
+      workflow_id: data.workflow_id || currentWorkflowResponse.value.workflow_id,
+      session_id: data.session_id || currentWorkflowResponse.value.session_id,
+      run_id: data.run_id || currentWorkflowResponse.value.run_id,
+      outputs: {
+        ...(currentWorkflowResponse.value.outputs || {}),
+        image_review:
+          data.image_review || currentWorkflowResponse.value.outputs?.image_review || {},
+        video_prompts:
+          data.video_prompts || currentWorkflowResponse.value.outputs?.video_prompts || {},
+      },
+    }
+
+    applyWorkflowResponse(mergedResponse)
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : '手动选图请求失败'
+  } finally {
+    selectingSceneId.value = ''
+  }
+}
 async function runWorkflow() {
   resultText.value = ''
   storyText.value = ''
   storyboardText.value = ''
+  currentWorkflowResponse.value = null
+  currentWorkflowPayload.value = null
   imagePromptsText.value = ''
   imageAssetsText.value = ''
   imageReviewText.value = ''
@@ -582,6 +761,7 @@ async function runWorkflow() {
     },
     steps: selectedSteps.value.map((name) => ({ name })),
   }
+  currentWorkflowPayload.value = payload as WorkflowRunPayload
 
   try {
     const response = await fetch(`${apiBaseUrl}/v1/workflow/run`, {
@@ -601,21 +781,8 @@ async function runWorkflow() {
       sessionId.value = data.session_id
     }
 
-    storyText.value = extractStoryText(data)
-    storyboardText.value = extractStoryboardText(data)
-    imagePromptsText.value = extractImagePromptsText(data)
-    imageAssetsText.value = extractImageAssetsText(data)
-    imageReviewText.value = extractImageReviewText(data)
-    videoPromptsText.value = extractVideoPromptsText(data)
-    narrationText.value = extractNarrationText(data)
-    subtitlesText.value = extractSubtitlesText(data)
-    renderPlanText.value = extractRenderPlanText(data)
-    extractMockAudioState(data)
-    stepSummaries.value = buildStepSummaries(data)
-    characterCandidatesText.value = extractCharacterCandidatesText(data)
-    characterManifestText.value = extractCharacterManifestText(data)
+    applyWorkflowResponse(data)
 
-    resultText.value = stringifyPretty(data)
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : 'Request failed'
   } finally {
@@ -1032,6 +1199,81 @@ onMounted(() => {
         <pre class="light-result">{{ imageAssetsText }}</pre>
       </section>
 
+      <section v-if="imageReviewSelectedAssets.length > 0" class="result-panel">
+        <h2 class="section-title">Interactive Image Review</h2>
+
+        <div class="review-scene-grid">
+          <article
+            v-for="item in imageReviewSelectedAssets"
+            :key="item.scene_id || item.scene_title"
+            class="review-scene-card"
+          >
+            <div class="review-scene-head">
+              <div>
+                <strong>{{ item.scene_title || item.scene_id || 'unknown-scene' }}</strong>
+                <p class="detail-text">
+                  {{ item.selection_source || '-' }} / {{ item.selection_mode || '-' }}
+                </p>
+              </div>
+
+              <span class="summary-status">
+                {{ selectingSceneId === item.scene_id ? 'Switching...' : item.review_status || '-' }}
+              </span>
+            </div>
+
+            <div class="detail-block">
+              <span class="detail-label">Current Selected</span>
+              <code>{{ assetRefPath(item.selected_asset_ref) || '-' }}</code>
+
+              <a
+                v-if="isImageAsset(assetRefPath(item.selected_asset_ref))"
+                class="asset-image-link"
+                :href="toAssetHref(assetRefPath(item.selected_asset_ref))"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <img
+                  class="asset-image asset-image-thumbnail review-selected-image"
+                  :src="toAssetHref(assetRefPath(item.selected_asset_ref))"
+                  :alt="item.scene_title || item.scene_id || 'selected-image'"
+                />
+              </a>
+            </div>
+
+            <div class="detail-block">
+              <span class="detail-label">Candidate Assets</span>
+
+              <div class="review-candidate-grid">
+                <button
+                  v-for="candidate in item.candidate_asset_refs || []"
+                  :key="candidate.relative_path || candidate.file_name || candidate.public_url"
+                  type="button"
+                  class="asset-select-card"
+                  :class="{
+                    active: isSameAssetRef(candidate, item.selected_asset_ref),
+                  }"
+                  :disabled="loading || selectingSceneId === item.scene_id"
+                  @click="selectImageAsset(item.scene_id || '', candidate)"
+                >
+                  <span class="detail-label">
+                    {{ isSameAssetRef(candidate, item.selected_asset_ref) ? 'Selected' : 'Click to Select' }}
+                  </span>
+
+                  <code>{{ candidate.file_name || '-' }}</code>
+
+                  <img
+                    v-if="isImageAsset(assetRefPath(candidate))"
+                    class="asset-image asset-image-thumbnail"
+                    :src="toAssetHref(assetRefPath(candidate))"
+                    :alt="candidate.file_name || 'candidate-image'"
+                  />
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
       <section v-if="imageReviewText" class="result-panel">
         <h2 class="section-title">Image Review / Asset Selection</h2>
         <pre class="light-result">{{ imageReviewText }}</pre>
@@ -1066,10 +1308,7 @@ onMounted(() => {
         <h2 class="section-title">Character Manifest</h2>
         <pre class="light-result">{{ characterManifestText }}</pre>
       </section>
-      <section v-if="imageReviewText" class="result-panel">
-        <h2 class="section-title">Image Review / Asset Selection</h2>
-        <pre class="light-result">{{ imageReviewText }}</pre>
-      </section>
+
       <section
         v-if="mockAudioIndexUrl || mockAudioSceneGroups.length > 0 || mockAudioDirectoryText"
         class="result-panel"
@@ -1592,6 +1831,60 @@ h1 {
   border: 1px solid #e5e7eb;
   border-radius: 10px;
   background: #f8fafc;
+}
+
+.review-scene-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.review-scene-card {
+  padding: 16px;
+  border-radius: 14px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+}
+
+.review-scene-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.review-candidate-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.asset-select-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  background: #f8fafc;
+  cursor: pointer;
+  text-align: left;
+}
+
+.asset-select-card.active {
+  border-color: #111827;
+  background: #eef2ff;
+}
+
+.asset-select-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.review-selected-image {
+  max-width: 280px;
 }
 
 .notes-preview-block {


### PR DESCRIPTION
## Summary

This PR adds the first interactive manual image selection flow for project 4.

It aligns the backend selection contract, adds a manual selection API, connects the frontend review UI, and rebuilds `video_prompts` after asset selection changes.

## Changes

- align `image_review` to a stable selection contract
- make `video_prompts` read from selection state
- add `POST /v1/image-review/select`
- rebuild `video_prompts` with preserved storyboard context after manual selection
- add frontend interactive image review UI
- support candidate asset switching from the frontend
- add temporary mock candidate assets for selection flow validation

## Validation

Validated locally for:

- workflow run
- manual selection API
- frontend selection interaction
- `image_review` update after selection
- `video_prompts` refresh after selection
- candidate asset rendering without broken images

## Notes

- current candidate assets are still mock candidates
- `candidate_b` is a temporary copied asset for interaction validation
- real multi-candidate image generation is not included in this PR
- `App.vue` refactor is planned for the next phase

## Next

- split `App.vue` into smaller components
- improve page information architecture and interaction flow
- replace mock candidates with real multi-candidate generation
- continue deeper modular refactor of `runner.py`