### PR TITLE
refactor: split workflow frontend into tabbed panels

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import InteractiveImageReview from './components/InteractiveImageReview.vue'
 import WorkflowResultsPanel from './components/WorkflowResultsPanel.vue'
 import WorkflowRunPanel from './components/WorkflowRunPanel.vue'
+import SampleAssetsPanel from './components/SampleAssetsPanel.vue'
 type StepName =
   | 'story'
   | 'storyboard'
@@ -284,34 +285,6 @@ function toAssetHref(path?: string): string {
   const normalizedPath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
 
   return `${normalizedBase}${normalizedPath}`
-}
-
-function hasAssetLink(path?: string): boolean {
-  return Boolean(path && path.trim())
-}
-
-function isImageAsset(path?: string): boolean {
-  if (!path) {
-    return false
-  }
-
-  const value = path.toLowerCase()
-  return (
-    value.endsWith('.png') ||
-    value.endsWith('.jpg') ||
-    value.endsWith('.jpeg') ||
-    value.endsWith('.webp') ||
-    value.endsWith('.gif')
-  )
-}
-
-function isVideoAsset(path?: string): boolean {
-  if (!path) {
-    return false
-  }
-
-  const value = path.toLowerCase()
-  return value.endsWith('.mp4') || value.endsWith('.webm') || value.endsWith('.mov')
 }
 
 function stringifyPretty(value: unknown): string {
@@ -790,194 +763,20 @@ onMounted(() => {
       <p class="desc">
         输入一个主题，系统按默认参数或可选配置生成故事、分镜、旁白、字幕与视频渲染计划。
       </p>
-            <section class="samples-panel">
-        <div class="samples-panel-head">
-          <div>
-            <h2 class="section-title">Real Sample Assets</h2>
-            <p class="samples-desc">
-              展示项目四当前已归档的真实可灵样片，总览 / 列表 / 详情三层查询已接入。
-            </p>
-          </div>
-
-          <button class="secondary-btn" :disabled="samplesLoading" @click="loadSampleAssets">
-            {{ samplesLoading ? 'Loading...' : 'Refresh Samples' }}
-          </button>
-        </div>
-
-        <p v-if="samplesErrorMessage" class="error">
-          样例资产加载失败：{{ samplesErrorMessage }}
-        </p>
-
-        <div v-if="samplesSummary" class="samples-summary-grid">
-          <div class="samples-metric">
-            <span class="metric-label">Providers</span>
-            <strong class="metric-value">
-              {{ (samplesSummary.providers || []).join(', ') || '-' }}
-            </strong>
-          </div>
-
-          <div class="samples-metric">
-            <span class="metric-label">Total Samples</span>
-            <strong class="metric-value">
-              {{ samplesSummary.total_sample_count ?? 0 }}
-            </strong>
-          </div>
-
-          <div class="samples-metric samples-metric-wide">
-            <span class="metric-label">Provider Stats</span>
-            <pre class="light-result compact-result">{{ providerStatsText }}</pre>
-          </div>
-        </div>
-
-        <div class="samples-layout">
-          <section class="samples-list-panel">
-            <h3 class="subsection-title">Kling Sample List</h3>
-
-            <p v-if="klingSamples.length === 0" class="hint">
-              当前没有可展示的样片记录。
-            </p>
-
-            <button
-              v-for="sample in klingSamples"
-              :key="sample.sample_id || sample.scene_id"
-              class="sample-list-item"
-              :class="{ active: sample.sample_id === selectedSampleId }"
-              @click="selectSample(sample.sample_id || '')"
-            >
-              <strong>{{ sample.sample_id || 'unknown-sample' }}</strong>
-              <span>scene_id: {{ sample.scene_id || '-' }}</span>
-              <span>status: {{ sample.status || '-' }}</span>
-            </button>
-          </section>
-
-          <section class="sample-detail-panel">
-            <h3 class="subsection-title">Sample Detail</h3>
-
-            <div v-if="selectedSampleDetail" class="sample-detail-content">
-              <div class="detail-row">
-                <span class="detail-label">sample_id</span>
-                <code>{{ selectedSampleDetail.sample_id || '-' }}</code>
-              </div>
-
-              <div class="detail-row">
-                <span class="detail-label">scene_id</span>
-                <code>{{ selectedSampleDetail.scene_id || '-' }}</code>
-              </div>
-
-              <div class="detail-row">
-                <span class="detail-label">generated_scene_id</span>
-                <code>{{ selectedSampleDetail.generated_scene_id || '-' }}</code>
-              </div>
-
-              <div class="detail-row">
-                <span class="detail-label">status</span>
-                <code>{{ selectedSampleDetail.status || '-' }}</code>
-              </div>
-
-              <div class="detail-block">
-                <span class="detail-label">notes</span>
-                <p class="detail-text">{{ selectedSampleDetail.notes || '-' }}</p>
-                <a
-                  v-if="hasAssetLink(selectedSampleDetail.assets?.notes)"
-                  class="asset-link"
-                  :href="toAssetHref(selectedSampleDetail.assets?.notes)"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Open notes file
-                </a>
-
-                <div class="notes-preview-block">
-                  <span class="detail-label">notes preview</span>
-                  <p v-if="selectedSampleNotesLoading" class="detail-text">Loading notes...</p>
-                  <pre v-else class="notes-preview">{{ selectedSampleNotesText || '-' }}</pre>
-                </div>
-              </div>
-
-              <div class="detail-block">
-                <span class="detail-label">clean_video</span>
-                <code>{{ selectedSampleDetail.assets?.clean_video || '-' }}</code>
-                <a
-                  v-if="hasAssetLink(selectedSampleDetail.assets?.clean_video)"
-                  class="asset-link"
-                  :href="toAssetHref(selectedSampleDetail.assets?.clean_video)"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Open clean video
-                </a>
-                <video
-                  v-if="isVideoAsset(selectedSampleDetail.assets?.clean_video)"
-                  class="asset-video"
-                  controls
-                  preload="metadata"
-                  :src="toAssetHref(selectedSampleDetail.assets?.clean_video)"
-                />
-              </div>
-
-              <div class="detail-block">
-                <span class="detail-label">watermarked_video</span>
-                <code>{{ selectedSampleDetail.assets?.watermarked_video || '-' }}</code>
-                <a
-                  v-if="hasAssetLink(selectedSampleDetail.assets?.watermarked_video)"
-                  class="asset-link"
-                  :href="toAssetHref(selectedSampleDetail.assets?.watermarked_video)"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Open watermarked video
-                </a>
-              </div>
-
-              <div class="detail-block">
-                <span class="detail-label">input_screenshot</span>
-                <code>{{ selectedSampleDetail.assets?.input_screenshot || '-' }}</code>
-                <a
-                  v-if="isImageAsset(selectedSampleDetail.assets?.input_screenshot)"
-                  class="asset-image-link"
-                  :href="toAssetHref(selectedSampleDetail.assets?.input_screenshot)"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <img
-                    class="asset-image asset-image-thumbnail"
-                    :src="toAssetHref(selectedSampleDetail.assets?.input_screenshot)"
-                    alt="input screenshot preview"
-                  />
-                </a>
-              </div>
-
-              <div class="detail-block">
-                <span class="detail-label">result_screenshots</span>
-                <ul class="asset-list asset-grid-list">
-                  <li
-                    v-for="path in selectedSampleDetail.assets?.result_screenshots || []"
-                    :key="path"
-                    class="asset-list-item"
-                  >
-                    <code>{{ path }}</code>
-                    <a
-                      v-if="isImageAsset(path)"
-                      class="asset-image-link"
-                      :href="toAssetHref(path)"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      <img
-                        class="asset-image asset-image-thumbnail"
-                        :src="toAssetHref(path)"
-                        :alt="path"
-                      />
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-
-            <p v-else class="hint">请选择左侧样片查看详情。</p>
-          </section>
-        </div>
-      </section>
+      <SampleAssetsPanel
+        :samples-loading="samplesLoading"
+        :samples-error-message="samplesErrorMessage"
+        :samples-summary="samplesSummary"
+        :provider-stats-text="providerStatsText"
+        :kling-samples="klingSamples"
+        :selected-sample-id="selectedSampleId"
+        :selected-sample-detail="selectedSampleDetail"
+        :selected-sample-notes-text="selectedSampleNotesText"
+        :selected-sample-notes-loading="selectedSampleNotesLoading"
+        :api-base-url="apiBaseUrl"
+        @refresh="loadSampleAssets"
+        @select-sample="selectSample"
+      />    
       <WorkflowRunPanel
         :loading="loading"
         :can-submit="canSubmit"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue'
 import InteractiveImageReview from './components/InteractiveImageReview.vue'
 import WorkflowResultsPanel from './components/WorkflowResultsPanel.vue'
+import WorkflowRunPanel from './components/WorkflowRunPanel.vue'
 type StepName =
   | 'story'
   | 'storyboard'
@@ -979,196 +980,67 @@ onMounted(() => {
           </section>
         </div>
       </section>
-
-      <label class="label" for="session-id">Session ID</label>
-      <input
-        id="session-id"
-        v-model="sessionId"
-        class="input"
-        type="text"
-        placeholder="请输入会话标识，例如 demo-session-001"
+      <WorkflowRunPanel
+        :loading="loading"
+        :can-submit="canSubmit"
+        :error-message="errorMessage"
+        :session-id="sessionId"
+        :topic="topic"
+        :audience="audience"
+        :tone="tone"
+        :visual-style="visualStyle"
+        :character-style="characterStyle"
+        :voice-style="voiceStyle"
+        :voiceover-enabled="voiceoverEnabled"
+        :voice-mode="voiceMode"
+        :narrator-voice-style="narratorVoiceStyle"
+        :mother-voice-style="motherVoiceStyle"
+        :child-voice-style="childVoiceStyle"
+        :duration-sec="durationSec"
+        :language="language"
+        :subtitle-enabled="subtitleEnabled"
+        :video-provider="videoProvider"
+        :output-mode="outputMode"
+        :structured-characters-enabled="structuredCharactersEnabled"
+        :primary-character-display-name="primaryCharacterDisplayName"
+        :primary-character-species="primaryCharacterSpecies"
+        :primary-character-visual-traits="primaryCharacterVisualTraits"
+        :primary-character-forbidden-traits="primaryCharacterForbiddenTraits"
+        :secondary-character-display-name="secondaryCharacterDisplayName"
+        :secondary-character-species="secondaryCharacterSpecies"
+        :secondary-character-visual-traits="secondaryCharacterVisualTraits"
+        :secondary-character-forbidden-traits="secondaryCharacterForbiddenTraits"
+        :selected-steps="selectedSteps"
+        :step-options="STEP_OPTIONS"
+        @update:sessionId="sessionId = $event"
+        @update:topic="topic = $event"
+        @update:audience="audience = $event"
+        @update:tone="tone = $event"
+        @update:visualStyle="visualStyle = $event"
+        @update:characterStyle="characterStyle = $event"
+        @update:voiceStyle="voiceStyle = $event"
+        @update:voiceoverEnabled="voiceoverEnabled = $event"
+        @update:voiceMode="voiceMode = $event"
+        @update:narratorVoiceStyle="narratorVoiceStyle = $event"
+        @update:motherVoiceStyle="motherVoiceStyle = $event"
+        @update:childVoiceStyle="childVoiceStyle = $event"
+        @update:durationSec="durationSec = $event"
+        @update:language="language = $event"
+        @update:subtitleEnabled="subtitleEnabled = $event"
+        @update:videoProvider="videoProvider = $event"
+        @update:outputMode="outputMode = $event"
+        @update:structuredCharactersEnabled="structuredCharactersEnabled = $event"
+        @update:primaryCharacterDisplayName="primaryCharacterDisplayName = $event"
+        @update:primaryCharacterSpecies="primaryCharacterSpecies = $event"
+        @update:primaryCharacterVisualTraits="primaryCharacterVisualTraits = $event"
+        @update:primaryCharacterForbiddenTraits="primaryCharacterForbiddenTraits = $event"
+        @update:secondaryCharacterDisplayName="secondaryCharacterDisplayName = $event"
+        @update:secondaryCharacterSpecies="secondaryCharacterSpecies = $event"
+        @update:secondaryCharacterVisualTraits="secondaryCharacterVisualTraits = $event"
+        @update:secondaryCharacterForbiddenTraits="secondaryCharacterForbiddenTraits = $event"
+        @update:selectedSteps="selectedSteps = $event"
+        @run="runWorkflow"
       />
-
-      <label class="label" for="topic">Topic</label>
-      <textarea
-        id="topic"
-        v-model="topic"
-        class="textarea"
-        rows="4"
-        placeholder="请输入一个主题，例如：写一个关于小猫冒险的故事"
-      />
-
-      <section class="config-panel">
-        <h2 class="section-title">Generation Config</h2>
-
-        <div class="config-grid">
-          <label class="field">
-            <span>Audience</span>
-            <input v-model="audience" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Tone</span>
-            <input v-model="tone" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Visual Style</span>
-            <input v-model="visualStyle" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Character Style</span>
-            <input v-model="characterStyle" class="input" type="text" />
-          </label>
-
-                    <label class="field">
-            <span>Voice Style</span>
-            <input v-model="voiceStyle" class="input" type="text" />
-          </label>
-
-          <label class="checkbox-field">
-            <input v-model="voiceoverEnabled" type="checkbox" />
-            <span>Enable Voiceover</span>
-          </label>
-
-          <label class="field">
-            <span>Voice Mode</span>
-            <select v-model="voiceMode" class="input">
-              <option value="single">single</option>
-              <option value="multi">multi</option>
-            </select>
-          </label>
-
-          <label class="field">
-            <span>Narrator Voice</span>
-            <input v-model="narratorVoiceStyle" class="input" type="text" />
-          </label>
-
-          <label v-if="voiceMode === 'multi'" class="field">
-            <span>Mother Voice</span>
-            <input v-model="motherVoiceStyle" class="input" type="text" />
-          </label>
-
-          <label v-if="voiceMode === 'multi'" class="field">
-            <span>Child Voice</span>
-            <input v-model="childVoiceStyle" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Duration (sec)</span>
-            <input v-model.number="durationSec" class="input" type="number" min="15" max="300" />
-          </label>
-
-          <label class="field">
-            <span>Language</span>
-            <input v-model="language" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Video Provider</span>
-            <input v-model="videoProvider" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Output Mode</span>
-            <input v-model="outputMode" class="input" type="text" />
-          </label>
-
-          <label class="checkbox-field">
-            <input v-model="subtitleEnabled" type="checkbox" />
-            <span>Enable Subtitles</span>
-          </label>
-        </div>
-      </section>
-
-      <section class="config-panel">
-        <h2 class="section-title">Character Finalization</h2>
-
-        <label class="checkbox-field">
-          <input v-model="structuredCharactersEnabled" type="checkbox" />
-          <span>Enable Structured Characters</span>
-        </label>
-
-        <div v-if="structuredCharactersEnabled" class="config-grid">
-          <label class="field">
-            <span>Primary Character Display Name</span>
-            <input v-model="primaryCharacterDisplayName" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Primary Character Species</span>
-            <input v-model="primaryCharacterSpecies" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Primary Visual Traits</span>
-            <textarea
-              v-model="primaryCharacterVisualTraits"
-              class="textarea"
-              rows="3"
-              placeholder="例如：long upright ears, white fur, red scarf"
-            />
-          </label>
-
-          <label class="field">
-            <span>Primary Forbidden Traits</span>
-            <textarea
-              v-model="primaryCharacterForbiddenTraits"
-              class="textarea"
-              rows="3"
-              placeholder="例如：cat ears, turtle shell"
-            />
-          </label>
-
-          <label class="field">
-            <span>Secondary Character Display Name</span>
-            <input v-model="secondaryCharacterDisplayName" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Secondary Character Species</span>
-            <input v-model="secondaryCharacterSpecies" class="input" type="text" />
-          </label>
-
-          <label class="field">
-            <span>Secondary Visual Traits</span>
-            <textarea
-              v-model="secondaryCharacterVisualTraits"
-              class="textarea"
-              rows="3"
-              placeholder="例如：round shell, short legs, green shell"
-            />
-          </label>
-
-          <label class="field">
-            <span>Secondary Forbidden Traits</span>
-            <textarea
-              v-model="secondaryCharacterForbiddenTraits"
-              class="textarea"
-              rows="3"
-              placeholder="例如：rabbit ears, cat ears"
-            />
-          </label>
-        </div>
-      </section>
-
-      <section class="steps-panel">
-        <h2 class="section-title">Workflow Steps</h2>
-        <div class="steps-grid">
-          <label v-for="step in STEP_OPTIONS" :key="step.value" class="step-option">
-            <input v-model="selectedSteps" type="checkbox" :value="step.value" />
-            <span>{{ step.label }}</span>
-          </label>
-        </div>
-        <p v-if="selectedSteps.length === 0" class="hint">请至少选择一个 step。</p>
-      </section>
-
-      <button class="btn" :disabled="!canSubmit" @click="runWorkflow">
-        {{ loading ? '请求中...' : 'Run Workflow' }}
-      </button>
-
-      <p v-if="errorMessage" class="error">请求失败：{{ errorMessage }}</p>
       <InteractiveImageReview
         :items="imageReviewSelectedAssets"
         :api-base-url="apiBaseUrl"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import InteractiveImageReview from './components/InteractiveImageReview.vue'
-
+import WorkflowResultsPanel from './components/WorkflowResultsPanel.vue'
 type StepName =
   | 'story'
   | 'storyboard'
@@ -1169,26 +1169,6 @@ onMounted(() => {
       </button>
 
       <p v-if="errorMessage" class="error">请求失败：{{ errorMessage }}</p>
-
-      <section v-if="storyText" class="story-panel">
-        <h2 class="section-title">Story Result</h2>
-        <p class="story-text">{{ storyText }}</p>
-      </section>
-
-      <section v-if="storyboardText" class="result-panel">
-        <h2 class="section-title">Storyboard</h2>
-        <pre class="light-result">{{ storyboardText }}</pre>
-      </section>
-            <section v-if="imagePromptsText" class="result-panel">
-        <h2 class="section-title">Image Prompts</h2>
-        <pre class="light-result">{{ imagePromptsText }}</pre>
-      </section>
-
-      <section v-if="imageAssetsText" class="result-panel">
-        <h2 class="section-title">Image Assets</h2>
-        <pre class="light-result">{{ imageAssetsText }}</pre>
-      </section>
-
       <InteractiveImageReview
         :items="imageReviewSelectedAssets"
         :api-base-url="apiBaseUrl"
@@ -1196,42 +1176,19 @@ onMounted(() => {
         :selecting-scene-id="selectingSceneId"
         @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
       />
-
-      <section v-if="imageReviewText" class="result-panel">
-        <h2 class="section-title">Image Review / Asset Selection</h2>
-        <pre class="light-result">{{ imageReviewText }}</pre>
-      </section>
-
-      <section v-if="videoPromptsText" class="result-panel">
-        <h2 class="section-title">Video Prompts</h2>
-        <pre class="light-result">{{ videoPromptsText }}</pre>
-      </section>
-
-      <section v-if="narrationText" class="result-panel">
-        <h2 class="section-title">Narration</h2>
-        <pre class="light-result">{{ narrationText }}</pre>
-      </section>
-
-      <section v-if="subtitlesText" class="result-panel">
-        <h2 class="section-title">Subtitles Preview</h2>
-        <pre class="light-result">{{ subtitlesText }}</pre>
-      </section>
-
-      <section v-if="renderPlanText" class="result-panel">
-        <h2 class="section-title">Render Plan</h2>
-        <pre class="light-result">{{ renderPlanText }}</pre>
-      </section>
-
-      <section v-if="characterCandidatesText" class="result-panel">
-        <h2 class="section-title">Character Candidates</h2>
-        <pre class="light-result">{{ characterCandidatesText }}</pre>
-      </section>
-
-      <section v-if="characterManifestText" class="result-panel">
-        <h2 class="section-title">Character Manifest</h2>
-        <pre class="light-result">{{ characterManifestText }}</pre>
-      </section>
-
+      <WorkflowResultsPanel
+        :story-text="storyText"
+        :storyboard-text="storyboardText"
+        :image-prompts-text="imagePromptsText"
+        :image-assets-text="imageAssetsText"
+        :image-review-text="imageReviewText"
+        :video-prompts-text="videoPromptsText"
+        :narration-text="narrationText"
+        :subtitles-text="subtitlesText"
+        :render-plan-text="renderPlanText"
+        :character-candidates-text="characterCandidatesText"
+        :character-manifest-text="characterManifestText"
+      />
       <section
         v-if="mockAudioIndexUrl || mockAudioSceneGroups.length > 0 || mockAudioDirectoryText"
         class="result-panel"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import InteractiveImageReview from './components/InteractiveImageReview.vue'
 
 type StepName =
   | 'story'
@@ -262,19 +263,6 @@ function assetRefPath(assetRef?: ImageAssetRef): string {
     return ''
   }
   return assetRef.public_url || assetRef.relative_path || ''
-}
-
-function isSameAssetRef(a?: ImageAssetRef, b?: ImageAssetRef): boolean {
-  if (!a || !b) {
-    return false
-  }
-
-  const aRelativePath = (a.relative_path || '').trim()
-  const bRelativePath = (b.relative_path || '').trim()
-  const aFileName = (a.file_name || '').trim()
-  const bFileName = (b.file_name || '').trim()
-
-  return aRelativePath === bRelativePath && aFileName === bFileName
 }
 
 function toAssetHref(path?: string): string {
@@ -692,6 +680,8 @@ async function selectImageAsset(sceneId: string, assetRef: ImageAssetRef) {
 }
 async function runWorkflow() {
   resultText.value = ''
+  currentWorkflowResponse.value = null
+  currentWorkflowPayload.value = null
   storyText.value = ''
   storyboardText.value = ''
   currentWorkflowResponse.value = null
@@ -1199,80 +1189,13 @@ onMounted(() => {
         <pre class="light-result">{{ imageAssetsText }}</pre>
       </section>
 
-      <section v-if="imageReviewSelectedAssets.length > 0" class="result-panel">
-        <h2 class="section-title">Interactive Image Review</h2>
-
-        <div class="review-scene-grid">
-          <article
-            v-for="item in imageReviewSelectedAssets"
-            :key="item.scene_id || item.scene_title"
-            class="review-scene-card"
-          >
-            <div class="review-scene-head">
-              <div>
-                <strong>{{ item.scene_title || item.scene_id || 'unknown-scene' }}</strong>
-                <p class="detail-text">
-                  {{ item.selection_source || '-' }} / {{ item.selection_mode || '-' }}
-                </p>
-              </div>
-
-              <span class="summary-status">
-                {{ selectingSceneId === item.scene_id ? 'Switching...' : item.review_status || '-' }}
-              </span>
-            </div>
-
-            <div class="detail-block">
-              <span class="detail-label">Current Selected</span>
-              <code>{{ assetRefPath(item.selected_asset_ref) || '-' }}</code>
-
-              <a
-                v-if="isImageAsset(assetRefPath(item.selected_asset_ref))"
-                class="asset-image-link"
-                :href="toAssetHref(assetRefPath(item.selected_asset_ref))"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <img
-                  class="asset-image asset-image-thumbnail review-selected-image"
-                  :src="toAssetHref(assetRefPath(item.selected_asset_ref))"
-                  :alt="item.scene_title || item.scene_id || 'selected-image'"
-                />
-              </a>
-            </div>
-
-            <div class="detail-block">
-              <span class="detail-label">Candidate Assets</span>
-
-              <div class="review-candidate-grid">
-                <button
-                  v-for="candidate in item.candidate_asset_refs || []"
-                  :key="candidate.relative_path || candidate.file_name || candidate.public_url"
-                  type="button"
-                  class="asset-select-card"
-                  :class="{
-                    active: isSameAssetRef(candidate, item.selected_asset_ref),
-                  }"
-                  :disabled="loading || selectingSceneId === item.scene_id"
-                  @click="selectImageAsset(item.scene_id || '', candidate)"
-                >
-                  <span class="detail-label">
-                    {{ isSameAssetRef(candidate, item.selected_asset_ref) ? 'Selected' : 'Click to Select' }}
-                  </span>
-
-                  <code>{{ candidate.file_name || '-' }}</code>
-
-                  <img
-                    v-if="isImageAsset(assetRefPath(candidate))"
-                    class="asset-image asset-image-thumbnail"
-                    :src="toAssetHref(assetRefPath(candidate))"
-                    :alt="candidate.file_name || 'candidate-image'"
-                  />
-                </button>
-              </div>
-            </div>
-          </article>
-        </div>
-      </section>
+      <InteractiveImageReview
+        :items="imageReviewSelectedAssets"
+        :api-base-url="apiBaseUrl"
+        :loading="loading"
+        :selecting-scene-id="selectingSceneId"
+        @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
+      />
 
       <section v-if="imageReviewText" class="result-panel">
         <h2 class="section-title">Image Review / Asset Selection</h2>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -685,8 +685,6 @@ async function runWorkflow() {
   currentWorkflowPayload.value = null
   storyText.value = ''
   storyboardText.value = ''
-  currentWorkflowResponse.value = null
-  currentWorkflowPayload.value = null
   imagePromptsText.value = ''
   imageAssetsText.value = ''
   imageReviewText.value = ''
@@ -1176,129 +1174,10 @@ h1 {
   font-size: 15px;
 }
 
-.label {
-  display: block;
-  margin-bottom: 8px;
-  color: #111827;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.input {
-  width: 100%;
-  box-sizing: border-box;
-  border: 1px solid #d1d5db;
-  border-radius: 12px;
-  padding: 12px 14px;
-  margin-bottom: 16px;
-  font-size: 14px;
-  color: #111827;
-  background: #ffffff;
-}
-
-.textarea {
-  width: 100%;
-  box-sizing: border-box;
-  border: 1px solid #d1d5db;
-  border-radius: 12px;
-  padding: 12px 14px;
-  font-size: 15px;
-  line-height: 1.5;
-  resize: vertical;
-  background: #ffffff;
-  color: #111827;
-}
-
-.textarea:focus,
-.input:focus,
-.textarea:focus {
-  outline: none;
-  border-color: #111827;
-}
-
-.config-panel,
-.steps-panel,
-.story-panel,
-.result-panel,
-.summary-item {
-  margin-top: 20px;
-  padding: 16px;
-  border-radius: 14px;
-  background: #f8fafc;
-  border: 1px solid #e5e7eb;
-}
-
-.config-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
-}
-
-.field {
-  display: block;
-}
-
-.field span,
-.checkbox-field span {
-  display: block;
-  margin-bottom: 8px;
-  color: #111827;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.checkbox-field {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-top: 28px;
-}
-
-.checkbox-field span {
-  margin-bottom: 0;
-  font-weight: 500;
-}
-
-.steps-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.step-option {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #111827;
-  font-size: 14px;
-}
-
 .hint {
   margin: 12px 0 0;
   color: #dc2626;
   font-size: 13px;
-}
-
-.btn {
-  margin-top: 16px;
-  border: none;
-  border-radius: 10px;
-  padding: 12px 18px;
-  font-size: 15px;
-  cursor: pointer;
-  background: #111827;
-  color: #ffffff;
-}
-
-.btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.7;
-}
-
-.error {
-  margin-top: 16px;
-  color: #dc2626;
-  font-size: 14px;
 }
 
 .summary-panel,
@@ -1334,14 +1213,6 @@ h1 {
   font-size: 16px;
   line-height: 1.4;
   color: #111827;
-}
-
-.story-text {
-  margin: 0;
-  color: #1f2937;
-  font-size: 15px;
-  line-height: 1.8;
-  white-space: pre-wrap;
 }
 
 .result {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+type ImageAssetRef = {
+  scene_id?: string
+  file_name?: string
+  relative_path?: string
+  public_url?: string
+  mime_type?: string
+  provider?: string
+}
+
+type ImageReviewSelectedAsset = {
+  scene_id?: string
+  scene_title?: string
+  review_status?: string
+  selection_mode?: string
+  selection_source?: string
+  selection_reason?: string
+  selected_asset_ref?: ImageAssetRef
+  candidate_asset_refs?: ImageAssetRef[]
+  characters?: Array<Record<string, unknown>>
+  character_ids?: string[]
+  prompt?: string
+}
+
+const props = defineProps<{
+  items: ImageReviewSelectedAsset[]
+  apiBaseUrl: string
+  loading: boolean
+  selectingSceneId: string
+}>()
+
+const emit = defineEmits<{
+  (
+    e: 'select-asset',
+    payload: {
+      sceneId: string
+      assetRef: ImageAssetRef
+    }
+  ): void
+}>()
+
+function toAssetHref(path?: string): string {
+  if (!path) {
+    return ''
+  }
+
+  const trimmed = path.trim()
+  if (!trimmed) {
+    return ''
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed
+  }
+
+  const normalizedBase = props.apiBaseUrl.replace(/\/+$/, '')
+  const normalizedPath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+
+  return `${normalizedBase}${normalizedPath}`
+}
+
+function assetRefPath(assetRef?: ImageAssetRef): string {
+  if (!assetRef) {
+    return ''
+  }
+  return assetRef.public_url || assetRef.relative_path || ''
+}
+
+function isImageAsset(path?: string): boolean {
+  if (!path) {
+    return false
+  }
+
+  const value = path.toLowerCase()
+  return (
+    value.endsWith('.png') ||
+    value.endsWith('.jpg') ||
+    value.endsWith('.jpeg') ||
+    value.endsWith('.webp') ||
+    value.endsWith('.gif')
+  )
+}
+
+function isSameAssetRef(a?: ImageAssetRef, b?: ImageAssetRef): boolean {
+  if (!a || !b) {
+    return false
+  }
+
+  const aRelativePath = (a.relative_path || '').trim()
+  const bRelativePath = (b.relative_path || '').trim()
+  const aFileName = (a.file_name || '').trim()
+  const bFileName = (b.file_name || '').trim()
+
+  return aRelativePath === bRelativePath && aFileName === bFileName
+}
+
+function onSelect(sceneId: string, assetRef: ImageAssetRef) {
+  emit('select-asset', {
+    sceneId,
+    assetRef,
+  })
+}
+</script>
+
+<template>
+  <section v-if="items.length > 0" class="result-panel">
+    <h2 class="section-title">Interactive Image Review</h2>
+
+    <div class="review-scene-grid">
+      <article
+        v-for="item in items"
+        :key="item.scene_id || item.scene_title"
+        class="review-scene-card"
+      >
+        <div class="review-scene-head">
+          <div>
+            <strong>{{ item.scene_title || item.scene_id || 'unknown-scene' }}</strong>
+            <p class="detail-text">
+              {{ item.selection_source || '-' }} / {{ item.selection_mode || '-' }}
+            </p>
+          </div>
+
+          <span class="summary-status">
+            {{ selectingSceneId === item.scene_id ? 'Switching...' : item.review_status || '-' }}
+          </span>
+        </div>
+
+        <div class="detail-block">
+          <span class="detail-label">Current Selected</span>
+          <code>{{ assetRefPath(item.selected_asset_ref) || '-' }}</code>
+
+          <a
+            v-if="isImageAsset(assetRefPath(item.selected_asset_ref))"
+            class="asset-image-link"
+            :href="toAssetHref(assetRefPath(item.selected_asset_ref))"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <img
+              class="asset-image asset-image-thumbnail review-selected-image"
+              :src="toAssetHref(assetRefPath(item.selected_asset_ref))"
+              :alt="item.scene_title || item.scene_id || 'selected-image'"
+            />
+          </a>
+        </div>
+
+        <div class="detail-block">
+          <span class="detail-label">Candidate Assets</span>
+
+          <div class="review-candidate-grid">
+            <button
+              v-for="candidate in item.candidate_asset_refs || []"
+              :key="candidate.relative_path || candidate.file_name || candidate.public_url"
+              type="button"
+              class="asset-select-card"
+              :class="{
+                active: isSameAssetRef(candidate, item.selected_asset_ref),
+              }"
+              :disabled="loading || selectingSceneId === item.scene_id"
+              @click="onSelect(item.scene_id || '', candidate)"
+            >
+              <span class="detail-label">
+                {{ isSameAssetRef(candidate, item.selected_asset_ref) ? 'Selected' : 'Click to Select' }}
+              </span>
+
+              <code>{{ candidate.file_name || '-' }}</code>
+
+              <img
+                v-if="isImageAsset(assetRefPath(candidate))"
+                class="asset-image asset-image-thumbnail"
+                :src="toAssetHref(assetRefPath(candidate))"
+                :alt="candidate.file_name || 'candidate-image'"
+              />
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.result-panel {
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 14px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+}
+
+.section-title {
+  margin: 0 0 12px;
+  font-size: 16px;
+  line-height: 1.4;
+  color: #111827;
+}
+
+.summary-status {
+  color: #2563eb;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.detail-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.detail-label {
+  color: #6b7280;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.detail-text {
+  color: #111827;
+  line-height: 1.6;
+}
+
+.asset-image {
+  display: block;
+  width: 100%;
+  max-width: 520px;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  margin-top: 8px;
+}
+
+.asset-image-link {
+  display: inline-block;
+  width: fit-content;
+  margin-top: 8px;
+}
+
+.asset-image-thumbnail {
+  max-width: 240px;
+  max-height: 180px;
+  object-fit: cover;
+  cursor: pointer;
+}
+
+.review-scene-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.review-scene-card {
+  padding: 16px;
+  border-radius: 14px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+}
+
+.review-scene-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.review-candidate-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.asset-select-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  background: #f8fafc;
+  cursor: pointer;
+  text-align: left;
+}
+
+.asset-select-card.active {
+  border-color: #111827;
+  background: #eef2ff;
+}
+
+.asset-select-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.review-selected-image {
+  max-width: 280px;
+}
+</style>

--- a/frontend/src/components/SampleAssetsPanel.vue
+++ b/frontend/src/components/SampleAssetsPanel.vue
@@ -1,0 +1,564 @@
+<script setup lang="ts">
+type SampleAssetPaths = {
+  notes?: string
+  clean_video?: string
+  watermarked_video?: string
+  input_screenshot?: string
+  result_screenshots?: string[]
+}
+
+type KlingSample = {
+  sample_id?: string
+  scene_id?: string
+  generated_scene_id?: string
+  status?: string
+  notes?: string
+  assets?: SampleAssetPaths
+}
+
+type SamplesSummaryResponse = {
+  providers?: string[]
+  total_sample_count?: number
+  provider_stats?: Record<
+    string,
+    {
+      sample_count?: number
+      latest_sample_id?: string
+      available_scene_ids?: string[]
+    }
+  >
+}
+
+const props = defineProps<{
+  samplesLoading: boolean
+  samplesErrorMessage: string
+  samplesSummary: SamplesSummaryResponse | null
+  providerStatsText: string
+  klingSamples: KlingSample[]
+  selectedSampleId: string
+  selectedSampleDetail: KlingSample | null
+  selectedSampleNotesText: string
+  selectedSampleNotesLoading: boolean
+  apiBaseUrl: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'refresh'): void
+  (e: 'select-sample', sampleId: string): void
+}>()
+
+function toAssetHref(path?: string): string {
+  if (!path) {
+    return ''
+  }
+
+  const trimmed = path.trim()
+  if (!trimmed) {
+    return ''
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed
+  }
+
+  const normalizedBase = props.apiBaseUrl.replace(/\/+$/, '')
+  const normalizedPath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+
+  return `${normalizedBase}${normalizedPath}`
+}
+
+function hasAssetLink(path?: string): boolean {
+  return Boolean(path && path.trim())
+}
+
+function isImageAsset(path?: string): boolean {
+  if (!path) {
+    return false
+  }
+
+  const value = path.toLowerCase()
+  return (
+    value.endsWith('.png') ||
+    value.endsWith('.jpg') ||
+    value.endsWith('.jpeg') ||
+    value.endsWith('.webp') ||
+    value.endsWith('.gif')
+  )
+}
+
+function isVideoAsset(path?: string): boolean {
+  if (!path) {
+    return false
+  }
+
+  const value = path.toLowerCase()
+  return value.endsWith('.mp4') || value.endsWith('.webm') || value.endsWith('.mov')
+}
+</script>
+
+<template>
+  <section class="samples-panel">
+    <div class="samples-panel-head">
+      <div>
+        <h2 class="section-title">Real Sample Assets</h2>
+        <p class="samples-desc">
+          展示项目四当前已归档的真实可灵样片，总览 / 列表 / 详情三层查询已接入。
+        </p>
+      </div>
+
+      <button class="secondary-btn" :disabled="samplesLoading" @click="emit('refresh')">
+        {{ samplesLoading ? 'Loading...' : 'Refresh Samples' }}
+      </button>
+    </div>
+
+    <p v-if="samplesErrorMessage" class="error">
+      样例资产加载失败：{{ samplesErrorMessage }}
+    </p>
+
+    <div v-if="samplesSummary" class="samples-summary-grid">
+      <div class="samples-metric">
+        <span class="metric-label">Providers</span>
+        <strong class="metric-value">
+          {{ (samplesSummary.providers || []).join(', ') || '-' }}
+        </strong>
+      </div>
+
+      <div class="samples-metric">
+        <span class="metric-label">Total Samples</span>
+        <strong class="metric-value">
+          {{ samplesSummary.total_sample_count ?? 0 }}
+        </strong>
+      </div>
+
+      <div class="samples-metric samples-metric-wide">
+        <span class="metric-label">Provider Stats</span>
+        <pre class="light-result compact-result">{{ providerStatsText }}</pre>
+      </div>
+    </div>
+
+    <div class="samples-layout">
+      <section class="samples-list-panel">
+        <h3 class="subsection-title">Kling Sample List</h3>
+
+        <p v-if="klingSamples.length === 0" class="hint">
+          当前没有可展示的样片记录。
+        </p>
+
+        <button
+          v-for="sample in klingSamples"
+          :key="sample.sample_id || sample.scene_id"
+          class="sample-list-item"
+          :class="{ active: sample.sample_id === selectedSampleId }"
+          @click="emit('select-sample', sample.sample_id || '')"
+        >
+          <strong>{{ sample.sample_id || 'unknown-sample' }}</strong>
+          <span>scene_id: {{ sample.scene_id || '-' }}</span>
+          <span>status: {{ sample.status || '-' }}</span>
+        </button>
+      </section>
+
+      <section class="sample-detail-panel">
+        <h3 class="subsection-title">Sample Detail</h3>
+
+        <div v-if="selectedSampleDetail" class="sample-detail-content">
+          <div class="detail-row">
+            <span class="detail-label">sample_id</span>
+            <code>{{ selectedSampleDetail.sample_id || '-' }}</code>
+          </div>
+
+          <div class="detail-row">
+            <span class="detail-label">scene_id</span>
+            <code>{{ selectedSampleDetail.scene_id || '-' }}</code>
+          </div>
+
+          <div class="detail-row">
+            <span class="detail-label">generated_scene_id</span>
+            <code>{{ selectedSampleDetail.generated_scene_id || '-' }}</code>
+          </div>
+
+          <div class="detail-row">
+            <span class="detail-label">status</span>
+            <code>{{ selectedSampleDetail.status || '-' }}</code>
+          </div>
+
+          <div class="detail-block">
+            <span class="detail-label">notes</span>
+            <p class="detail-text">{{ selectedSampleDetail.notes || '-' }}</p>
+            <a
+              v-if="hasAssetLink(selectedSampleDetail.assets?.notes)"
+              class="asset-link"
+              :href="toAssetHref(selectedSampleDetail.assets?.notes)"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open notes file
+            </a>
+
+            <div class="notes-preview-block">
+              <span class="detail-label">notes preview</span>
+              <p v-if="selectedSampleNotesLoading" class="detail-text">Loading notes...</p>
+              <pre v-else class="notes-preview">{{ selectedSampleNotesText || '-' }}</pre>
+            </div>
+          </div>
+
+          <div class="detail-block">
+            <span class="detail-label">clean_video</span>
+            <code>{{ selectedSampleDetail.assets?.clean_video || '-' }}</code>
+            <a
+              v-if="hasAssetLink(selectedSampleDetail.assets?.clean_video)"
+              class="asset-link"
+              :href="toAssetHref(selectedSampleDetail.assets?.clean_video)"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open clean video
+            </a>
+            <video
+              v-if="isVideoAsset(selectedSampleDetail.assets?.clean_video)"
+              class="asset-video"
+              controls
+              preload="metadata"
+              :src="toAssetHref(selectedSampleDetail.assets?.clean_video)"
+            />
+          </div>
+
+          <div class="detail-block">
+            <span class="detail-label">watermarked_video</span>
+            <code>{{ selectedSampleDetail.assets?.watermarked_video || '-' }}</code>
+            <a
+              v-if="hasAssetLink(selectedSampleDetail.assets?.watermarked_video)"
+              class="asset-link"
+              :href="toAssetHref(selectedSampleDetail.assets?.watermarked_video)"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open watermarked video
+            </a>
+          </div>
+
+          <div class="detail-block">
+            <span class="detail-label">input_screenshot</span>
+            <code>{{ selectedSampleDetail.assets?.input_screenshot || '-' }}</code>
+            <a
+              v-if="isImageAsset(selectedSampleDetail.assets?.input_screenshot)"
+              class="asset-image-link"
+              :href="toAssetHref(selectedSampleDetail.assets?.input_screenshot)"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <img
+                class="asset-image asset-image-thumbnail"
+                :src="toAssetHref(selectedSampleDetail.assets?.input_screenshot)"
+                alt="input screenshot preview"
+              />
+            </a>
+          </div>
+
+          <div class="detail-block">
+            <span class="detail-label">result_screenshots</span>
+            <ul class="asset-list asset-grid-list">
+              <li
+                v-for="path in selectedSampleDetail.assets?.result_screenshots || []"
+                :key="path"
+                class="asset-list-item"
+              >
+                <code>{{ path }}</code>
+                <a
+                  v-if="isImageAsset(path)"
+                  class="asset-image-link"
+                  :href="toAssetHref(path)"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <img
+                    class="asset-image asset-image-thumbnail"
+                    :src="toAssetHref(path)"
+                    :alt="path"
+                  />
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <p v-else class="hint">请选择左侧样片查看详情。</p>
+      </section>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.samples-panel {
+  margin: 24px 0;
+  padding: 20px;
+  border-radius: 16px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+}
+
+.samples-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.samples-desc {
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.secondary-btn {
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #111827;
+  border-radius: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.secondary-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.samples-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.samples-metric {
+  padding: 14px;
+  border-radius: 12px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  text-align: left;
+}
+
+.samples-metric-wide {
+  grid-column: 1 / -1;
+}
+
+.metric-label {
+  display: block;
+  margin-bottom: 8px;
+  color: #6b7280;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.metric-value {
+  color: #111827;
+  font-size: 18px;
+}
+
+.samples-layout {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 16px;
+}
+
+.samples-list-panel,
+.sample-detail-panel {
+  padding: 16px;
+  border-radius: 14px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+}
+
+.subsection-title {
+  margin: 0 0 12px;
+  color: #111827;
+  font-size: 18px;
+  text-align: left;
+}
+
+.sample-list-item {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  border: 1px solid #e5e7eb;
+  background: #f8fafc;
+  color: #111827;
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 10px;
+  cursor: pointer;
+}
+
+.sample-list-item.active {
+  border-color: #111827;
+  background: #eef2ff;
+}
+
+.sample-detail-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: left;
+}
+
+.detail-row,
+.detail-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.detail-label {
+  color: #6b7280;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.detail-text {
+  color: #111827;
+  line-height: 1.6;
+}
+
+.asset-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.asset-list li {
+  margin-bottom: 8px;
+}
+
+.compact-result {
+  margin: 0;
+  max-height: 220px;
+}
+
+.light-result {
+  margin: 12px 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #1f2937;
+}
+
+.hint {
+  margin: 12px 0 0;
+  color: #dc2626;
+  font-size: 13px;
+}
+
+.error {
+  margin-top: 16px;
+  color: #dc2626;
+  font-size: 14px;
+}
+
+.asset-link {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-top: 6px;
+  color: #2563eb;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.asset-link:hover {
+  text-decoration: underline;
+}
+
+.asset-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.asset-image {
+  display: block;
+  width: 100%;
+  max-width: 520px;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  margin-top: 8px;
+}
+
+.asset-video {
+  display: block;
+  width: 100%;
+  max-width: 520px;
+  border-radius: 10px;
+  margin-top: 8px;
+  background: #000000;
+}
+
+.asset-image-link {
+  display: inline-block;
+  width: fit-content;
+  margin-top: 8px;
+}
+
+.asset-image-thumbnail {
+  max-width: 240px;
+  max-height: 180px;
+  object-fit: cover;
+  cursor: pointer;
+}
+
+.asset-grid-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+  padding-left: 0;
+  list-style: none;
+}
+
+.asset-grid-list .asset-list-item {
+  padding: 10px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.notes-preview-block {
+  margin-top: 10px;
+}
+
+.notes-preview {
+  margin: 0;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #f8fafc;
+  color: #111827;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow: auto;
+  text-align: left;
+}
+
+@media (max-width: 900px) {
+  .samples-panel-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .samples-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .samples-layout {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/components/WorkflowResultsPanel.vue
+++ b/frontend/src/components/WorkflowResultsPanel.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+defineProps<{
+  storyText: string
+  storyboardText: string
+  imagePromptsText: string
+  imageAssetsText: string
+  imageReviewText: string
+  videoPromptsText: string
+  narrationText: string
+  subtitlesText: string
+  renderPlanText: string
+  characterCandidatesText: string
+  characterManifestText: string
+}>()
+</script>
+
+<template>
+  <section v-if="storyText" class="story-panel">
+    <h2 class="section-title">Story Result</h2>
+    <p class="story-text">{{ storyText }}</p>
+  </section>
+
+  <section v-if="storyboardText" class="result-panel">
+    <h2 class="section-title">Storyboard</h2>
+    <pre class="light-result">{{ storyboardText }}</pre>
+  </section>
+
+  <section v-if="imagePromptsText" class="result-panel">
+    <h2 class="section-title">Image Prompts</h2>
+    <pre class="light-result">{{ imagePromptsText }}</pre>
+  </section>
+
+  <section v-if="imageAssetsText" class="result-panel">
+    <h2 class="section-title">Image Assets</h2>
+    <pre class="light-result">{{ imageAssetsText }}</pre>
+  </section>
+
+  <section v-if="imageReviewText" class="result-panel">
+    <h2 class="section-title">Image Review / Asset Selection</h2>
+    <pre class="light-result">{{ imageReviewText }}</pre>
+  </section>
+
+  <section v-if="videoPromptsText" class="result-panel">
+    <h2 class="section-title">Video Prompts</h2>
+    <pre class="light-result">{{ videoPromptsText }}</pre>
+  </section>
+
+  <section v-if="narrationText" class="result-panel">
+    <h2 class="section-title">Narration</h2>
+    <pre class="light-result">{{ narrationText }}</pre>
+  </section>
+
+  <section v-if="subtitlesText" class="result-panel">
+    <h2 class="section-title">Subtitles Preview</h2>
+    <pre class="light-result">{{ subtitlesText }}</pre>
+  </section>
+
+  <section v-if="renderPlanText" class="result-panel">
+    <h2 class="section-title">Render Plan</h2>
+    <pre class="light-result">{{ renderPlanText }}</pre>
+  </section>
+
+  <section v-if="characterCandidatesText" class="result-panel">
+    <h2 class="section-title">Character Candidates</h2>
+    <pre class="light-result">{{ characterCandidatesText }}</pre>
+  </section>
+
+  <section v-if="characterManifestText" class="result-panel">
+    <h2 class="section-title">Character Manifest</h2>
+    <pre class="light-result">{{ characterManifestText }}</pre>
+  </section>
+</template>
+
+<style scoped>
+.story-panel,
+.result-panel {
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 14px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+}
+
+.section-title {
+  margin: 0 0 12px;
+  font-size: 16px;
+  line-height: 1.4;
+  color: #111827;
+}
+
+.story-text {
+  margin: 0;
+  color: #1f2937;
+  font-size: 15px;
+  line-height: 1.8;
+  white-space: pre-wrap;
+}
+
+.light-result {
+  margin: 12px 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #1f2937;
+}
+</style>

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -1,0 +1,578 @@
+<script setup lang="ts">
+type StepName =
+  | 'story'
+  | 'storyboard'
+  | 'image_prompts'
+  | 'image_assets'
+  | 'video_prompts'
+  | 'dialogue_script'
+  | 'narration'
+  | 'subtitles'
+  | 'render_plan'
+
+const props = defineProps<{
+  loading: boolean
+  canSubmit: boolean
+  errorMessage: string
+
+  sessionId: string
+  topic: string
+  audience: string
+  tone: string
+  visualStyle: string
+  characterStyle: string
+  voiceStyle: string
+  voiceoverEnabled: boolean
+  voiceMode: string
+  narratorVoiceStyle: string
+  motherVoiceStyle: string
+  childVoiceStyle: string
+  durationSec: number
+  language: string
+  subtitleEnabled: boolean
+  videoProvider: string
+  outputMode: string
+
+  structuredCharactersEnabled: boolean
+  primaryCharacterDisplayName: string
+  primaryCharacterSpecies: string
+  primaryCharacterVisualTraits: string
+  primaryCharacterForbiddenTraits: string
+  secondaryCharacterDisplayName: string
+  secondaryCharacterSpecies: string
+  secondaryCharacterVisualTraits: string
+  secondaryCharacterForbiddenTraits: string
+
+  selectedSteps: StepName[]
+  stepOptions: Array<{ label: string; value: StepName }>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:sessionId', value: string): void
+  (e: 'update:topic', value: string): void
+  (e: 'update:audience', value: string): void
+  (e: 'update:tone', value: string): void
+  (e: 'update:visualStyle', value: string): void
+  (e: 'update:characterStyle', value: string): void
+  (e: 'update:voiceStyle', value: string): void
+  (e: 'update:voiceoverEnabled', value: boolean): void
+  (e: 'update:voiceMode', value: string): void
+  (e: 'update:narratorVoiceStyle', value: string): void
+  (e: 'update:motherVoiceStyle', value: string): void
+  (e: 'update:childVoiceStyle', value: string): void
+  (e: 'update:durationSec', value: number): void
+  (e: 'update:language', value: string): void
+  (e: 'update:subtitleEnabled', value: boolean): void
+  (e: 'update:videoProvider', value: string): void
+  (e: 'update:outputMode', value: string): void
+
+  (e: 'update:structuredCharactersEnabled', value: boolean): void
+  (e: 'update:primaryCharacterDisplayName', value: string): void
+  (e: 'update:primaryCharacterSpecies', value: string): void
+  (e: 'update:primaryCharacterVisualTraits', value: string): void
+  (e: 'update:primaryCharacterForbiddenTraits', value: string): void
+  (e: 'update:secondaryCharacterDisplayName', value: string): void
+  (e: 'update:secondaryCharacterSpecies', value: string): void
+  (e: 'update:secondaryCharacterVisualTraits', value: string): void
+  (e: 'update:secondaryCharacterForbiddenTraits', value: string): void
+
+  (e: 'update:selectedSteps', value: StepName[]): void
+  (e: 'run'): void
+}>()
+
+function updateSelectedStep(step: StepName, checked: boolean) {
+  const current = [...props.selectedSteps]
+
+  if (checked) {
+    if (!current.includes(step)) {
+      emit('update:selectedSteps', [...current, step])
+    }
+    return
+  }
+
+  emit(
+    'update:selectedSteps',
+    current.filter((item) => item !== step)
+  )
+}
+</script>
+
+<template>
+  <section class="workflow-run-panel">
+    <label class="label" for="session-id">Session ID</label>
+    <input
+      id="session-id"
+      :value="sessionId"
+      class="input"
+      type="text"
+      placeholder="请输入会话标识，例如 demo-session-001"
+      @input="emit('update:sessionId', ($event.target as HTMLInputElement).value)"
+    />
+
+    <label class="label" for="topic">Topic</label>
+    <textarea
+      id="topic"
+      :value="topic"
+      class="textarea"
+      rows="4"
+      placeholder="请输入一个主题，例如：写一个关于小猫冒险的故事"
+      @input="emit('update:topic', ($event.target as HTMLTextAreaElement).value)"
+    />
+
+    <section class="config-panel">
+      <h2 class="section-title">Generation Config</h2>
+
+      <div class="config-grid">
+        <label class="field">
+          <span>Audience</span>
+          <input
+            :value="audience"
+            class="input"
+            type="text"
+            @input="emit('update:audience', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Tone</span>
+          <input
+            :value="tone"
+            class="input"
+            type="text"
+            @input="emit('update:tone', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Visual Style</span>
+          <input
+            :value="visualStyle"
+            class="input"
+            type="text"
+            @input="emit('update:visualStyle', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Character Style</span>
+          <input
+            :value="characterStyle"
+            class="input"
+            type="text"
+            @input="emit('update:characterStyle', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Voice Style</span>
+          <input
+            :value="voiceStyle"
+            class="input"
+            type="text"
+            @input="emit('update:voiceStyle', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="checkbox-field">
+          <input
+            :checked="voiceoverEnabled"
+            type="checkbox"
+            @change="emit('update:voiceoverEnabled', ($event.target as HTMLInputElement).checked)"
+          />
+          <span>Enable Voiceover</span>
+        </label>
+
+        <label class="field">
+          <span>Voice Mode</span>
+          <select
+            :value="voiceMode"
+            class="input"
+            @change="emit('update:voiceMode', ($event.target as HTMLSelectElement).value)"
+          >
+            <option value="single">single</option>
+            <option value="multi">multi</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Narrator Voice</span>
+          <input
+            :value="narratorVoiceStyle"
+            class="input"
+            type="text"
+            @input="emit('update:narratorVoiceStyle', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label v-if="voiceMode === 'multi'" class="field">
+          <span>Mother Voice</span>
+          <input
+            :value="motherVoiceStyle"
+            class="input"
+            type="text"
+            @input="emit('update:motherVoiceStyle', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label v-if="voiceMode === 'multi'" class="field">
+          <span>Child Voice</span>
+          <input
+            :value="childVoiceStyle"
+            class="input"
+            type="text"
+            @input="emit('update:childVoiceStyle', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Duration (sec)</span>
+          <input
+            :value="durationSec"
+            class="input"
+            type="number"
+            min="15"
+            max="300"
+            @input="emit('update:durationSec', Number(($event.target as HTMLInputElement).value))"
+          />
+        </label>
+
+        <label class="field">
+          <span>Language</span>
+          <input
+            :value="language"
+            class="input"
+            type="text"
+            @input="emit('update:language', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Video Provider</span>
+          <input
+            :value="videoProvider"
+            class="input"
+            type="text"
+            @input="emit('update:videoProvider', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Output Mode</span>
+          <input
+            :value="outputMode"
+            class="input"
+            type="text"
+            @input="emit('update:outputMode', ($event.target as HTMLInputElement).value)"
+          />
+        </label>
+
+        <label class="checkbox-field">
+          <input
+            :checked="subtitleEnabled"
+            type="checkbox"
+            @change="emit('update:subtitleEnabled', ($event.target as HTMLInputElement).checked)"
+          />
+          <span>Enable Subtitles</span>
+        </label>
+      </div>
+    </section>
+
+    <section class="config-panel">
+      <h2 class="section-title">Character Finalization</h2>
+
+      <label class="checkbox-field">
+        <input
+          :checked="structuredCharactersEnabled"
+          type="checkbox"
+          @change="
+            emit(
+              'update:structuredCharactersEnabled',
+              ($event.target as HTMLInputElement).checked
+            )
+          "
+        />
+        <span>Enable Structured Characters</span>
+      </label>
+
+      <div v-if="structuredCharactersEnabled" class="config-grid">
+        <label class="field">
+          <span>Primary Character Display Name</span>
+          <input
+            :value="primaryCharacterDisplayName"
+            class="input"
+            type="text"
+            @input="
+              emit(
+                'update:primaryCharacterDisplayName',
+                ($event.target as HTMLInputElement).value
+              )
+            "
+          />
+        </label>
+
+        <label class="field">
+          <span>Primary Character Species</span>
+          <input
+            :value="primaryCharacterSpecies"
+            class="input"
+            type="text"
+            @input="
+              emit(
+                'update:primaryCharacterSpecies',
+                ($event.target as HTMLInputElement).value
+              )
+            "
+          />
+        </label>
+
+        <label class="field">
+          <span>Primary Visual Traits</span>
+          <textarea
+            :value="primaryCharacterVisualTraits"
+            class="textarea"
+            rows="3"
+            placeholder="例如：long upright ears, white fur, red scarf"
+            @input="
+              emit(
+                'update:primaryCharacterVisualTraits',
+                ($event.target as HTMLTextAreaElement).value
+              )
+            "
+          />
+        </label>
+
+        <label class="field">
+          <span>Primary Forbidden Traits</span>
+          <textarea
+            :value="primaryCharacterForbiddenTraits"
+            class="textarea"
+            rows="3"
+            placeholder="例如：cat ears, turtle shell"
+            @input="
+              emit(
+                'update:primaryCharacterForbiddenTraits',
+                ($event.target as HTMLTextAreaElement).value
+              )
+            "
+          />
+        </label>
+
+        <label class="field">
+          <span>Secondary Character Display Name</span>
+          <input
+            :value="secondaryCharacterDisplayName"
+            class="input"
+            type="text"
+            @input="
+              emit(
+                'update:secondaryCharacterDisplayName',
+                ($event.target as HTMLInputElement).value
+              )
+            "
+          />
+        </label>
+
+        <label class="field">
+          <span>Secondary Character Species</span>
+          <input
+            :value="secondaryCharacterSpecies"
+            class="input"
+            type="text"
+            @input="
+              emit(
+                'update:secondaryCharacterSpecies',
+                ($event.target as HTMLInputElement).value
+              )
+            "
+          />
+        </label>
+
+        <label class="field">
+          <span>Secondary Visual Traits</span>
+          <textarea
+            :value="secondaryCharacterVisualTraits"
+            class="textarea"
+            rows="3"
+            placeholder="例如：round shell, short legs, green shell"
+            @input="
+              emit(
+                'update:secondaryCharacterVisualTraits',
+                ($event.target as HTMLTextAreaElement).value
+              )
+            "
+          />
+        </label>
+
+        <label class="field">
+          <span>Secondary Forbidden Traits</span>
+          <textarea
+            :value="secondaryCharacterForbiddenTraits"
+            class="textarea"
+            rows="3"
+            placeholder="例如：rabbit ears, cat ears"
+            @input="
+              emit(
+                'update:secondaryCharacterForbiddenTraits',
+                ($event.target as HTMLTextAreaElement).value
+              )
+            "
+          />
+        </label>
+      </div>
+    </section>
+
+    <section class="steps-panel">
+      <h2 class="section-title">Workflow Steps</h2>
+      <div class="steps-grid">
+        <label v-for="step in stepOptions" :key="step.value" class="step-option">
+          <input
+            type="checkbox"
+            :checked="selectedSteps.includes(step.value)"
+            :value="step.value"
+            @change="
+              updateSelectedStep(
+                step.value,
+                ($event.target as HTMLInputElement).checked
+              )
+            "
+          />
+          <span>{{ step.label }}</span>
+        </label>
+      </div>
+      <p v-if="selectedSteps.length === 0" class="hint">请至少选择一个 step。</p>
+    </section>
+
+    <button class="btn" :disabled="!canSubmit" @click="emit('run')">
+      {{ loading ? '请求中...' : 'Run Workflow' }}
+    </button>
+
+    <p v-if="errorMessage" class="error">请求失败：{{ errorMessage }}</p>
+  </section>
+</template>
+
+<style scoped>
+.workflow-run-panel {
+  display: contents;
+}
+
+.label {
+  display: block;
+  margin-bottom: 8px;
+  color: #111827;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  color: #111827;
+  background: #ffffff;
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 15px;
+  line-height: 1.5;
+  resize: vertical;
+  background: #ffffff;
+  color: #111827;
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: #111827;
+}
+
+.config-panel,
+.steps-panel {
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 14px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+}
+
+.config-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.field {
+  display: block;
+}
+
+.field span,
+.checkbox-field span {
+  display: block;
+  margin-bottom: 8px;
+  color: #111827;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.checkbox-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 28px;
+}
+
+.checkbox-field span {
+  margin-bottom: 0;
+  font-weight: 500;
+}
+
+.steps-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.step-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #111827;
+  font-size: 14px;
+}
+
+.hint {
+  margin: 12px 0 0;
+  color: #dc2626;
+  font-size: 13px;
+}
+
+.btn {
+  margin-top: 16px;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 18px;
+  font-size: 15px;
+  cursor: pointer;
+  background: #111827;
+  color: #ffffff;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.error {
+  margin-top: 16px;
+  color: #dc2626;
+  font-size: 14px;
+}
+</style>


### PR DESCRIPTION
## Summary

This PR refactors the project 4 frontend into smaller focused panels and adds a tabbed shell layout.

## Changes

- extract `InteractiveImageReview.vue`
- extract `WorkflowResultsPanel.vue`
- extract `WorkflowRunPanel.vue`
- extract `SampleAssetsPanel.vue`
- add top-level tabs: `Run / Review / Assets / Debug`
- add empty-state messaging for `Review` and `Debug`
- clean up part of `App.vue` after component extraction

## Validation

Validated locally for:
- frontend build success
- workflow run from `Run`
- result display in `Review`
- sample assets in `Assets`
- debug output in `Debug`
- manual image selection still works after tab layout changes

## Notes

- current candidate assets are still mock candidates
- real multi-candidate image generation is not included in this PR
- further cleanup of `App.vue` can be done incrementally later

## Next

- continue frontend polish if needed
- then move to real multi-candidate generation
- later continue deeper `runner.py` modular refactor