### PR TITLE
refactor: standardize image provider execution with adapter and queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# =========================
+# TTS
+# =========================
+
 # Real TTS switch
 TTS_ENABLED=false
 
@@ -16,3 +20,40 @@ TTS_TIMEOUT_SECONDS=120
 TTS_VOICE_NARRATOR=
 TTS_VOICE_MOTHER=
 TTS_VOICE_CHILD=
+
+# =========================
+# Image Provider
+# =========================
+
+# Primary image provider:
+# - pillow_storybook_renderer
+# - api_image_generator
+IMAGE_PROVIDER=pillow_storybook_renderer
+
+# Fallback provider when primary provider fails
+IMAGE_FALLBACK_PROVIDER=pillow_storybook_renderer
+
+# Strategy when API provider hits 429/rate-limit:
+# - pending
+# - fail
+IMAGE_429_STRATEGY=pending
+
+# If true, allow api_image_generator to fall back to pillow_storybook_renderer
+API_IMAGE_FALLBACK_TO_PILLOW=true
+
+# Enable real API image generation
+API_IMAGE_ENABLED=false
+
+# OpenAI-compatible / SiliconFlow style image endpoint
+IMAGE_API_KEY=
+IMAGE_API_BASE_URL=https://api.siliconflow.cn/v1
+
+# Model config
+SILICONFLOW_IMAGE_MODEL=Kwai-Kolors/Kolors
+SILICONFLOW_IMAGE_SIZE=720x1280
+SILICONFLOW_IMAGE_NEGATIVE_PROMPT=low quality, blurry, distorted anatomy, broken composition, extra limbs, duplicated subject, unreadable details
+SILICONFLOW_IMAGE_STEPS=20
+SILICONFLOW_IMAGE_GUIDANCE=7.5
+
+# Test switches
+FORCE_IMAGE_RATE_LIMIT=false

--- a/app/main.py
+++ b/app/main.py
@@ -110,6 +110,7 @@ def select_image_review_asset(req: ImageReviewSelectRequest):
         print("[image-review] runtime error", repr(e))
         raise
 
+
 @app.post("/v1/final-video/render", response_model=FinalVideoRenderResponse)
 def render_final_video(req: FinalVideoRenderRequest):
     print("[final-video] render request received", req.workflow_id, req.run_id)
@@ -137,7 +138,8 @@ def render_final_video(req: FinalVideoRenderRequest):
     except Exception as e:
         print("[final-video] runtime error", repr(e))
         raise
-    
+
+
 @app.post("/v1/image-review/refresh", response_model=ImageReviewRefreshResponse)
 def refresh_image_review(req: ImageReviewRefreshRequest):
     print("[image-review] refresh request received", req.workflow_id, req.run_id)
@@ -171,7 +173,12 @@ def refresh_image_review(req: ImageReviewRefreshRequest):
 
 @app.post("/v1/image-review/refresh-scene", response_model=ImageReviewRefreshSceneResponse)
 def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
-    print("[image-review] refresh-scene request received", req.workflow_id, req.run_id, req.scene_id)
+    print(
+        "[image-review] refresh-scene request received",
+        req.workflow_id,
+        req.run_id,
+        req.scene_id,
+    )
     try:
         result = _runner.refresh_image_review_scene(
             workflow_id=req.workflow_id,
@@ -200,32 +207,4 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         print("[image-review] refresh-scene runtime error", repr(e))
-        raise
-
-    print("[image-review] refresh request received", req.workflow_id, req.run_id)
-    try:
-        result = _runner.refresh_image_review(
-            workflow_id=req.workflow_id,
-            session_id=req.session_id,
-            run_id=req.run_id,
-            storyboard=req.storyboard,
-            workflow_input=req.workflow_input,
-            image_review=req.image_review,
-            video_provider=req.video_provider,
-        )
-        print("[image-review] refresh completed", req.run_id)
-        return ImageReviewRefreshResponse(
-            workflow_id=result["workflow_id"],
-            session_id=result.get("session_id"),
-            run_id=result["run_id"],
-            image_assets=result["image_assets"],
-            image_review=result["image_review"],
-            video_prompts=result["video_prompts"],
-            timestamp=ImageReviewRefreshResponse.now_timestamp(),
-        )
-    except ValueError as e:
-        print("[image-review] refresh bad request", str(e))
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        print("[image-review] refresh runtime error", repr(e))
         raise

--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from app.services.image_provider_retry import run_with_retry
+from app.services.image_provider_types import (
+    PROVIDER_API,
+    PROVIDER_PILLOW,
+    ImageGenerationTask,
+    RetryConfig,
+)
+
+
+class PillowStorybookAdapter:
+    def __init__(self, runner: Any) -> None:
+        self._runner = runner
+
+    @property
+    def provider_name(self) -> str:
+        return PROVIDER_PILLOW
+
+    def generate(self, task: ImageGenerationTask) -> bytes:
+        scene = dict(task.prompt_metadata.get("scene") or {})
+        scene_index = int(task.prompt_metadata.get("scene_index") or 1)
+        ctx = task.prompt_metadata.get("ctx")
+        if ctx is None:
+            raise RuntimeError("pillow adapter requires ctx in prompt_metadata")
+
+        return self._runner._build_scene_png(ctx, scene, scene_index)
+
+
+class ApiImageGeneratorAdapter:
+    def __init__(self, runner: Any) -> None:
+        self._runner = runner
+
+    @property
+    def provider_name(self) -> str:
+        return PROVIDER_API
+
+    def generate(self, task: ImageGenerationTask) -> bytes:
+        return self._generate_api_image_bytes(
+            prompt=task.prompt,
+            scene=task.prompt_metadata.get("scene") or {},
+            scene_index=int(task.prompt_metadata.get("scene_index") or 1),
+        )
+
+    def _generate_api_image_bytes(
+        self,
+        *,
+        prompt: str,
+        scene: dict[str, Any],
+        scene_index: int,
+    ) -> bytes:
+        if self._runner._force_image_rate_limit():
+            raise RuntimeError("HTTP 429: IPM limit reached (forced for local testing)")
+
+        if not self._runner._api_image_enabled():
+            raise RuntimeError("API_IMAGE_ENABLED is false")
+
+        api_key = self._runner._image_api_key()
+        if not api_key:
+            raise RuntimeError("image api key is missing")
+
+        base_url = self._runner._image_api_base_url()
+
+        model = os.getenv("SILICONFLOW_IMAGE_MODEL", "Kwai-Kolors/Kolors").strip()
+        if not model:
+            model = "Kwai-Kolors/Kolors"
+
+        image_size = os.getenv("SILICONFLOW_IMAGE_SIZE", "720x1280").strip()
+        if not image_size:
+            image_size = "720x1280"
+
+        negative_prompt = os.getenv(
+            "SILICONFLOW_IMAGE_NEGATIVE_PROMPT",
+            (
+                "low quality, blurry, distorted anatomy, broken composition, "
+                "extra limbs, duplicated subject, unreadable details"
+            ),
+        ).strip()
+
+        num_inference_steps_raw = os.getenv("SILICONFLOW_IMAGE_STEPS", "20").strip()
+        guidance_scale_raw = os.getenv("SILICONFLOW_IMAGE_GUIDANCE", "7.5").strip()
+
+        try:
+            num_inference_steps = int(num_inference_steps_raw)
+        except ValueError:
+            num_inference_steps = 20
+
+        try:
+            guidance_scale = float(guidance_scale_raw)
+        except ValueError:
+            guidance_scale = 7.5
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "image_size": image_size,
+        }
+
+        if negative_prompt:
+            payload["negative_prompt"] = negative_prompt
+
+        if "kolors" in model.lower():
+            payload["batch_size"] = 1
+            payload["num_inference_steps"] = num_inference_steps
+            payload["guidance_scale"] = guidance_scale
+
+        request_url = f"{base_url.rstrip('/')}/images/generations"
+        request_body = json.dumps(payload).encode("utf-8")
+
+        request = urllib.request.Request(
+            request_url,
+            data=request_body,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=120) as response:
+                response_text = response.read().decode("utf-8")
+        except urllib.error.HTTPError as error:
+            error_body = ""
+            try:
+                error_body = error.read().decode("utf-8")
+            except Exception:
+                error_body = repr(error)
+            raise RuntimeError(
+                f"SiliconFlow image generation failed with HTTP {error.code}: {error_body}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(
+                f"SiliconFlow image generation request failed: {error}"
+            ) from error
+
+        try:
+            result = json.loads(response_text)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(
+                "SiliconFlow image generation returned invalid JSON: "
+                f"{response_text[:500]}"
+            ) from error
+
+        images = result.get("images") or []
+        if not images:
+            raise RuntimeError(
+                f"SiliconFlow image generation returned no images: {response_text[:500]}"
+            )
+
+        first_image = images[0] or {}
+        image_url = str(first_image.get("url") or "").strip()
+        if not image_url:
+            raise RuntimeError(
+                "SiliconFlow image generation returned empty image url: "
+                f"{response_text[:500]}"
+            )
+
+        download_request = urllib.request.Request(
+            image_url,
+            headers={"User-Agent": "Mozilla/5.0"},
+            method="GET",
+        )
+
+        retry_result = run_with_retry(
+            lambda: self._download_generated_image_bytes(
+                download_request=download_request,
+                scene_index=scene_index,
+            ),
+            RetryConfig(
+                max_attempts=3,
+                base_delay_seconds=1.5,
+                backoff_multiplier=1.5,
+                retry_on_rate_limit=True,
+                retry_on_network_error=True,
+            ),
+        )
+
+        if retry_result.ok and isinstance(retry_result.value, (bytes, bytearray)):
+            return bytes(retry_result.value)
+
+        if retry_result.error is not None:
+            raise retry_result.error
+
+        raise RuntimeError(
+            f"Generated image download returned empty bytes for scene {scene_index}"
+        )
+
+    def _download_generated_image_bytes(
+        self,
+        *,
+        download_request: urllib.request.Request,
+        scene_index: int,
+    ) -> bytes:
+        try:
+            with urllib.request.urlopen(download_request, timeout=120) as response:
+                downloaded = response.read()
+        except urllib.error.HTTPError as error:
+            raise RuntimeError(
+                f"Generated image download failed with HTTP {error.code} for scene {scene_index}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(
+                f"Generated image download failed for scene {scene_index}: {error}"
+            ) from error
+        except Exception as error:
+            raise RuntimeError(
+                f"Generated image download failed for scene {scene_index}: {error}"
+            ) from error
+
+        if not downloaded:
+            raise RuntimeError(
+                f"Generated image download returned empty bytes for scene {scene_index}"
+            )
+
+        return downloaded

--- a/app/services/image_provider_queue.py
+++ b/app/services/image_provider_queue.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from app.services.image_provider_adapter import (
+    ApiImageGeneratorAdapter,
+    PillowStorybookAdapter,
+)
+from app.services.image_provider_retry import is_rate_limit_error
+from app.services.image_provider_types import (
+    PROVIDER_API,
+    PROVIDER_PILLOW,
+    ImageGenerationTask,
+    QueueExecutionResult,
+    QueuePolicy,
+)
+
+
+class ImageProviderQueue:
+    def __init__(self, runner: Any) -> None:
+        self._runner = runner
+        self._adapters = {
+            PROVIDER_PILLOW: PillowStorybookAdapter(runner),
+            PROVIDER_API: ApiImageGeneratorAdapter(runner),
+        }
+
+    def run(
+        self,
+        *,
+        ctx: Any,
+        outputs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        policy = QueuePolicy(
+            primary_provider=self._runner._image_provider_name(),
+            fallback_provider=self._runner._image_fallback_provider_name(),
+            fallback_enabled=self._runner._api_image_fallback_to_pillow(),
+            rate_limit_strategy=self._runner._image_429_strategy(),
+        )
+
+        try:
+            result = self._run_provider(
+                provider=policy.primary_provider,
+                ctx=ctx,
+                outputs=outputs,
+            )
+            return self._to_output_dict(result, ctx=ctx)
+        except Exception as error:
+            if (
+                policy.primary_provider == PROVIDER_API
+                and policy.rate_limit_strategy == "pending"
+                and is_rate_limit_error(error)
+            ):
+                return self._runner._build_pending_image_assets_result(
+                    ctx=ctx,
+                    provider=PROVIDER_API,
+                    reason=str(error),
+                    retry_after_sec=60,
+                )
+
+            if (
+                policy.primary_provider == PROVIDER_API
+                and policy.fallback_enabled
+                and policy.fallback_provider == PROVIDER_PILLOW
+            ):
+                fallback_result = self._run_provider(
+                    provider=PROVIDER_PILLOW,
+                    ctx=ctx,
+                    outputs=outputs,
+                )
+                fallback_output = self._to_output_dict(fallback_result, ctx=ctx)
+                fallback_output["fallback"] = {
+                    "from_provider": PROVIDER_API,
+                    "to_provider": PROVIDER_PILLOW,
+                    "reason": str(error),
+                }
+                return fallback_output
+
+            raise RuntimeError(
+                f"image asset generation failed with provider={policy.primary_provider}: {error}"
+            ) from error
+
+    def _run_provider(
+        self,
+        *,
+        provider: str,
+        ctx: Any,
+        outputs: Dict[str, Any],
+    ) -> QueueExecutionResult:
+        sentence_shots = outputs.get("sentence_shots") or {}
+        shot_items = sentence_shots.get("items") or []
+
+        storyboard = outputs.get("storyboard") or {}
+        scenes = storyboard.get("scenes") or []
+        scene_by_id = {
+            str(scene.get("scene_id")): scene
+            for scene in scenes
+            if scene.get("scene_id")
+        }
+
+        prompt_by_scene_id, prompt_by_shot_id = self._runner._image_prompt_item_maps(outputs)
+        run_dir = self._runner._ensure_image_run_dir(ctx.run_id)
+        assets: List[Dict[str, Any]] = []
+
+        if shot_items:
+            for index, shot in enumerate(shot_items, start=1):
+                shot_id = str(shot.get("shot_id") or f"shot_{index:02d}")
+                scene_id = str(shot.get("scene_id") or "").strip()
+                scene_title = str(shot.get("scene_title") or f"Shot {index}").strip()
+                visual_description = str(shot.get("visual_description") or "").strip()
+                shot_text = str(shot.get("text") or "").strip()
+                shot_type = str(shot.get("shot_type") or "medium").strip()
+                transition = str(shot.get("transition") or "fade").strip()
+
+                parent_scene = scene_by_id.get(scene_id) or {}
+                prompt_item = (
+                    prompt_by_shot_id.get(shot_id)
+                    or prompt_by_scene_id.get(scene_id)
+                    or {}
+                )
+                base_prompt = str(prompt_item.get("prompt") or "").strip()
+                if not base_prompt:
+                    base_prompt = visual_description or shot_text or f"storybook shot {shot_id}"
+
+                asset_meta = self._runner._image_asset_metadata(
+                    scene=scene_by_id.get(scene_id) or {},
+                    prompt_item=prompt_item,
+                    fallback_scene_title=scene_title,
+                )
+
+                candidate_asset_refs = self._generate_shot_candidates(
+                    provider=provider,
+                    ctx=ctx,
+                    run_dir=run_dir,
+                    index=index,
+                    shot=shot,
+                    shot_id=shot_id,
+                    scene_id=scene_id,
+                    scene_title=scene_title,
+                    base_prompt=base_prompt,
+                    prompt_item=prompt_item,
+                    parent_scene=parent_scene,
+                    shot_type=shot_type,
+                    transition=transition,
+                )
+
+                primary_ref = candidate_asset_refs[0]
+                assets.append(
+                    {
+                        "shot_id": shot_id,
+                        "scene_id": scene_id,
+                        "scene_title": asset_meta["scene_title"],
+                        "characters": asset_meta["characters"],
+                        "character_ids": asset_meta["character_ids"],
+                        "prompt": base_prompt,
+                        "selected_asset_ref": dict(primary_ref),
+                        "file_name": primary_ref["file_name"],
+                        "relative_path": primary_ref["relative_path"],
+                        "public_url": primary_ref["public_url"],
+                        "mime_type": primary_ref["mime_type"],
+                        "status": "generated",
+                        "candidate_asset_refs": candidate_asset_refs,
+                    }
+                )
+        else:
+            for index, scene in enumerate(scenes, start=1):
+                scene_id = str(scene.get("scene_id") or f"scene_{index:02d}")
+                prompt_item = prompt_by_scene_id.get(scene_id) or {}
+                base_prompt = str(prompt_item.get("prompt") or "").strip()
+
+                if not base_prompt:
+                    visual_description = str(scene.get("visual_description") or "").strip()
+                    narration = str(scene.get("narration") or "").strip()
+                    base_prompt = visual_description or narration or f"storybook scene {scene_id}"
+
+                asset_meta = self._runner._image_asset_metadata(
+                    scene=scene,
+                    prompt_item=prompt_item,
+                    fallback_scene_title=str(scene.get("scene_title") or "").strip(),
+                )
+
+                candidate_asset_refs = self._generate_scene_candidates(
+                    provider=provider,
+                    ctx=ctx,
+                    run_dir=run_dir,
+                    index=index,
+                    scene=scene,
+                    scene_id=scene_id,
+                    base_prompt=base_prompt,
+                )
+
+                primary_ref = candidate_asset_refs[0]
+                assets.append(
+                    {
+                        "scene_id": scene_id,
+                        "scene_title": asset_meta["scene_title"],
+                        "characters": asset_meta["characters"],
+                        "character_ids": asset_meta["character_ids"],
+                        "prompt": base_prompt,
+                        "selected_asset_ref": dict(primary_ref),
+                        "file_name": primary_ref["file_name"],
+                        "relative_path": primary_ref["relative_path"],
+                        "public_url": primary_ref["public_url"],
+                        "mime_type": primary_ref["mime_type"],
+                        "status": "generated",
+                        "candidate_asset_refs": candidate_asset_refs,
+                    }
+                )
+
+        return QueueExecutionResult(
+            status="generated",
+            provider=provider,
+            assets=assets,
+        )
+
+    def _generate_shot_candidates(
+        self,
+        *,
+        provider: str,
+        ctx: Any,
+        run_dir: Any,
+        index: int,
+        shot: Dict[str, Any],
+        shot_id: str,
+        scene_id: str,
+        scene_title: str,
+        base_prompt: str,
+        prompt_item: Dict[str, Any],
+        parent_scene: Dict[str, Any],
+        shot_type: str,
+        transition: str,
+    ) -> List[Dict[str, Any]]:
+        candidate_asset_refs: List[Dict[str, Any]] = []
+
+        for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
+            candidate_prompt = base_prompt
+            if candidate_index == 1:
+                candidate_prompt = (
+                    f"{base_prompt}, alternate composition, different framing, "
+                    "slightly changed pose emphasis, secondary visual arrangement"
+                )
+
+            candidate_scene = {
+                "scene_id": shot_id,
+                "scene_title": scene_title,
+                "visual_description": str(shot.get("visual_description") or "").strip(),
+                "narration": str(shot.get("text") or "").strip(),
+                "duration_sec": 0,
+                "shot_type": shot_type,
+                "transition": transition,
+                "characters": (
+                    prompt_item.get("characters")
+                    or parent_scene.get("characters")
+                    or []
+                ),
+                "candidate_key": candidate_suffix,
+                "candidate_label": (
+                    "Primary Composition"
+                    if candidate_index == 0
+                    else "Alternate Composition"
+                ),
+            }
+
+            file_name = f"{shot_id}__{candidate_suffix}.png"
+            output_path = run_dir / file_name
+
+            task = ImageGenerationTask(
+                run_id=ctx.run_id,
+                item_id=shot_id,
+                scene_id=scene_id,
+                prompt=candidate_prompt,
+                candidate_suffix=candidate_suffix,
+                output_path=output_path,
+                relative_path=f"assets/mock/image/{ctx.run_id}/{file_name}",
+                public_url=f"/assets/mock/image/{ctx.run_id}/{file_name}",
+                prompt_metadata={
+                    "ctx": ctx,
+                    "scene": candidate_scene,
+                    "scene_index": index + candidate_index,
+                },
+            )
+
+            image_bytes = self._generate_candidate_bytes(provider=provider, task=task)
+            output_path.write_bytes(bytes(image_bytes))
+
+            candidate_asset_refs.append(
+                {
+                    "scene_id": scene_id,
+                    "shot_id": shot_id,
+                    "file_name": file_name,
+                    "relative_path": task.relative_path,
+                    "public_url": task.public_url,
+                    "mime_type": "image/png",
+                    "provider": provider,
+                }
+            )
+
+        return candidate_asset_refs
+
+    def _generate_scene_candidates(
+        self,
+        *,
+        provider: str,
+        ctx: Any,
+        run_dir: Any,
+        index: int,
+        scene: Dict[str, Any],
+        scene_id: str,
+        base_prompt: str,
+    ) -> List[Dict[str, Any]]:
+        candidate_asset_refs: List[Dict[str, Any]] = []
+
+        for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
+            candidate_scene = self._runner._scene_candidate_variant(
+                scene=scene,
+                candidate_index=candidate_index,
+            )
+
+            candidate_prompt = base_prompt
+            if candidate_index == 1:
+                candidate_prompt = (
+                    f"{base_prompt}, alternate composition, different framing, "
+                    "slightly changed pose emphasis, secondary visual arrangement"
+                )
+
+            file_name = f"{scene_id}__{candidate_suffix}.png"
+            output_path = run_dir / file_name
+
+            task = ImageGenerationTask(
+                run_id=ctx.run_id,
+                item_id=scene_id,
+                scene_id=scene_id,
+                prompt=candidate_prompt,
+                candidate_suffix=candidate_suffix,
+                output_path=output_path,
+                relative_path=f"assets/mock/image/{ctx.run_id}/{file_name}",
+                public_url=f"/assets/mock/image/{ctx.run_id}/{file_name}",
+                prompt_metadata={
+                    "ctx": ctx,
+                    "scene": candidate_scene,
+                    "scene_index": index + candidate_index,
+                },
+            )
+
+            image_bytes = self._generate_candidate_bytes(provider=provider, task=task)
+            output_path.write_bytes(bytes(image_bytes))
+
+            candidate_asset_refs.append(
+                {
+                    "scene_id": scene_id,
+                    "file_name": file_name,
+                    "relative_path": task.relative_path,
+                    "public_url": task.public_url,
+                    "mime_type": "image/png",
+                    "provider": provider,
+                }
+            )
+
+        return candidate_asset_refs
+
+    def _generate_candidate_bytes(
+        self,
+        *,
+        provider: str,
+        task: ImageGenerationTask,
+    ) -> bytes:
+        adapter = self._adapters.get(provider)
+        if adapter is None:
+            raise RuntimeError(f"unknown image provider: {provider}")
+
+        image_bytes = adapter.generate(task)
+        if not isinstance(image_bytes, (bytes, bytearray)):
+            raise RuntimeError(
+                f"image provider returned invalid bytes for item {task.item_id} ({task.candidate_suffix})"
+            )
+        return bytes(image_bytes)
+
+    def _to_output_dict(
+        self,
+        result: QueueExecutionResult,
+        *,
+        ctx: Any,
+    ) -> Dict[str, Any]:
+        return {
+            "enabled": True,
+            "run_id": ctx.run_id,
+            "provider": result.provider,
+            "asset_count": len(result.assets),
+            "assets": result.assets,
+        }

--- a/app/services/image_provider_retry.py
+++ b/app/services/image_provider_retry.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+from app.services.image_provider_types import RetryConfig, RetryResult
+
+
+def is_rate_limit_error(error: Exception) -> bool:
+    message = str(error or "").lower()
+    if "429" in message:
+        return True
+    if "rate limit" in message:
+        return True
+    if "too many requests" in message:
+        return True
+    if "ipm limit" in message:
+        return True
+    return False
+
+
+def should_retry(error: Exception, config: RetryConfig) -> bool:
+    message = str(error or "").lower()
+
+    if config.retry_on_rate_limit and is_rate_limit_error(error):
+        return True
+
+    if config.retry_on_network_error:
+        network_markers = [
+            "timed out",
+            "timeout",
+            "temporarily unavailable",
+            "connection reset",
+            "connection refused",
+            "urlopen error",
+            "remote end closed connection",
+            "name or service not known",
+            "nodename nor servname provided",
+            "http error 500",
+            "http error 502",
+            "http error 503",
+            "http error 504",
+        ]
+        if any(marker in message for marker in network_markers):
+            return True
+
+    return False
+
+
+def compute_backoff_delay(
+    *,
+    attempt_index: int,
+    base_delay_seconds: float,
+    backoff_multiplier: float,
+) -> float:
+    if attempt_index <= 0:
+        return base_delay_seconds
+    return base_delay_seconds * (backoff_multiplier ** attempt_index)
+
+
+def run_with_retry(
+    operation: Callable[[], Any],
+    config: RetryConfig,
+) -> RetryResult:
+    last_error: Exception | None = None
+    last_delay_seconds = 0.0
+
+    for attempt in range(1, config.max_attempts + 1):
+        try:
+            value = operation()
+            return RetryResult(
+                ok=True,
+                value=value,
+                error=None,
+                attempts=attempt,
+                last_delay_seconds=last_delay_seconds,
+            )
+        except Exception as error:
+            last_error = error
+
+            if attempt >= config.max_attempts or not should_retry(error, config):
+                return RetryResult(
+                    ok=False,
+                    value=None,
+                    error=error,
+                    attempts=attempt,
+                    last_delay_seconds=last_delay_seconds,
+                )
+
+            delay_seconds = compute_backoff_delay(
+                attempt_index=attempt - 1,
+                base_delay_seconds=config.base_delay_seconds,
+                backoff_multiplier=config.backoff_multiplier,
+            )
+            last_delay_seconds = delay_seconds
+            time.sleep(delay_seconds)
+
+    return RetryResult(
+        ok=False,
+        value=None,
+        error=last_error,
+        attempts=config.max_attempts,
+        last_delay_seconds=last_delay_seconds,
+    )

--- a/app/services/image_provider_types.py
+++ b/app/services/image_provider_types.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+
+ImageProviderName = Literal[
+    "pillow_storybook_renderer",
+    "api_image_generator",
+]
+
+ImageAssetStatus = Literal[
+    "generated",
+    "pending",
+    "retrying",
+    "failed",
+]
+
+
+PROVIDER_PILLOW: ImageProviderName = "pillow_storybook_renderer"
+PROVIDER_API: ImageProviderName = "api_image_generator"
+
+
+@dataclass
+class ImageCandidateResult:
+    provider: str
+    file_name: str
+    relative_path: str
+    public_url: str
+    mime_type: str = "image/png"
+    bytes_data: bytes = b""
+
+
+@dataclass
+class ImageGenerationTask:
+    run_id: str
+    item_id: str
+    scene_id: str
+    prompt: str
+    candidate_suffix: str
+    output_path: Any
+    relative_path: str
+    public_url: str
+    prompt_metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RetryConfig:
+    max_attempts: int = 3
+    base_delay_seconds: float = 1.5
+    backoff_multiplier: float = 1.5
+    retry_on_rate_limit: bool = True
+    retry_on_network_error: bool = True
+
+
+@dataclass
+class RetryResult:
+    ok: bool
+    value: Any = None
+    error: Optional[Exception] = None
+    attempts: int = 0
+    last_delay_seconds: float = 0.0
+
+
+@dataclass
+class QueueExecutionResult:
+    status: ImageAssetStatus
+    provider: str
+    assets: List[Dict[str, Any]] = field(default_factory=list)
+    reason: str = ""
+    retry_after_sec: Optional[int] = None
+    fallback: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class QueuePolicy:
+    primary_provider: str
+    fallback_provider: str
+    fallback_enabled: bool
+    rate_limit_strategy: str = "pending"
+
+
+AdapterGenerateFunc = Callable[[ImageGenerationTask], bytes]

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -3820,50 +3820,6 @@ class WorkflowRunner:
         queue = ImageProviderQueue(self)
         return queue.run(ctx=ctx, outputs=outputs)
     
-    def _run_pillow_image_assets(
-        self, ctx: StepContext, outputs: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        queue = ImageProviderQueue(self)
-        result = queue._run_provider(
-            provider="pillow_storybook_renderer",
-            ctx=ctx,
-            outputs=outputs,
-        )
-        return queue._to_output_dict(result, ctx=ctx)
-    def _generate_api_image_bytes(
-        self,
-        *,
-        prompt: str,
-        scene: Dict[str, Any],
-        scene_index: int,
-    ) -> bytes:
-        adapter = ApiImageGeneratorAdapter(self)
-        task = ImageGenerationTask(
-            run_id="compat_run",
-            item_id=str(scene.get("scene_id") or f"scene_{scene_index:02d}"),
-            scene_id=str(scene.get("scene_id") or f"scene_{scene_index:02d}"),
-            prompt=prompt,
-            candidate_suffix=str(scene.get("candidate_key") or "candidate_a"),
-            output_path=None,
-            relative_path="",
-            public_url="",
-            prompt_metadata={
-                "scene": scene,
-                "scene_index": scene_index,
-            },
-        )
-        return adapter.generate(task)
-    def _run_api_image_assets(
-        self, ctx: StepContext, outputs: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        queue = ImageProviderQueue(self)
-        result = queue._run_provider(
-            provider="api_image_generator",
-            ctx=ctx,
-            outputs=outputs,
-        )
-        return queue._to_output_dict(result, ctx=ctx)
-    
     def _run_video_prompts(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -20,6 +20,9 @@ from app.schemas.workflow import (
     WorkflowRunResponse,
 )
 from app.services.runner_audio_render_support import RunnerAudioRenderSupport
+from app.services.image_provider_queue import ImageProviderQueue
+from app.services.image_provider_adapter import ApiImageGeneratorAdapter
+from app.services.image_provider_types import ImageGenerationTask
 
 
 class UnknownStepError(Exception):
@@ -1903,9 +1906,6 @@ class WorkflowRunner:
         scene: Dict[str, Any],
         scene_index: int,
     ) -> Dict[str, Any]:
-        if self._force_image_rate_limit():
-            raise RuntimeError("HTTP 429: IPM limit reached (forced for local testing)")
-
         storyboard = outputs.get("storyboard") or {}
         scenes = storyboard.get("scenes") or []
         prompt_by_scene_id, _ = self._image_prompt_item_maps(outputs)
@@ -1927,6 +1927,7 @@ class WorkflowRunner:
         )
 
         candidate_asset_refs: List[Dict[str, Any]] = []
+        adapter = ApiImageGeneratorAdapter(self)
 
         for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
             candidate_scene = self._scene_candidate_variant(
@@ -1944,11 +1945,23 @@ class WorkflowRunner:
             file_name = f"{scene_id}__{candidate_suffix}.png"
             output_path = run_dir / file_name
 
-            image_bytes = self._generate_api_image_bytes(
+            task = ImageGenerationTask(
+                run_id=ctx.run_id,
+                item_id=scene_id,
+                scene_id=scene_id,
                 prompt=candidate_prompt,
-                scene=candidate_scene,
-                scene_index=scene_index + candidate_index,
+                candidate_suffix=candidate_suffix,
+                output_path=output_path,
+                relative_path=f"assets/mock/image/{ctx.run_id}/{file_name}",
+                public_url=f"/assets/mock/image/{ctx.run_id}/{file_name}",
+                prompt_metadata={
+                    "ctx": ctx,
+                    "scene": candidate_scene,
+                    "scene_index": scene_index + candidate_index,
+                },
             )
+
+            image_bytes = adapter.generate(task)
             if not isinstance(image_bytes, (bytes, bytearray)):
                 raise RuntimeError(
                     f"api image provider returned invalid bytes for scene {scene_id} ({candidate_suffix})"
@@ -1960,8 +1973,8 @@ class WorkflowRunner:
                 {
                     "scene_id": scene_id,
                     "file_name": file_name,
-                    "relative_path": f"assets/mock/image/{ctx.run_id}/{file_name}",
-                    "public_url": f"/assets/mock/image/{ctx.run_id}/{file_name}",
+                    "relative_path": task.relative_path,
+                    "public_url": task.public_url,
                     "mime_type": "image/png",
                     "provider": "api_image_generator",
                 }
@@ -1982,7 +1995,7 @@ class WorkflowRunner:
             "status": "generated",
             "candidate_asset_refs": candidate_asset_refs,
         }
-
+    
     def _run_single_scene_image_asset(
         self,
         ctx: StepContext,
@@ -3804,217 +3817,19 @@ class WorkflowRunner:
     def _run_image_assets(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:
-        provider = self._image_provider_name()
-
-        if provider == "pillow_storybook_renderer":
-            return self._run_pillow_image_assets(ctx, outputs)
-
-        if provider == "api_image_generator":
-            try:
-                return self._run_api_image_assets(ctx, outputs)
-            except Exception as e:
-                strategy = self._image_429_strategy()
-
-                if strategy == "pending" and self._is_rate_limit_error(e):
-                    return self._build_pending_image_assets_result(
-                        ctx=ctx,
-                        provider="api_image_generator",
-                        reason=str(e),
-                        retry_after_sec=60,
-                    )
-
-                fallback_provider = self._image_fallback_provider_name()
-                fallback_enabled = self._api_image_fallback_to_pillow()
-
-                if (
-                    fallback_enabled
-                    and fallback_provider == "pillow_storybook_renderer"
-                ):
-                    fallback_result = self._run_pillow_image_assets(ctx, outputs)
-                    fallback_result["fallback"] = {
-                        "from_provider": "api_image_generator",
-                        "to_provider": "pillow_storybook_renderer",
-                        "reason": str(e),
-                    }
-                    return fallback_result
-
-                raise RuntimeError(
-                    f"image asset generation failed with provider={provider}: {e}"
-                ) from e
-
-        raise RuntimeError(f"unknown image provider: {provider}")
-
+        queue = ImageProviderQueue(self)
+        return queue.run(ctx=ctx, outputs=outputs)
+    
     def _run_pillow_image_assets(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:
-        sentence_shots = outputs.get("sentence_shots") or {}
-        shot_items = sentence_shots.get("items") or []
-
-        storyboard = outputs.get("storyboard") or {}
-        scenes = storyboard.get("scenes") or []
-        scene_by_id = {
-            str(scene.get("scene_id")): scene
-            for scene in scenes
-            if scene.get("scene_id")
-        }
-
-        prompt_by_scene_id, prompt_by_shot_id = self._image_prompt_item_maps(outputs)
-
-        run_dir = self._ensure_image_run_dir(ctx.run_id)
-        assets: List[Dict[str, Any]] = []
-
-        if shot_items:
-            for index, shot in enumerate(shot_items, start=1):
-                shot_id = str(shot.get("shot_id") or f"shot_{index:02d}")
-                scene_id = str(shot.get("scene_id") or "").strip()
-                scene_title = str(shot.get("scene_title") or f"Shot {index}").strip()
-                visual_description = str(shot.get("visual_description") or "").strip()
-                shot_text = str(shot.get("text") or "").strip()
-                shot_type = str(shot.get("shot_type") or "medium").strip()
-                transition = str(shot.get("transition") or "fade").strip()
-
-                parent_scene = scene_by_id.get(scene_id) or {}
-                prompt_item = (
-                    prompt_by_shot_id.get(shot_id)
-                    or prompt_by_scene_id.get(scene_id)
-                    or {}
-                )
-
-                asset_meta = self._image_asset_metadata(
-                    scene=scene_by_id.get(scene_id) or {},
-                    prompt_item=prompt_item,
-                    fallback_scene_title=scene_title,
-                )
-
-                candidate_asset_refs: List[Dict[str, Any]] = []
-
-                for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
-                    candidate_scene = {
-                        "scene_id": shot_id,
-                        "scene_title": scene_title,
-                        "visual_description": visual_description,
-                        "narration": shot_text,
-                        "duration_sec": 0,
-                        "shot_type": shot_type,
-                        "transition": transition,
-                        "characters": (
-                            prompt_item.get("characters")
-                            or parent_scene.get("characters")
-                            or []
-                        ),
-                        "candidate_key": candidate_suffix,
-                        "candidate_label": (
-                            "Primary Composition"
-                            if candidate_index == 0
-                            else "Alternate Composition"
-                        ),
-                    }
-
-                    file_name = f"{shot_id}__{candidate_suffix}.png"
-                    output_path = run_dir / file_name
-                    output_path.write_bytes(
-                        self._build_scene_png(ctx, candidate_scene, index + candidate_index)
-                    )
-
-                    candidate_asset_refs.append(
-                        {
-                            "scene_id": scene_id,
-                            "shot_id": shot_id,
-                            "file_name": file_name,
-                            "relative_path": f"assets/mock/image/{ctx.run_id}/{file_name}",
-                            "public_url": f"/assets/mock/image/{ctx.run_id}/{file_name}",
-                            "mime_type": "image/png",
-                            "provider": "pillow_storybook_renderer",
-                        }
-                    )
-
-                primary_ref = candidate_asset_refs[0]
-
-                assets.append(
-                    {
-                        "shot_id": shot_id,
-                        "scene_id": scene_id,
-                        "scene_title": asset_meta["scene_title"],
-                        "characters": asset_meta["characters"],
-                        "character_ids": asset_meta["character_ids"],
-                        "prompt": asset_meta["prompt"],
-                        "selected_asset_ref": dict(primary_ref),
-                        "file_name": primary_ref["file_name"],
-                        "relative_path": primary_ref["relative_path"],
-                        "public_url": primary_ref["public_url"],
-                        "mime_type": primary_ref["mime_type"],
-                        "status": "generated",
-                        "candidate_asset_refs": candidate_asset_refs,
-                    }
-                )
-
-            return {
-                "enabled": True,
-                "run_id": ctx.run_id,
-                "provider": "pillow_storybook_renderer",
-                "asset_count": len(assets),
-                "assets": assets,
-            }
-
-        for index, scene in enumerate(scenes, start=1):
-            scene_id = str(scene.get("scene_id") or f"scene_{index:02d}")
-            prompt_item = prompt_by_scene_id.get(scene_id) or {}
-            asset_meta = self._image_asset_metadata(
-                scene=scene,
-                prompt_item=prompt_by_scene_id.get(scene_id) or {},
-                fallback_scene_title=str(scene.get("scene_title") or "").strip(),
-            )
-            
-            candidate_asset_refs: List[Dict[str, Any]] = []
-            
-            for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
-                candidate_scene = self._scene_candidate_variant(
-                    scene=scene,
-                    candidate_index=candidate_index,
-                )
-
-                file_name = f"{scene_id}__{candidate_suffix}.png"
-                output_path = run_dir / file_name
-                output_path.write_bytes(
-                    self._build_scene_png(ctx, candidate_scene, index + candidate_index)
-                )
-
-                candidate_asset_refs.append(
-                    {
-                        "scene_id": scene_id,
-                        "file_name": file_name,
-                        "relative_path": f"assets/mock/image/{ctx.run_id}/{file_name}",
-                        "public_url": f"/assets/mock/image/{ctx.run_id}/{file_name}",
-                        "mime_type": "image/png",
-                        "provider": "pillow_storybook_renderer",
-                    }
-                )
-
-            primary_ref = candidate_asset_refs[0]
-
-            assets.append(
-                {
-                    "scene_id": scene_id,
-                    "scene_title": asset_meta["scene_title"],
-                    "characters": asset_meta["characters"],
-                    "character_ids": asset_meta["character_ids"],
-                    "prompt": asset_meta["prompt"],
-                    "selected_asset_ref": dict(primary_ref),
-                    "file_name": primary_ref["file_name"],
-                    "relative_path": primary_ref["relative_path"],
-                    "public_url": primary_ref["public_url"],
-                    "mime_type": primary_ref["mime_type"],
-                    "status": "generated",
-                    "candidate_asset_refs": candidate_asset_refs,
-                }
-            )
-        return {
-            "enabled": True,
-            "run_id": ctx.run_id,
-            "provider": "pillow_storybook_renderer",
-            "asset_count": len(assets),
-            "assets": assets,
-        }
+        queue = ImageProviderQueue(self)
+        result = queue._run_provider(
+            provider="pillow_storybook_renderer",
+            ctx=ctx,
+            outputs=outputs,
+        )
+        return queue._to_output_dict(result, ctx=ctx)
     def _generate_api_image_bytes(
         self,
         *,
@@ -4022,382 +3837,33 @@ class WorkflowRunner:
         scene: Dict[str, Any],
         scene_index: int,
     ) -> bytes:
-        """
-        Generate image bytes through SiliconFlow image generation API.
-
-        Current implementation:
-        - text-to-image only
-        - request image URL from SiliconFlow
-        - immediately download bytes because the returned URL is temporary
-        """
-        import json
-        import urllib.error
-        import urllib.request
-
-        if not self._api_image_enabled():
-            raise RuntimeError("API_IMAGE_ENABLED is false")
-
-        api_key = self._image_api_key()
-        if not api_key:
-            raise RuntimeError("image api key is missing")
-
-        base_url = self._image_api_base_url()
-
-        model = os.getenv("SILICONFLOW_IMAGE_MODEL", "Kwai-Kolors/Kolors").strip()
-        if not model:
-            model = "Kwai-Kolors/Kolors"
-
-        image_size = os.getenv("SILICONFLOW_IMAGE_SIZE", "720x1280").strip()
-        if not image_size:
-            image_size = "720x1280"
-
-        negative_prompt = os.getenv(
-            "SILICONFLOW_IMAGE_NEGATIVE_PROMPT",
-            "low quality, blurry, distorted anatomy, broken composition, extra limbs, duplicated subject, unreadable details",
-        ).strip()
-
-        num_inference_steps_raw = os.getenv("SILICONFLOW_IMAGE_STEPS", "20").strip()
-        guidance_scale_raw = os.getenv("SILICONFLOW_IMAGE_GUIDANCE", "7.5").strip()
-
-        try:
-            num_inference_steps = int(num_inference_steps_raw)
-        except ValueError:
-            num_inference_steps = 20
-
-        try:
-            guidance_scale = float(guidance_scale_raw)
-        except ValueError:
-            guidance_scale = 7.5
-
-        payload: Dict[str, Any] = {
-            "model": model,
-            "prompt": prompt,
-            "image_size": image_size,
-        }
-
-        if negative_prompt:
-            payload["negative_prompt"] = negative_prompt
-
-        # SiliconFlow docs indicate these parameters are applicable to Kolors.
-        # Keep them for the default Kolors model and omit for other model families.
-        if "kolors" in model.lower():
-            payload["batch_size"] = 1
-            payload["num_inference_steps"] = num_inference_steps
-            payload["guidance_scale"] = guidance_scale
-
-        request_url = f"{base_url.rstrip('/')}/images/generations"
-        request_body = json.dumps(payload).encode("utf-8")
-
-        request = urllib.request.Request(
-            request_url,
-            data=request_body,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
+        adapter = ApiImageGeneratorAdapter(self)
+        task = ImageGenerationTask(
+            run_id="compat_run",
+            item_id=str(scene.get("scene_id") or f"scene_{scene_index:02d}"),
+            scene_id=str(scene.get("scene_id") or f"scene_{scene_index:02d}"),
+            prompt=prompt,
+            candidate_suffix=str(scene.get("candidate_key") or "candidate_a"),
+            output_path=None,
+            relative_path="",
+            public_url="",
+            prompt_metadata={
+                "scene": scene,
+                "scene_index": scene_index,
             },
-            method="POST",
         )
-
-        try:
-            with urllib.request.urlopen(request, timeout=120) as response:
-                response_text = response.read().decode("utf-8")
-        except urllib.error.HTTPError as e:
-            error_body = ""
-            try:
-                error_body = e.read().decode("utf-8")
-            except Exception:
-                error_body = repr(e)
-            raise RuntimeError(
-                f"SiliconFlow image generation failed with HTTP {e.code}: {error_body}"
-            ) from e
-        except urllib.error.URLError as e:
-            raise RuntimeError(
-                f"SiliconFlow image generation request failed: {e}"
-            ) from e
-
-        try:
-            result = json.loads(response_text)
-        except json.JSONDecodeError as e:
-            raise RuntimeError(
-                f"SiliconFlow image generation returned invalid JSON: {response_text[:500]}"
-            ) from e
-
-        images = result.get("images") or []
-        if not images:
-            raise RuntimeError(
-                f"SiliconFlow image generation returned no images: {response_text[:500]}"
-            )
-
-        first_image = images[0] or {}
-        image_url = str(first_image.get("url") or "").strip()
-        if not image_url:
-            raise RuntimeError(
-                f"SiliconFlow image generation returned empty image url: {response_text[:500]}"
-            )
-
-        download_request = urllib.request.Request(
-            image_url,
-            headers={
-                "User-Agent": "Mozilla/5.0",
-            },
-            method="GET",
-        )
-
-        last_error: Optional[Exception] = None
-        image_bytes: bytes = b""
-
-        for attempt in range(3):
-            try:
-                with urllib.request.urlopen(download_request, timeout=120) as response:
-                    downloaded = response.read()
-
-                if downloaded:
-                    image_bytes = downloaded
-                    break
-
-                last_error = RuntimeError(
-                    f"Generated image download returned empty bytes for scene {scene_index}"
-                )
-            except urllib.error.HTTPError as e:
-                last_error = RuntimeError(
-                    f"Generated image download failed with HTTP {e.code} for scene {scene_index}"
-                )
-            except urllib.error.URLError as e:
-                last_error = RuntimeError(
-                    f"Generated image download failed for scene {scene_index}: {e}"
-                )
-            except Exception as e:
-                last_error = RuntimeError(
-                    f"Generated image download failed for scene {scene_index}: {e}"
-                )
-
-            if attempt < 2:
-                time.sleep(1.5 * (attempt + 1))
-
-        if not image_bytes:
-            if last_error is not None:
-                raise last_error
-            raise RuntimeError(
-                f"Generated image download returned empty bytes for scene {scene_index}"
-            )
-
-        return image_bytes
-
+        return adapter.generate(task)
     def _run_api_image_assets(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:
-        if self._force_image_rate_limit():
-            raise RuntimeError("HTTP 429: IPM limit reached (forced for local testing)")
-        sentence_shots = outputs.get("sentence_shots") or {}
-        shot_items = sentence_shots.get("items") or []
-
-        storyboard = outputs.get("storyboard") or {}
-        scenes = storyboard.get("scenes") or []
-        scene_by_id = {
-            str(scene.get("scene_id")): scene
-            for scene in scenes
-            if scene.get("scene_id")
-        }
-
-        prompt_by_scene_id, prompt_by_shot_id = self._image_prompt_item_maps(outputs)
-
-        run_dir = self._ensure_image_run_dir(ctx.run_id)
-        assets: List[Dict[str, Any]] = []
-
-        if shot_items:
-            for index, shot in enumerate(shot_items, start=1):
-                shot_id = str(shot.get("shot_id") or f"shot_{index:02d}")
-                scene_id = str(shot.get("scene_id") or "").strip()
-                scene_title = str(shot.get("scene_title") or f"Shot {index}").strip()
-
-                prompt_item = (
-                    prompt_by_shot_id.get(shot_id)
-                    or prompt_by_scene_id.get(scene_id)
-                    or {}
-                )
-                base_prompt = str(prompt_item.get("prompt") or "").strip()
-
-                if not base_prompt:
-                    text = str(shot.get("text", "")).strip()
-                    visual_description = str(shot.get("visual_description", "")).strip()
-                    base_prompt = visual_description or text or f"storybook shot {shot_id}"
-
-                asset_meta = self._image_asset_metadata(
-                    scene=scene_by_id.get(scene_id) or {},
-                    prompt_item=prompt_item,
-                    fallback_scene_title=scene_title,
-                )
-
-                candidate_asset_refs: List[Dict[str, Any]] = []
-
-                for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
-                    candidate_prompt = base_prompt
-                    if candidate_index == 1:
-                        candidate_prompt = (
-                            f"{base_prompt}, alternate composition, different framing, "
-                            "slightly changed pose emphasis, secondary visual arrangement"
-                        )
-
-                    pseudo_scene = {
-                        "scene_id": shot_id,
-                        "scene_title": scene_title,
-                        "visual_description": str(shot.get("visual_description") or "").strip(),
-                        "narration": str(shot.get("text") or "").strip(),
-                        "duration_sec": 0,
-                        "shot_type": str(shot.get("shot_type") or "medium").strip(),
-                        "transition": str(shot.get("transition") or "fade").strip(),
-                        "characters": (
-                            prompt_item.get("characters")
-                            or (scene_by_id.get(scene_id) or {}).get("characters")
-                            or []
-                        ),
-                        "candidate_key": candidate_suffix,
-                        "candidate_label": (
-                            "Primary Composition"
-                            if candidate_index == 0
-                            else "Alternate Composition"
-                        ),
-                    }
-
-                    file_name = f"{shot_id}__{candidate_suffix}.png"
-                    output_path = run_dir / file_name
-
-                    image_bytes = self._generate_api_image_bytes(
-                        prompt=candidate_prompt,
-                        scene=pseudo_scene,
-                        scene_index=index + candidate_index,
-                    )
-                    if not isinstance(image_bytes, (bytes, bytearray)):
-                        raise RuntimeError(
-                            f"api image provider returned invalid bytes for shot {shot_id} ({candidate_suffix})"
-                        )
-
-                    output_path.write_bytes(bytes(image_bytes))
-
-                    candidate_asset_refs.append(
-                        {
-                            "scene_id": scene_id,
-                            "file_name": file_name,
-                            "relative_path": f"assets/mock/image/{ctx.run_id}/{file_name}",
-                            "public_url": f"/assets/mock/image/{ctx.run_id}/{file_name}",
-                            "mime_type": "image/png",
-                            "provider": "api_image_generator",
-                        }
-                    )
-
-                primary_ref = candidate_asset_refs[0]
-
-                assets.append(
-                    {
-                        "shot_id": shot_id,
-                        "scene_id": scene_id,
-                        "scene_title": asset_meta["scene_title"],
-                        "characters": asset_meta["characters"],
-                        "character_ids": asset_meta["character_ids"],
-                        "prompt": base_prompt,
-                        "selected_asset_ref": dict(primary_ref),
-                        "file_name": primary_ref["file_name"],
-                        "relative_path": primary_ref["relative_path"],
-                        "public_url": primary_ref["public_url"],
-                        "mime_type": primary_ref["mime_type"],
-                        "status": "generated",
-                        "candidate_asset_refs": candidate_asset_refs,
-                    }
-                )
-
-            return {
-                "enabled": True,
-                "run_id": ctx.run_id,
-                "provider": "api_image_generator",
-                "asset_count": len(assets),
-                "assets": assets,
-            }
-
-        for index, scene in enumerate(scenes, start=1):
-            scene_id = str(scene.get("scene_id") or f"scene_{index:02d}")
-            prompt_item = prompt_by_scene_id.get(scene_id) or {}
-            base_prompt = str(prompt_item.get("prompt") or "").strip()
-
-            if not base_prompt:
-                visual_description = str(scene.get("visual_description") or "").strip()
-                narration = str(scene.get("narration") or "").strip()
-                base_prompt = (
-                    visual_description or narration or f"storybook scene {scene_id}"
-                )
-
-            asset_meta = self._image_asset_metadata(
-                scene=scene,
-                prompt_item=prompt_item,
-                fallback_scene_title=str(scene.get("scene_title") or "").strip(),
-            )
-
-            candidate_asset_refs: List[Dict[str, Any]] = []
-
-            for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
-                candidate_scene = self._scene_candidate_variant(
-                    scene=scene,
-                    candidate_index=candidate_index,
-                )
-
-                candidate_prompt = base_prompt
-                if candidate_index == 1:
-                    candidate_prompt = (
-                        f"{base_prompt}, alternate composition, different framing, "
-                        "slightly changed pose emphasis, secondary visual arrangement"
-                    )
-
-                file_name = f"{scene_id}__{candidate_suffix}.png"
-                output_path = run_dir / file_name
-
-                image_bytes = self._generate_api_image_bytes(
-                    prompt=candidate_prompt,
-                    scene=candidate_scene,
-                    scene_index=index + candidate_index,
-                )
-                if not isinstance(image_bytes, (bytes, bytearray)):
-                    raise RuntimeError(
-                        f"api image provider returned invalid bytes for scene {scene_id} ({candidate_suffix})"
-                    )
-
-                output_path.write_bytes(bytes(image_bytes))
-
-                candidate_asset_refs.append(
-                    {
-                        "scene_id": scene_id,
-                        "file_name": file_name,
-                        "relative_path": f"assets/mock/image/{ctx.run_id}/{file_name}",
-                        "public_url": f"/assets/mock/image/{ctx.run_id}/{file_name}",
-                        "mime_type": "image/png",
-                        "provider": "api_image_generator",
-                    }
-                )
-
-            primary_ref = candidate_asset_refs[0]
-
-            assets.append(
-                {
-                    "scene_id": scene_id,
-                    "scene_title": asset_meta["scene_title"],
-                    "characters": asset_meta["characters"],
-                    "character_ids": asset_meta["character_ids"],
-                    "prompt": base_prompt,
-                    "selected_asset_ref": dict(primary_ref),
-                    "file_name": primary_ref["file_name"],
-                    "relative_path": primary_ref["relative_path"],
-                    "public_url": primary_ref["public_url"],
-                    "mime_type": primary_ref["mime_type"],
-                    "status": "generated",
-                    "candidate_asset_refs": candidate_asset_refs,
-                }
-            )
-
-        return {
-            "enabled": True,
-            "run_id": ctx.run_id,
-            "provider": "api_image_generator",
-            "asset_count": len(assets),
-            "assets": assets,
-        }
+        queue = ImageProviderQueue(self)
+        result = queue._run_provider(
+            provider="api_image_generator",
+            ctx=ctx,
+            outputs=outputs,
+        )
+        return queue._to_output_dict(result, ctx=ctx)
+    
     def _run_video_prompts(
         self, ctx: StepContext, outputs: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/scripts/acceptance_image_provider.py
+++ b/scripts/acceptance_image_provider.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict
+from uuid import uuid4
+
+import requests
+
+
+def _fail(msg: str) -> None:
+    print(f"[FAIL] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _ok(msg: str) -> None:
+    print(f"[OK] {msg}")
+
+
+def _post_json(base_url: str, path: str, payload: Dict[str, Any], timeout: int = 20) -> Dict[str, Any]:
+    response = requests.post(
+        f"{base_url}{path}",
+        json=payload,
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        _fail(f"{path} http_status={response.status_code}, body={response.text}")
+    return response.json()
+
+
+def _build_run_payload(session_id: str) -> Dict[str, Any]:
+    return {
+        "workflow_id": "storybook-demo",
+        "session_id": session_id,
+        "input": {
+            "topic": "小兔子的一天",
+            "audience": "children",
+            "tone": "warm",
+            "visual_style": "storybook",
+            "character_style": "animal",
+            "voice_style": "warm_female",
+            "voiceover_enabled": False,
+            "duration_sec": 60,
+            "language": "zh-CN",
+            "subtitle_enabled": True,
+            "video_provider": "mock",
+            "output_mode": "full_video",
+        },
+        "steps": [
+            {"name": "story"},
+            {"name": "storyboard"},
+            {"name": "image_prompts"},
+            {"name": "image_assets"},
+            {"name": "video_prompts"},
+            {"name": "render_plan"},
+        ],
+    }
+
+
+def _build_refresh_payload(run_response: Dict[str, Any]) -> Dict[str, Any]:
+    outputs = run_response.get("outputs") or {}
+    return {
+        "workflow_id": run_response["workflow_id"],
+        "session_id": run_response.get("session_id"),
+        "run_id": run_response["run_id"],
+        "storyboard": outputs.get("storyboard") or {},
+        "workflow_input": {},
+        "image_review": outputs.get("image_review") or {},
+        "video_provider": "mock",
+    }
+
+
+def _run_then_refresh(base_url: str, session_prefix: str) -> Dict[str, Any]:
+    session_id = f"{session_prefix}-{uuid4().hex[:8]}"
+    run_payload = _build_run_payload(session_id)
+    run_response = _post_json(base_url, "/v1/workflow/run", run_payload)
+    refresh_payload = _build_refresh_payload(run_response)
+    refresh_response = _post_json(
+        base_url,
+        "/v1/image-review/refresh",
+        refresh_payload,
+    )
+    return refresh_response
+
+
+def _assert_generated_pillow(refresh_response: Dict[str, Any]) -> None:
+    image_assets = refresh_response.get("image_assets") or {}
+    image_review = refresh_response.get("image_review") or {}
+    video_prompts = refresh_response.get("video_prompts") or {}
+
+    if image_assets.get("provider") != "pillow_storybook_renderer":
+        _fail(f"expected pillow provider, got: {image_assets}")
+
+    asset_count = image_assets.get("asset_count")
+    if not isinstance(asset_count, int) or asset_count <= 0:
+        _fail(f"expected asset_count > 0, got: {image_assets}")
+
+    if image_assets.get("status") in {"pending", "retrying", "failed"}:
+        _fail(f"unexpected non-generated image_assets status: {image_assets}")
+
+    assets = image_assets.get("assets") or []
+    if not isinstance(assets, list) or not assets:
+        _fail(f"expected non-empty assets list, got: {image_assets}")
+
+    first = assets[0]
+    candidates = first.get("candidate_asset_refs") or []
+    if len(candidates) != 2:
+        _fail(f"expected 2 candidate assets, got: {first}")
+
+    if candidates[0].get("provider") != "pillow_storybook_renderer":
+        _fail(f"expected pillow candidate provider, got: {first}")
+
+    if image_review.get("mode") != "selection_contract":
+        _fail(f"expected selection_contract image_review mode, got: {image_review}")
+
+    if video_prompts.get("status") in {"pending", "retrying"}:
+        _fail(f"unexpected pending video_prompts on generated path: {video_prompts}")
+
+    _ok("pillow generated path")
+
+
+def _assert_retrying_pending(refresh_response: Dict[str, Any]) -> None:
+    image_assets = refresh_response.get("image_assets") or {}
+    video_prompts = refresh_response.get("video_prompts") or {}
+
+    if image_assets.get("provider") != "api_image_generator":
+        _fail(f"expected api_image_generator provider, got: {image_assets}")
+
+    if image_assets.get("status") not in {"pending", "retrying"}:
+        _fail(f"expected pending/retrying image_assets status, got: {image_assets}")
+
+    if image_assets.get("reason") not in {"rate_limited", "deferred_to_refresh"}:
+        _fail(f"expected rate-limited style reason, got: {image_assets}")
+
+    retry_after_sec = image_assets.get("retry_after_sec")
+    if retry_after_sec != 60:
+        _fail(f"expected retry_after_sec=60, got: {image_assets}")
+
+    asset_count = image_assets.get("asset_count")
+    if asset_count not in {0, None}:
+        _fail(f"expected empty/pending asset_count, got: {image_assets}")
+
+    if video_prompts.get("status") != "pending":
+        _fail(f"expected pending video_prompts, got: {video_prompts}")
+
+    if video_prompts.get("reason") != "waiting_for_image_assets":
+        _fail(f"expected waiting_for_image_assets reason, got: {video_prompts}")
+
+    _ok("api retrying/pending path")
+
+
+def _assert_fallback_to_pillow(refresh_response: Dict[str, Any]) -> None:
+    image_assets = refresh_response.get("image_assets") or {}
+    fallback = image_assets.get("fallback") or {}
+    assets = image_assets.get("assets") or []
+
+    if image_assets.get("provider") != "pillow_storybook_renderer":
+        _fail(f"expected pillow provider after fallback, got: {image_assets}")
+
+    asset_count = image_assets.get("asset_count")
+    if not isinstance(asset_count, int) or asset_count <= 0:
+        _fail(f"expected generated fallback assets, got: {image_assets}")
+
+    if fallback.get("from_provider") != "api_image_generator":
+        _fail(f"expected fallback from api_image_generator, got: {image_assets}")
+
+    if fallback.get("to_provider") != "pillow_storybook_renderer":
+        _fail(f"expected fallback to pillow_storybook_renderer, got: {image_assets}")
+
+    fallback_reason = str(fallback.get("reason") or "")
+    if "429" not in fallback_reason and "rate" not in fallback_reason.lower():
+        _fail(f"expected rate-limit style fallback reason, got: {image_assets}")
+
+    if not isinstance(assets, list) or not assets:
+        _fail(f"expected non-empty assets list on fallback path, got: {image_assets}")
+
+    first = assets[0]
+    candidates = first.get("candidate_asset_refs") or []
+    if not candidates:
+        _fail(f"expected candidate assets on fallback path, got: {first}")
+
+    if candidates[0].get("provider") != "pillow_storybook_renderer":
+        _fail(f"expected pillow candidate provider after fallback, got: {first}")
+
+    _ok("api fallback to pillow path")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:8004")
+    parser.add_argument(
+        "--mode",
+        choices=["pillow", "pending", "fallback"],
+        required=True,
+    )
+    args = parser.parse_args()
+
+    base_url = args.base_url.rstrip("/")
+
+    if args.mode == "pillow":
+        response = _run_then_refresh(base_url, "image-provider-pillow")
+        _assert_generated_pillow(response)
+        return
+
+    if args.mode == "pending":
+        response = _run_then_refresh(base_url, "image-provider-pending")
+        _assert_retrying_pending(response)
+        return
+
+    if args.mode == "fallback":
+        response = _run_then_refresh(base_url, "image-provider-fallback")
+        _assert_fallback_to_pillow(response)
+        return
+
+    _fail(f"unknown mode: {args.mode}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR refactors image provider execution into a cleaner and more maintainable structure.

## What changed

### 1. Introduced dedicated image provider modules

Added:

- `app/services/image_provider_types.py`
- `app/services/image_provider_retry.py`
- `app/services/image_provider_adapter.py`
- `app/services/image_provider_queue.py`

These modules separate provider responsibilities into:
- shared types
- retry / backoff handling
- provider-specific image generation
- orchestration / fallback / queue-style execution

### 2. Unified image asset generation path

- `runner.py` now delegates image asset execution through `ImageProviderQueue`
- provider execution is standardized through adapters instead of duplicated inline logic
- retry / rate-limit handling is centralized
- fallback behavior is centralized

### 3. Removed legacy runner wrappers

Removed legacy image-provider wrapper functions from `runner.py` so that:
- provider implementation no longer lives in the workflow runner
- `runner.py` stays focused on workflow orchestration
- duplicated image provider logic is no longer maintained in multiple places

### 4. Added acceptance coverage

Added:

- `scripts/acceptance_image_provider.py`

This script validates three critical paths:

- pillow generated path
- api retrying / pending path
- api fallback to pillow path

## Why

Previously, image provider logic was duplicated across multiple paths inside `runner.py`, including:

- batch scene generation
- batch shot generation
- single-scene refresh generation

This made the code harder to reason about, harder to maintain, and more error-prone when adding retry, fallback, or provider-specific behavior.

This refactor consolidates provider behavior into dedicated modules and reduces duplication in the workflow runner.

## Validation

Validated locally:

- `[OK] pillow generated path`
- `[OK] api retrying/pending path`
- `[OK] api fallback to pillow path`

## Notes

- this PR focuses on image provider execution only
- no new product-facing functionality is introduced
- the goal is structural cleanup, reliability improvement, and safer future iteration