### PR TITLE
Final video progress UI + pluggable image provider adapter + prevent empty image run dirs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ IMAGE_API_BASE_URL=https://api.siliconflow.cn/v1
 
 # Model config
 SILICONFLOW_IMAGE_MODEL=Kwai-Kolors/Kolors
-SILICONFLOW_IMAGE_SIZE=720x1280
+SILICONFLOW_IMAGE_SIZE=1280x720
 SILICONFLOW_IMAGE_NEGATIVE_PROMPT=low quality, blurry, distorted anatomy, broken composition, extra limbs, duplicated subject, unreadable details
 SILICONFLOW_IMAGE_STEPS=20
 SILICONFLOW_IMAGE_GUIDANCE=7.5

--- a/app/main.py
+++ b/app/main.py
@@ -100,6 +100,7 @@ def select_image_review_asset(req: ImageReviewSelectRequest):
             run_id=result["run_id"],
             scene_id=result["scene_id"],
             image_review=result["image_review"],
+            image_assets=result.get("image_assets", {}),
             video_prompts=result["video_prompts"],
             timestamp=ImageReviewSelectResponse.now_timestamp(),
         )
@@ -109,8 +110,6 @@ def select_image_review_asset(req: ImageReviewSelectRequest):
     except Exception as e:
         print("[image-review] runtime error", repr(e))
         raise
-
-
 @app.post("/v1/final-video/render", response_model=FinalVideoRenderResponse)
 def render_final_video(req: FinalVideoRenderRequest):
     print("[final-video] render request received", req.workflow_id, req.run_id)

--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -196,6 +196,7 @@ class ImageReviewSelectResponse(BaseModel):
     run_id: str
     scene_id: str
     image_review: Dict[str, Any] = Field(default_factory=dict)
+    image_assets: Dict[str, Any] = Field(default_factory=dict)
     video_prompts: Dict[str, Any] = Field(default_factory=dict)
     timestamp: str
 

--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -123,22 +123,23 @@ class ApiImageGeneratorAdapter:
             method="POST",
         )
 
-        try:
-            with urllib.request.urlopen(request, timeout=120) as response:
-                response_text = response.read().decode("utf-8")
-        except urllib.error.HTTPError as error:
-            error_body = ""
-            try:
-                error_body = error.read().decode("utf-8")
-            except Exception:
-                error_body = repr(error)
-            raise RuntimeError(
-                f"SiliconFlow image generation failed with HTTP {error.code}: {error_body}"
-            ) from error
-        except urllib.error.URLError as error:
-            raise RuntimeError(
-                f"SiliconFlow image generation request failed: {error}"
-            ) from error
+        generation_retry_result = run_with_retry(
+            lambda: self._request_generation_response_text(request=request),
+            RetryConfig(
+                max_attempts=3,
+                base_delay_seconds=2.0,
+                backoff_multiplier=1.8,
+                retry_on_rate_limit=True,
+                retry_on_network_error=True,
+            ),
+        )
+
+        if generation_retry_result.ok and isinstance(generation_retry_result.value, str):
+            response_text = generation_retry_result.value
+        elif generation_retry_result.error is not None:
+            raise generation_retry_result.error
+        else:
+            raise RuntimeError("SiliconFlow image generation returned empty response text")
 
         try:
             result = json.loads(response_text)
@@ -192,6 +193,32 @@ class ApiImageGeneratorAdapter:
             f"Generated image download returned empty bytes for scene {scene_index}"
         )
 
+    def _request_generation_response_text(
+        self,
+        *,
+        request: urllib.request.Request,
+    ) -> str:
+        try:
+            with urllib.request.urlopen(request, timeout=120) as response:
+                return response.read().decode("utf-8")
+        except urllib.error.HTTPError as error:
+            error_body = ""
+            try:
+                error_body = error.read().decode("utf-8")
+            except Exception:
+                error_body = repr(error)
+            raise RuntimeError(
+                f"SiliconFlow image generation failed with HTTP {error.code}: {error_body}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(
+                f"SiliconFlow image generation request failed: {error}"
+            ) from error
+        except Exception as error:
+            raise RuntimeError(
+                f"SiliconFlow image generation request failed: {error}"
+            ) from error
+    
     def _download_generated_image_bytes(
         self,
         *,

--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -71,9 +71,9 @@ class ApiImageGeneratorAdapter:
         if not model:
             model = "Kwai-Kolors/Kolors"
 
-        image_size = os.getenv("SILICONFLOW_IMAGE_SIZE", "720x1280").strip()
+        image_size = os.getenv("SILICONFLOW_IMAGE_SIZE", "1280x720").strip()
         if not image_size:
-            image_size = "720x1280"
+            image_size = "1280x720"
 
         negative_prompt = os.getenv(
             "SILICONFLOW_IMAGE_NEGATIVE_PROMPT",

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -20,9 +20,11 @@ from app.schemas.workflow import (
     WorkflowRunResponse,
 )
 from app.services.runner_audio_render_support import RunnerAudioRenderSupport
+from app.services.runner_image_selection_support import RunnerImageSelectionSupport
 from app.services.image_provider_queue import ImageProviderQueue
 from app.services.image_provider_adapter import ApiImageGeneratorAdapter
 from app.services.image_provider_types import ImageGenerationTask
+from app.services.runner_single_scene_image_support import RunnerSingleSceneImageSupport
 
 
 class UnknownStepError(Exception):
@@ -84,6 +86,8 @@ class WorkflowRunner:
 
     def __init__(self) -> None:
         self._audio_render_support = RunnerAudioRenderSupport(self)
+        self._image_selection_support = RunnerImageSelectionSupport(self)
+        self._single_scene_image_support = RunnerSingleSceneImageSupport(self)
 
         self._handlers = {
             "story": self._run_story,
@@ -145,6 +149,19 @@ class WorkflowRunner:
             subtitles=subtitles,
         )
    
+    def build_image_assets_from_selected_assets(
+        self,
+        *,
+        run_id: str,
+        image_review: Dict[str, Any],
+        provider: str,
+    ) -> Dict[str, Any]:
+        return self._image_selection_support.build_image_assets_from_selected_assets(
+            run_id=run_id,
+            image_review=image_review,
+            provider=provider,
+        )
+    
     def get_real_kling_samples_manifest(self) -> Dict[str, Any]:
         manifest = self._build_real_samples_manifest()
         samples = manifest.get("samples") or []
@@ -2003,40 +2020,12 @@ class WorkflowRunner:
         scene: Dict[str, Any],
         scene_index: int,
     ) -> Dict[str, Any]:
-        provider = self._image_provider_name()
-
-        if provider == "pillow_storybook_renderer":
-            raise RuntimeError("single-scene pillow path is not implemented in this phase")
-
-        if provider == "api_image_generator":
-            try:
-                asset = self._run_single_scene_api_image_asset(
-                    ctx=ctx,
-                    outputs=outputs,
-                    scene=scene,
-                    scene_index=scene_index,
-                )
-                return {
-                    "enabled": True,
-                    "run_id": ctx.run_id,
-                    "provider": "api_image_generator",
-                    "asset_count": 1,
-                    "assets": [asset],
-                }
-            except Exception as e:
-                strategy = self._image_429_strategy()
-                if strategy == "pending" and self._is_rate_limit_error(e):
-                    return self._build_pending_image_assets_result(
-                        ctx=ctx,
-                        provider="api_image_generator",
-                        reason=str(e),
-                        retry_after_sec=60,
-                    )
-                raise RuntimeError(
-                    f"single scene image asset generation failed with provider={provider}: {e}"
-                ) from e
-
-        raise RuntimeError(f"unknown image provider: {provider}")
+        return self._single_scene_image_support.run_single_scene_image_asset(
+            ctx=ctx,
+            outputs=outputs,
+            scene=scene,
+            scene_index=scene_index,
+        )
     def _video_prompt_scene_metadata(
         self,
         scene: Dict[str, Any],
@@ -2256,8 +2245,15 @@ class WorkflowRunner:
             input=normalized_input,
         )
 
+        image_assets = self.build_image_assets_from_selected_assets(
+            run_id=run_id,
+            image_review=updated_image_review,
+            provider=str(self._image_provider_name()),
+        )
+
         outputs = {
             "image_review": updated_image_review,
+            "image_assets": image_assets,
             "storyboard": {
                 "scenes": storyboard_scenes,
             },
@@ -2275,9 +2271,9 @@ class WorkflowRunner:
             "run_id": run_id,
             "scene_id": scene_id,
             "image_review": updated_image_review,
+            "image_assets": image_assets,
             "video_prompts": video_prompts,
         }
-    
     def refresh_image_review_scene(
         self,
         workflow_id: str,
@@ -2365,37 +2361,11 @@ class WorkflowRunner:
 
         outputs["image_review"] = updated_image_review
 
-        merged_assets: List[Dict[str, Any]] = []
-        selected_assets = updated_image_review.get("selected_assets") or []
-        if isinstance(selected_assets, list):
-            for item in selected_assets:
-                if not isinstance(item, dict):
-                    continue
-                selected_asset_ref = item.get("selected_asset_ref") or {}
-                merged_assets.append(
-                    {
-                        "scene_id": item.get("scene_id"),
-                        "scene_title": item.get("scene_title"),
-                        "characters": item.get("characters") or [],
-                        "character_ids": item.get("character_ids") or [],
-                        "prompt": item.get("prompt") or "",
-                        "file_name": selected_asset_ref.get("file_name"),
-                        "relative_path": selected_asset_ref.get("relative_path"),
-                        "public_url": selected_asset_ref.get("public_url"),
-                        "mime_type": selected_asset_ref.get("mime_type"),
-                        "selected_asset_ref": dict(selected_asset_ref) if isinstance(selected_asset_ref, dict) else {},
-                        "status": "generated",
-                        "candidate_asset_refs": item.get("candidate_asset_refs") or [],
-                    }
-                )
-
-        outputs["image_assets"] = {
-            "enabled": True,
-            "run_id": run_id,
-            "provider": str(single_scene_assets.get("provider") or self._image_provider_name()),
-            "asset_count": len(merged_assets),
-            "assets": merged_assets,
-        }
+        outputs["image_assets"] = self.build_image_assets_from_selected_assets(
+            run_id=run_id,
+            image_review=updated_image_review,
+            provider=str(single_scene_assets.get("provider") or self._image_provider_name()),
+        )
 
         video_prompts = self._run_video_prompts(ctx, outputs)
 

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -285,8 +285,10 @@ class WorkflowRunner:
         return run_dir
 
     def _ensure_image_run_dir(self, run_id: str) -> Path:
+        # NOTE: Do NOT create directories here.
+        # We create parent dirs only when we actually write an output file.
+        # This prevents leaving lots of empty run dirs when generation/refresh fails.
         run_dir = MOCK_IMAGE_ROOT / run_id
-        run_dir.mkdir(parents=True, exist_ok=True)
         return run_dir
 
     def _probe_audio_duration_seconds(self, audio_path: Path) -> Optional[float]:

--- a/app/services/runner_image_selection_support.py
+++ b/app/services/runner_image_selection_support.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class RunnerImageSelectionSupport:
+    def __init__(self, runner: Any) -> None:
+        self._runner = runner
+
+    def build_image_assets_from_selected_assets(
+        self,
+        *,
+        run_id: str,
+        image_review: Dict[str, Any],
+        provider: str,
+    ) -> Dict[str, Any]:
+        selected_assets = image_review.get("selected_assets") or []
+
+        merged_assets: List[Dict[str, Any]] = []
+        if isinstance(selected_assets, list):
+            for item in selected_assets:
+                if not isinstance(item, dict):
+                    continue
+
+                selected_asset_ref = item.get("selected_asset_ref") or {}
+                if not isinstance(selected_asset_ref, dict):
+                    selected_asset_ref = {}
+
+                merged_assets.append(
+                    {
+                        "scene_id": item.get("scene_id"),
+                        "scene_title": item.get("scene_title"),
+                        "characters": item.get("characters") or [],
+                        "character_ids": item.get("character_ids") or [],
+                        "prompt": item.get("prompt") or "",
+                        "file_name": selected_asset_ref.get("file_name"),
+                        "relative_path": selected_asset_ref.get("relative_path"),
+                        "public_url": selected_asset_ref.get("public_url"),
+                        "mime_type": selected_asset_ref.get("mime_type"),
+                        "selected_asset_ref": dict(selected_asset_ref),
+                        "status": "generated",
+                        "candidate_asset_refs": item.get("candidate_asset_refs") or [],
+                    }
+                )
+
+        return {
+            "enabled": True,
+            "run_id": run_id,
+            "provider": str(provider or self._runner._image_provider_name()),
+            "asset_count": len(merged_assets),
+            "assets": merged_assets,
+        }

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -43,6 +43,7 @@ class RunnerSingleSceneImageSupport:
 
             file_name = f"{scene_id}__{candidate_suffix}.png"
             output_path = run_dir / file_name
+            output_path.parent.mkdir(parents=True, exist_ok=True)
 
             image_bytes = self._runner._build_scene_png(
                 ctx,

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class RunnerSingleSceneImageSupport:
+    def __init__(self, runner: Any) -> None:
+        self._runner = runner
+
+    def run_single_scene_pillow_image_asset(
+        self,
+        *,
+        ctx: Any,
+        outputs: Dict[str, Any],
+        scene: Dict[str, Any],
+        scene_index: int,
+    ) -> Dict[str, Any]:
+        prompt_by_scene_id, _ = self._runner._image_prompt_item_maps(outputs)
+
+        run_dir = self._runner._ensure_image_run_dir(ctx.run_id)
+        scene_id = str(scene.get("scene_id") or f"scene_{scene_index:02d}")
+        prompt_item = prompt_by_scene_id.get(scene_id) or {}
+        base_prompt = str(prompt_item.get("prompt") or "").strip()
+
+        if not base_prompt:
+            visual_description = str(scene.get("visual_description") or "").strip()
+            narration = str(scene.get("narration") or "").strip()
+            base_prompt = visual_description or narration or f"storybook scene {scene_id}"
+
+        asset_meta = self._runner._image_asset_metadata(
+            scene=scene,
+            prompt_item=prompt_item,
+            fallback_scene_title=str(scene.get("scene_title") or "").strip(),
+        )
+
+        candidate_asset_refs: List[Dict[str, Any]] = []
+
+        for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
+            candidate_scene = self._runner._scene_candidate_variant(
+                scene=scene,
+                candidate_index=candidate_index,
+            )
+
+            file_name = f"{scene_id}__{candidate_suffix}.png"
+            output_path = run_dir / file_name
+
+            image_bytes = self._runner._build_scene_png(
+                ctx,
+                candidate_scene,
+                scene_index + candidate_index,
+            )
+            if not isinstance(image_bytes, (bytes, bytearray)):
+                raise RuntimeError(
+                    f"pillow fallback returned invalid bytes for scene {scene_id} ({candidate_suffix})"
+                )
+
+            output_path.write_bytes(bytes(image_bytes))
+
+            candidate_asset_refs.append(
+                {
+                    "scene_id": scene_id,
+                    "file_name": file_name,
+                    "relative_path": f"assets/mock/image/{ctx.run_id}/{file_name}",
+                    "public_url": f"/assets/mock/image/{ctx.run_id}/{file_name}",
+                    "mime_type": "image/png",
+                    "provider": "pillow_storybook_renderer",
+                }
+            )
+
+        primary_ref = candidate_asset_refs[0]
+
+        return {
+            "scene_id": scene_id,
+            "scene_title": asset_meta["scene_title"],
+            "characters": asset_meta["characters"],
+            "character_ids": asset_meta["character_ids"],
+            "prompt": base_prompt,
+            "file_name": primary_ref["file_name"],
+            "relative_path": primary_ref["relative_path"],
+            "public_url": primary_ref["public_url"],
+            "mime_type": primary_ref["mime_type"],
+            "status": "generated",
+            "candidate_asset_refs": candidate_asset_refs,
+        }
+
+    def run_single_scene_image_asset(
+        self,
+        *,
+        ctx: Any,
+        outputs: Dict[str, Any],
+        scene: Dict[str, Any],
+        scene_index: int,
+    ) -> Dict[str, Any]:
+        provider = self._runner._image_provider_name()
+
+        if provider == "pillow_storybook_renderer":
+            asset = self.run_single_scene_pillow_image_asset(
+                ctx=ctx,
+                outputs=outputs,
+                scene=scene,
+                scene_index=scene_index,
+            )
+            return {
+                "enabled": True,
+                "run_id": ctx.run_id,
+                "provider": "pillow_storybook_renderer",
+                "asset_count": 1,
+                "assets": [asset],
+            }
+
+        if provider == "api_image_generator":
+            try:
+                asset = self._runner._run_single_scene_api_image_asset(
+                    ctx=ctx,
+                    outputs=outputs,
+                    scene=scene,
+                    scene_index=scene_index,
+                )
+                return {
+                    "enabled": True,
+                    "run_id": ctx.run_id,
+                    "provider": "api_image_generator",
+                    "asset_count": 1,
+                    "assets": [asset],
+                }
+            except Exception as e:
+                if self._runner._is_rate_limit_error(e):
+                    if self._runner._api_image_fallback_to_pillow():
+                        fallback_asset = self.run_single_scene_pillow_image_asset(
+                            ctx=ctx,
+                            outputs=outputs,
+                            scene=scene,
+                            scene_index=scene_index,
+                        )
+                        return {
+                            "enabled": True,
+                            "run_id": ctx.run_id,
+                            "provider": "pillow_storybook_renderer",
+                            "asset_count": 1,
+                            "assets": [fallback_asset],
+                            "fallback": {
+                                "enabled": True,
+                                "source_provider": "api_image_generator",
+                                "fallback_provider": "pillow_storybook_renderer",
+                                "reason": str(e),
+                            },
+                        }
+
+                    strategy = self._runner._image_429_strategy()
+                    if strategy == "pending":
+                        return self._runner._build_pending_image_assets_result(
+                            ctx=ctx,
+                            provider="api_image_generator",
+                            reason=str(e),
+                            retry_after_sec=60,
+                        )
+
+                raise RuntimeError(
+                    f"single scene image asset generation failed with provider={provider}: {e}"
+                ) from e
+
+        raise RuntimeError(f"unknown image provider: {provider}")

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@ type StepName =
   | 'image_assets'
   | 'video_prompts'
   | 'dialogue_script'
+  | 'audio_segments'
   | 'narration'
   | 'subtitles'
   | 'render_plan'
@@ -71,6 +72,7 @@ type ImageReviewSelectResponse = {
   run_id?: string
   scene_id?: string
   image_review?: Record<string, unknown>
+  image_assets?: Record<string, unknown>
   video_prompts?: Record<string, unknown>
   timestamp?: string
 }
@@ -166,6 +168,14 @@ type ImageReviewRefreshSceneResponse = {
   timestamp?: string
 }
 
+type FinalVideoRenderResponse = {
+  workflow_id?: string
+  session_id?: string
+  run_id?: string
+  final_video?: Record<string, unknown>
+  timestamp?: string
+}
+
 type ReviewPlaceholderItem = {
   scene_id: string
   scene_title: string
@@ -180,7 +190,7 @@ const DEFAULT_WORKFLOW_FORM: WorkflowRunFormState = {
   visualStyle: 'storybook',
   characterStyle: 'animal',
   voiceStyle: 'warm_female',
-  voiceoverEnabled: false,
+  voiceoverEnabled: true,
   voiceMode: 'single',
   narratorVoiceStyle: 'warm_female',
   motherVoiceStyle: 'warm_female',
@@ -209,6 +219,7 @@ const STEP_OPTIONS: Array<{ label: string; value: StepName }> = [
   { label: 'Image Assets', value: 'image_assets' },
   { label: 'Video Prompts', value: 'video_prompts' },
   { label: 'Dialogue Script', value: 'dialogue_script' },
+  { label: 'Audio Segments', value: 'audio_segments' },
   { label: 'Narration', value: 'narration' },
   { label: 'Subtitles', value: 'subtitles' },
   { label: 'Render Plan', value: 'render_plan' },
@@ -222,6 +233,7 @@ const DEFAULT_STEPS: StepName[] = [
   'image_assets',
   'video_prompts',
   'dialogue_script',
+  'audio_segments',
   'narration',
   'subtitles',
   'render_plan',
@@ -243,6 +255,7 @@ const subtitlesText = ref('')
 const renderPlanText = ref('')
 const finalVideoText = ref('')
 const finalVideoUrl = ref('')
+const finalVideoRendering = ref(false)
 const workflowForm = ref<WorkflowRunFormState>({ ...DEFAULT_WORKFLOW_FORM })
 const characterCandidatesText = ref('')
 const characterManifestText = ref('')
@@ -817,12 +830,17 @@ async function selectImageAsset(sceneId: string, assetRef: ImageAssetRef) {
         ...(currentWorkflowResponse.value.outputs || {}),
         image_review:
           data.image_review || currentWorkflowResponse.value.outputs?.image_review || {},
+        image_assets:
+          data.image_assets || currentWorkflowResponse.value.outputs?.image_assets || {},
         video_prompts:
           data.video_prompts || currentWorkflowResponse.value.outputs?.video_prompts || {},
+        final_video:
+          currentWorkflowResponse.value.outputs?.final_video || {},
       },
     }
 
     applyWorkflowResponse(mergedResponse)
+    await renderFinalVideoIfReady(mergedResponse)
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : '手动选图请求失败'
   } finally {
@@ -833,6 +851,102 @@ function clearImageReviewAutoRefreshTimer() {
   if (imageReviewAutoRefreshTimer !== null) {
     window.clearTimeout(imageReviewAutoRefreshTimer)
     imageReviewAutoRefreshTimer = null
+  }
+}
+
+async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
+  if (!currentWorkflowPayload.value) {
+    return
+  }
+
+  if (finalVideoRendering.value) {
+    return
+  }
+
+  const outputs = baseResponse.outputs || {}
+  const storyboard = outputs.storyboard as Record<string, unknown> | undefined
+  const imageReview = outputs.image_review as Record<string, unknown> | undefined
+  const imageAssets = outputs.image_assets as Record<string, unknown> | undefined
+  const audioSegments = outputs.audio_segments as Record<string, unknown> | undefined
+  const subtitles = outputs.subtitles as Record<string, unknown> | undefined
+  const finalVideo = outputs.final_video as Record<string, unknown> | undefined
+
+  const scenesValue = storyboard?.scenes
+  const scenes = Array.isArray(scenesValue) ? scenesValue : []
+
+  const selectedAssetsValue = imageReview?.selected_assets
+  const selectedAssets = Array.isArray(selectedAssetsValue) ? selectedAssetsValue : []
+
+  const imageAssetsValue = imageAssets?.assets
+  const imageAssetList = Array.isArray(imageAssetsValue) ? imageAssetsValue : []
+
+  const audioItemsValue = audioSegments?.items
+  const audioItems = Array.isArray(audioItemsValue) ? audioItemsValue : []
+
+  const finalVideoStatus =
+    typeof finalVideo?.status === 'string' ? finalVideo.status : ''
+  const finalVideoEnabled = finalVideo?.enabled === true
+
+  if (finalVideoEnabled && finalVideoStatus === 'generated') {
+    return
+  }
+
+  if (scenes.length === 0) {
+    return
+  }
+
+  if (selectedAssets.length < scenes.length) {
+    return
+  }
+
+  if (imageAssetList.length < scenes.length) {
+    return
+  }
+
+  if (audioItems.length === 0) {
+    return
+  }
+
+  const payload = {
+    workflow_id: baseResponse.workflow_id || currentWorkflowPayload.value.workflow_id,
+    session_id: baseResponse.session_id || currentWorkflowPayload.value.session_id,
+    run_id: baseResponse.run_id || '',
+    workflow_input: currentWorkflowPayload.value.input,
+    image_assets: imageAssets || {},
+    audio_segments: audioSegments || {},
+    subtitles: subtitles || {},
+  }
+
+  finalVideoRendering.value = true
+  try {
+    const response = await fetch(`${apiBaseUrl}/v1/final-video/render`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+
+    const data: FinalVideoRenderResponse = await response.json()
+
+    const mergedResponse: WorkflowRunResponse = {
+      ...(baseResponse || {}),
+      workflow_id: data.workflow_id || baseResponse.workflow_id,
+      session_id: data.session_id || baseResponse.session_id,
+      run_id: data.run_id || baseResponse.run_id,
+      outputs: {
+        ...(baseResponse.outputs || {}),
+        final_video: data.final_video || baseResponse.outputs?.final_video || {},
+      },
+    }
+
+    applyWorkflowResponse(mergedResponse)
+  } finally {
+    finalVideoRendering.value = false
   }
 }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,6 +16,7 @@ type StepName =
   | 'narration'
   | 'subtitles'
   | 'render_plan'
+  | 'final_video'
 
 type StepResult = {
   name?: string
@@ -211,6 +212,7 @@ const STEP_OPTIONS: Array<{ label: string; value: StepName }> = [
   { label: 'Narration', value: 'narration' },
   { label: 'Subtitles', value: 'subtitles' },
   { label: 'Render Plan', value: 'render_plan' },
+  { label: 'Final Video', value: 'final_video' },
 ]
 
 const DEFAULT_STEPS: StepName[] = [
@@ -223,6 +225,7 @@ const DEFAULT_STEPS: StepName[] = [
   'narration',
   'subtitles',
   'render_plan',
+  'final_video',
 ]
 
 const loading = ref(false)
@@ -238,6 +241,8 @@ const videoPromptsText = ref('')
 const narrationText = ref('')
 const subtitlesText = ref('')
 const renderPlanText = ref('')
+const finalVideoText = ref('')
+const finalVideoUrl = ref('')
 const workflowForm = ref<WorkflowRunFormState>({ ...DEFAULT_WORKFLOW_FORM })
 const characterCandidatesText = ref('')
 const characterManifestText = ref('')
@@ -474,6 +479,33 @@ function extractRenderPlanText(data: WorkflowRunResponse): string {
   }
   return ''
 }
+
+function extractFinalVideoText(data: WorkflowRunResponse): string {
+  const finalVideo = data.outputs?.final_video
+  if (finalVideo && typeof finalVideo === 'object') {
+    return stringifyPretty(finalVideo)
+  }
+  return ''
+}
+
+function extractFinalVideoUrl(data: WorkflowRunResponse): string {
+  const finalVideo = data.outputs?.final_video
+  if (!finalVideo || typeof finalVideo !== 'object') {
+    return ''
+  }
+
+  const publicUrl = String((finalVideo as Record<string, unknown>).public_url || '').trim()
+  if (!publicUrl) {
+    return ''
+  }
+
+  if (publicUrl.startsWith('http://') || publicUrl.startsWith('https://')) {
+    return publicUrl
+  }
+
+  return `${apiBaseUrl}${publicUrl}`
+}
+
 function extractCharacterCandidatesText(data: WorkflowRunResponse): string {
   const value = data.outputs?.character_candidates
   if (value && typeof value === 'object') {
@@ -569,6 +601,8 @@ function applyWorkflowResponse(data: WorkflowRunResponse) {
   narrationText.value = extractNarrationText(data)
   subtitlesText.value = extractSubtitlesText(data)
   renderPlanText.value = extractRenderPlanText(data)
+  finalVideoText.value = extractFinalVideoText(data)
+  finalVideoUrl.value = extractFinalVideoUrl(data)
   extractMockAudioState(data)
   stepSummaries.value = buildStepSummaries(data)
   characterCandidatesText.value = extractCharacterCandidatesText(data)
@@ -934,6 +968,8 @@ async function runWorkflow() {
   narrationText.value = ''
   subtitlesText.value = ''
   renderPlanText.value = ''
+  finalVideoText.value = ''
+  finalVideoUrl.value = ''
   stepSummaries.value = []
 
   const form = workflowForm.value
@@ -1111,6 +1147,19 @@ onMounted(() => {
             :character-candidates-text="characterCandidatesText"
             :character-manifest-text="characterManifestText"
           />
+          <section v-if="finalVideoUrl || finalVideoText" class="result-panel">
+            <h3>Final Video</h3>
+
+            <video
+              v-if="finalVideoUrl"
+              :src="finalVideoUrl"
+              controls
+              playsinline
+              class="final-video-player"
+            />
+
+            <pre v-if="finalVideoText" class="light-result">{{ finalVideoText }}</pre>
+          </section>
         </template>
       </section>
       <section v-if="activeTab === 'assets'">
@@ -1588,6 +1637,13 @@ h1 {
   font-weight: 600;
   color: #111827;
   margin-bottom: 10px;
+}
+.final-video-player {
+  width: 100%;
+  max-width: 960px;
+  border-radius: 16px;
+  background: #000;
+  display: block;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,6 +6,7 @@ import WorkflowRunPanel, {
   type WorkflowRunFormState,
 } from './components/WorkflowRunPanel.vue'
 import SampleAssetsPanel from './components/SampleAssetsPanel.vue'
+import FinalVideoPanel from './components/FinalVideoPanel.vue'
 type StepName =
   | 'story'
   | 'storyboard'
@@ -241,6 +242,7 @@ const DEFAULT_STEPS: StepName[] = [
 ]
 
 const loading = ref(false)
+const finalVideoRenderInFlight = ref(false)
 const errorMessage = ref('')
 const resultText = ref('')
 
@@ -284,6 +286,7 @@ const refreshingImageReview = ref(false)
 const sceneRefreshQueue = ref<string[]>([])
 const sceneRefreshingId = ref('')
 const reviewPlaceholders = ref<ReviewPlaceholderItem[]>([])
+let reviewAutoRefreshFiredOnce = false
 let imageReviewAutoRefreshTimer: number | null = null
 type ViewTab = 'run' | 'review' | 'assets' | 'debug'
 const activeTab = ref<ViewTab>('run')
@@ -847,6 +850,7 @@ async function selectImageAsset(sceneId: string, assetRef: ImageAssetRef) {
     selectingSceneId.value = ''
   }
 }
+
 function clearImageReviewAutoRefreshTimer() {
   if (imageReviewAutoRefreshTimer !== null) {
     window.clearTimeout(imageReviewAutoRefreshTimer)
@@ -855,13 +859,8 @@ function clearImageReviewAutoRefreshTimer() {
 }
 
 async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
-  if (!currentWorkflowPayload.value) {
-    return
-  }
-
-  if (finalVideoRendering.value) {
-    return
-  }
+  if (!currentWorkflowPayload.value) return
+  if (finalVideoRendering.value) return
 
   const outputs = baseResponse.outputs || {}
   const storyboard = outputs.storyboard as Record<string, unknown> | undefined
@@ -871,41 +870,19 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
   const subtitles = outputs.subtitles as Record<string, unknown> | undefined
   const finalVideo = outputs.final_video as Record<string, unknown> | undefined
 
-  const scenesValue = storyboard?.scenes
-  const scenes = Array.isArray(scenesValue) ? scenesValue : []
+  const scenes = Array.isArray(storyboard?.scenes) ? storyboard.scenes : []
+  const selectedAssets = Array.isArray(imageReview?.selected_assets) ? imageReview.selected_assets : []
+  const imageAssetList = Array.isArray(imageAssets?.assets) ? imageAssets.assets : []
+  const audioItems = Array.isArray(audioSegments?.items) ? audioSegments.items : []
 
-  const selectedAssetsValue = imageReview?.selected_assets
-  const selectedAssets = Array.isArray(selectedAssetsValue) ? selectedAssetsValue : []
-
-  const imageAssetsValue = imageAssets?.assets
-  const imageAssetList = Array.isArray(imageAssetsValue) ? imageAssetsValue : []
-
-  const audioItemsValue = audioSegments?.items
-  const audioItems = Array.isArray(audioItemsValue) ? audioItemsValue : []
-
-  const finalVideoStatus =
-    typeof finalVideo?.status === 'string' ? finalVideo.status : ''
+  const finalVideoStatus = typeof finalVideo?.status === 'string' ? finalVideo.status : ''
   const finalVideoEnabled = finalVideo?.enabled === true
 
-  if (finalVideoEnabled && finalVideoStatus === 'generated') {
-    return
-  }
-
-  if (scenes.length === 0) {
-    return
-  }
-
-  if (selectedAssets.length < scenes.length) {
-    return
-  }
-
-  if (imageAssetList.length < scenes.length) {
-    return
-  }
-
-  if (audioItems.length === 0) {
-    return
-  }
+  if (finalVideoEnabled && finalVideoStatus === 'generated') return
+  if (scenes.length === 0) return
+  if (selectedAssets.length < scenes.length) return
+  if (imageAssetList.length < scenes.length) return
+  if (audioItems.length === 0) return
 
   const payload = {
     workflow_id: baseResponse.workflow_id || currentWorkflowPayload.value.workflow_id,
@@ -921,11 +898,15 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
   try {
     const response = await fetch(`${apiBaseUrl}/v1/final-video/render`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
+    finalVideoRenderInFlight.value = true
+    try {
+      // 原有 render fetch 逻辑不变
+    } finally {
+      finalVideoRenderInFlight.value = false
+    }
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
@@ -1160,9 +1141,12 @@ async function runWorkflow() {
 
     applyWorkflowResponse(data)
 
-    if (reviewWaitingState.value === 'deferred_pending') {
+    if (reviewWaitingState.value === 'deferred_pending' && !reviewAutoRefreshFiredOnce) {
+      reviewAutoRefreshFiredOnce = true
       clearImageReviewAutoRefreshTimer()
       imageReviewAutoRefreshTimer = window.setTimeout(() => {
+        // 二次保护：如果此时已经在刷新，则不再触发
+        if (refreshingImageReview.value) return
         void refreshImageReview()
       }, 1200)
     }
@@ -1218,7 +1202,14 @@ onMounted(() => {
           Debug
         </button>
       </div>
-      <section v-if="activeTab === 'run'">    
+      <section v-if="activeTab === 'run'">
+         <FinalVideoPanel
+          :final-video-url="finalVideoUrl"
+          :final-video-text="finalVideoText"
+          :workflow-response="currentWorkflowResponse"
+          :render-in-flight="finalVideoRenderInFlight"
+        />
+
         <WorkflowRunPanel
           :loading="loading"
           :can-submit="canSubmit"
@@ -1237,16 +1228,23 @@ onMounted(() => {
         </p>
 
         <template v-else>
-          <section v-if="activeTab === 'review'">
-            <InteractiveImageReview
-              :items="imageReviewItems"
-              :placeholders="reviewPlaceholders"
-              :api-base-url="apiBaseUrl"
-              :loading="loading || refreshingImageReview"
-              :selecting-scene-id="selectingSceneId || sceneRefreshingId"
-              @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
+          <section class="result-panel final-video-hero">
+            <FinalVideoPanel
+              :final-video-url="finalVideoUrl"
+              :final-video-text="finalVideoText"
+              :workflow-response="currentWorkflowResponse"
+              :render-in-flight="finalVideoRenderInFlight"
             />
           </section>
+
+          <InteractiveImageReview
+            :items="imageReviewItems"
+            :placeholders="reviewPlaceholders"
+            :api-base-url="apiBaseUrl"
+            :loading="loading || refreshingImageReview"
+            :selecting-scene-id="selectingSceneId || sceneRefreshingId"
+            @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
+          />
 
           <WorkflowResultsPanel
             :story-text="storyText"
@@ -1261,19 +1259,6 @@ onMounted(() => {
             :character-candidates-text="characterCandidatesText"
             :character-manifest-text="characterManifestText"
           />
-          <section v-if="finalVideoUrl || finalVideoText" class="result-panel">
-            <h3>Final Video</h3>
-
-            <video
-              v-if="finalVideoUrl"
-              :src="finalVideoUrl"
-              controls
-              playsinline
-              class="final-video-player"
-            />
-
-            <pre v-if="finalVideoText" class="light-result">{{ finalVideoText }}</pre>
-          </section>
         </template>
       </section>
       <section v-if="activeTab === 'assets'">
@@ -1752,12 +1737,93 @@ h1 {
   color: #111827;
   margin-bottom: 10px;
 }
+
+.final-video-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.final-video-placeholder-inner {
+  width: min(520px, 80%);
+  text-align: center;
+  color: #e5e7eb;
+}
+
+.final-video-summary-card {
+  margin-bottom: 20px;
+}
+
+.final-video-summary-ready,
+.final-video-summary-waiting {
+  border-radius: 16px;
+  padding: 24px;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+  border: 1px solid #e5e7eb;
+}
+
+.final-video-hero {
+  margin-bottom: 20px;
+}
+
+.final-video-shell {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 20px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #0f172a 0%, #111827 100%);
+}
+
 .final-video-player {
   width: 100%;
-  max-width: 960px;
-  border-radius: 16px;
-  background: #000;
+  height: 100%;
+  object-fit: contain;
   display: block;
+  background: #0f172a;
+}
+
+.final-video-status {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.final-video-desc {
+  font-size: 15px;
+  color: #475569;
+  line-height: 1.7;
+}
+
+.final-video-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  margin-top: 18px;
+  overflow: hidden;
+}
+
+.final-video-progress-bar {
+  display: block;
+  width: 35%;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #60a5fa, #a78bfa);
+  animation: final-video-loading 1.2s ease-in-out infinite;
+}
+
+.final-video-progress-bar.waiting {
+  width: 45%;
+  animation: none;
+  opacity: 0.72;
+}
+.review-video-placeholder {
+  min-height: 320px;
+}
+
+@keyframes final-video-loading {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(320%); }
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -1,0 +1,213 @@
+<template>
+  <section class="final-hero">
+    <h3 class="final-title">Final Video</h3>
+
+    <div class="final-shell" :class="{ ready: Boolean(finalVideoUrl) }">
+      <video
+        v-if="finalVideoUrl"
+        :src="finalVideoUrl"
+        controls
+        playsinline
+        class="final-video"
+      />
+
+      <div v-else class="final-placeholder">
+        <div class="ph-title">{{ placeholderTitle }}</div>
+        <div class="ph-desc">{{ placeholderDesc }}</div>
+
+        <div class="ph-progress">
+          <div class="ph-bar">
+            <div class="ph-bar-fill" :style="{ width: progressPct + '%' }"></div>
+          </div>
+          <div class="ph-meta">
+            <span>{{ progressPct }}%</span>
+            <span class="ph-dot">·</span>
+            <span>{{ progressLabel }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <pre v-if="finalVideoText" class="final-json">{{ finalVideoText }}</pre>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type UnknownRecord = Record<string, unknown>
+
+const props = defineProps<{
+  finalVideoUrl: string
+  finalVideoText: string
+  workflowResponse: UnknownRecord | null
+  renderInFlight: boolean
+}>()
+
+function asObj(v: unknown): UnknownRecord | null {
+  return v && typeof v === 'object' ? (v as UnknownRecord) : null
+}
+
+function asStr(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+function asNum(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+const outputs = computed(() => asObj(props.workflowResponse?.outputs))
+const storyboard = computed(() => asObj(outputs.value?.storyboard))
+const imageReview = computed(() => asObj(outputs.value?.image_review))
+const finalVideo = computed(() => asObj(outputs.value?.final_video))
+
+const sceneCount = computed(() => {
+  const n = asNum(storyboard.value?.scene_count)
+  return n && n > 0 ? Math.floor(n) : 0
+})
+
+const selectedCount = computed(() => {
+  const arr = imageReview.value?.selected_assets
+  return Array.isArray(arr) ? arr.length : 0
+})
+
+const finalStatus = computed(() => asStr(finalVideo.value?.status).toLowerCase())
+const finalEnabled = computed(() => Boolean(finalVideo.value?.enabled))
+
+const progressPct = computed(() => {
+  if (props.finalVideoUrl) return 100
+
+  // render 请求已发出：先给一个真实但保守的“渲染中”区间（不做假计时，只反映状态）
+  if (props.renderInFlight || finalStatus.value === 'rendering') {
+    // 选图完成度决定渲染前置进度（最多到 85%），渲染中固定显示 90%
+    return 90
+  }
+
+  // 没开始渲染：用“选图完成度”作为真实进度
+  const total = sceneCount.value
+  if (total <= 0) return 0
+  const ratio = Math.min(1, Math.max(0, selectedCount.value / total))
+  // 选图阶段最多显示到 85%，避免误导 “快好了但其实还没渲染”
+  return Math.floor(ratio * 85)
+})
+
+const progressLabel = computed(() => {
+  if (props.finalVideoUrl) return '已生成'
+  if (props.renderInFlight || finalStatus.value === 'rendering') return '视频渲染中'
+  if (!sceneCount.value) return '等待 Storyboard'
+  if (selectedCount.value < sceneCount.value) {
+    return `选图中（${selectedCount.value}/${sceneCount.value}）`
+  }
+  // 选图完成但还没渲染
+  if (finalEnabled.value && finalStatus.value === 'skipped') return '等待渲染触发'
+  return '等待渲染触发'
+})
+
+const placeholderTitle = computed(() => {
+  if (props.renderInFlight || finalStatus.value === 'rendering') return '正在生成视频'
+  if (!sceneCount.value) return '等待分镜'
+  if (selectedCount.value < sceneCount.value) return '等待选图完成'
+  return '等待渲染'
+})
+
+const placeholderDesc = computed(() => {
+  if (props.renderInFlight || finalStatus.value === 'rendering')
+    return '视频正在合成中，请稍候（音频/字幕/画面正在拼接）。'
+  if (!sceneCount.value) return '请先在 Run 执行一次，生成 storyboard。'
+  if (selectedCount.value < sceneCount.value)
+    return '请先完成每个场景的候选图生成与选择。'
+  return '选图已完成，等待触发 Final Video 渲染。'
+})
+</script>
+
+<style scoped>
+.final-hero {
+  margin: 16px 0 20px;
+}
+
+.final-title {
+  text-align: center;
+  font-weight: 700;
+  margin: 8px 0 12px;
+}
+
+.final-shell {
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #0b1220 0%, #0b152b 100%);
+  overflow: hidden;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+}
+
+.final-video {
+  width: 100%;
+  display: block;
+  /* 关键：9:16 在网页端“居中留边”，不怪异 */
+  background: transparent;
+  object-fit: contain;
+  max-height: 72vh;
+}
+
+.final-placeholder {
+  padding: 28px 16px 22px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.ph-title {
+  font-size: 22px;
+  font-weight: 800;
+  margin-bottom: 6px;
+}
+
+.ph-desc {
+  font-size: 14px;
+  opacity: 0.85;
+  margin-bottom: 18px;
+}
+
+.ph-progress {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.ph-bar {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.ph-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #6ea8fe 0%, #9f7aea 60%, #a78bfa 100%);
+  border-radius: 999px;
+  transition: width 180ms ease-out;
+}
+
+.ph-meta {
+  margin-top: 10px;
+  font-size: 13px;
+  opacity: 0.9;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+
+.ph-dot {
+  opacity: 0.6;
+}
+
+.final-json {
+  max-width: 1100px;
+  margin: 10px auto 0;
+  background: #f7f7f9;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 12px;
+  overflow: auto;
+}
+</style>

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -9,6 +9,7 @@ type StepName =
   | 'narration'
   | 'subtitles'
   | 'render_plan'
+  | 'final_video'
 
 export type WorkflowRunFormState = {
   sessionId: string

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -6,6 +6,7 @@ type StepName =
   | 'image_assets'
   | 'video_prompts'
   | 'dialogue_script'
+  | 'audio_segments'
   | 'narration'
   | 'subtitles'
   | 'render_plan'


### PR DESCRIPTION
## What changed
- Fix: avoid creating empty image run directories by creating image run dir only when writing output files.
- Refactor: extract image provider adapter to make image generator integration pluggable and easier to extend.
- UI: add FinalVideoPanel and unify final video placeholder/progress rendering across tabs (Run/Review).

## Why
- Prevent filesystem pollution from failed/aborted image generation attempts (no more empty run_* dirs).
- Decouple provider wiring so adding a real image generator becomes a small, isolated change.
- Make final video status/progress more consistent and easier to understand during generation.

## How to verify
1. Run workflow and trigger image generation/refresh; confirm no empty `assets/mock/image/run_*` directories are created.
2. Verify image generation still produces PNG outputs under the correct run directory when generation succeeds.
3. Open frontend:
   - Run tab: FinalVideoPanel shows placeholder/progress when final video is not ready.
   - Review tab: same placeholder/progress behavior (consistent UI).
4. (Optional) `python -m py_compile` for modified backend modules passes.

## Notes / Follow-ups
- Follow-up: switch final video rendering to explicit manual trigger (button) for full user control.