### PR TITLE
feat: add final video rerender endpoint for selected assets

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from app.schemas.workflow import (
+    FinalVideoRenderRequest,
+    FinalVideoRenderResponse,
     ImageReviewRefreshRequest,
     ImageReviewRefreshResponse,
     ImageReviewRefreshSceneRequest,
@@ -108,6 +110,34 @@ def select_image_review_asset(req: ImageReviewSelectRequest):
         print("[image-review] runtime error", repr(e))
         raise
 
+@app.post("/v1/final-video/render", response_model=FinalVideoRenderResponse)
+def render_final_video(req: FinalVideoRenderRequest):
+    print("[final-video] render request received", req.workflow_id, req.run_id)
+    try:
+        result = _runner.rerender_final_video(
+            workflow_id=req.workflow_id,
+            session_id=req.session_id,
+            run_id=req.run_id,
+            workflow_input=req.workflow_input,
+            image_assets=req.image_assets,
+            audio_segments=req.audio_segments,
+            subtitles=req.subtitles,
+        )
+        print("[final-video] render completed", req.run_id)
+        return FinalVideoRenderResponse(
+            workflow_id=result["workflow_id"],
+            session_id=result.get("session_id"),
+            run_id=result["run_id"],
+            final_video=result["final_video"],
+            timestamp=FinalVideoRenderResponse.now_timestamp(),
+        )
+    except ValueError as e:
+        print("[final-video] bad request", str(e))
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        print("[final-video] runtime error", repr(e))
+        raise
+    
 @app.post("/v1/image-review/refresh", response_model=ImageReviewRefreshResponse)
 def refresh_image_review(req: ImageReviewRefreshRequest):
     print("[image-review] refresh request received", req.workflow_id, req.run_id)

--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -267,3 +267,29 @@ class ImageReviewRefreshSceneResponse(BaseModel):
             .isoformat()
             .replace("+00:00", "Z")
         )
+        
+class FinalVideoRenderRequest(BaseModel):
+    workflow_id: str
+    session_id: Optional[str] = None
+    run_id: str
+    workflow_input: Dict[str, Any] = Field(default_factory=dict)
+    image_assets: Dict[str, Any] = Field(default_factory=dict)
+    audio_segments: Dict[str, Any] = Field(default_factory=dict)
+    subtitles: Dict[str, Any] = Field(default_factory=dict)
+
+
+class FinalVideoRenderResponse(BaseModel):
+    workflow_id: str
+    session_id: Optional[str] = None
+    run_id: str
+    final_video: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: str
+
+    @staticmethod
+    def now_timestamp() -> str:
+        return (
+            datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -98,6 +98,50 @@ class WorkflowRunner:
         }
         self._session_store: Dict[str, Dict[str, Any]] = {}
         self._run_store: Dict[str, Dict[str, Any]] = {}
+
+    def _workflow_input_from_dict(self, workflow_input: Dict[str, Any]) -> WorkflowInput:
+        if isinstance(workflow_input, WorkflowInput):
+            return workflow_input
+        if not isinstance(workflow_input, dict):
+            workflow_input = {}
+        return WorkflowInput(**workflow_input)
+
+    def _build_step_context(
+        self,
+        *,
+        workflow_id: str,
+        session_id: Optional[str],
+        run_id: str,
+        workflow_input: WorkflowInput,
+    ) -> StepContext:
+        return StepContext(
+            workflow_id=workflow_id,
+            session_id=session_id,
+            run_id=run_id,
+            input=workflow_input,
+        )
+
+    def rerender_final_video(
+        self,
+        *,
+        workflow_id: str,
+        session_id: Optional[str],
+        run_id: str,
+        workflow_input: Dict[str, Any],
+        image_assets: Dict[str, Any],
+        audio_segments: Dict[str, Any],
+        subtitles: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return self._audio_render_support.rerender_final_video(
+            workflow_id=workflow_id,
+            session_id=session_id,
+            run_id=run_id,
+            workflow_input=workflow_input,
+            image_assets=image_assets,
+            audio_segments=audio_segments,
+            subtitles=subtitles,
+        )
+   
     def get_real_kling_samples_manifest(self) -> Dict[str, Any]:
         manifest = self._build_real_samples_manifest()
         samples = manifest.get("samples") or []

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -726,3 +726,37 @@ class RunnerAudioRenderSupport:
             "audio_track_path": f"assets/mock/video/{ctx.run_id}/merged_audio.mp3",
             "subtitle_path": f"assets/mock/video/{ctx.run_id}/subtitles.srt",
         }
+    def rerender_final_video(
+        self,
+        *,
+        workflow_id: str,
+        session_id: Optional[str],
+        run_id: str,
+        workflow_input: Dict[str, Any],
+        image_assets: Dict[str, Any],
+        audio_segments: Dict[str, Any],
+        subtitles: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        ctx_input = self._runner._workflow_input_from_dict(workflow_input)
+        ctx = self._runner._build_step_context(
+            workflow_id=workflow_id,
+            session_id=session_id,
+            run_id=run_id,
+            workflow_input=ctx_input,
+        )
+
+        final_video = self.run_final_video(
+            ctx,
+            {
+                "image_assets": image_assets,
+                "audio_segments": audio_segments,
+                "subtitles": subtitles,
+            },
+        )
+
+        return {
+            "workflow_id": workflow_id,
+            "session_id": session_id,
+            "run_id": run_id,
+            "final_video": final_video,
+        }


### PR DESCRIPTION
Verified end-to-end with local pillow assets: manual selection of shot_01__candidate_b.png propagated into final video concat and generated final.mp4. Real API image validation is currently blocked by repeated SiliconFlow HTTP 429 rate limits during /v1/image-review/refresh