### PR TITLE
fix: refresh-scene returns image_assets; enable manual final-video render

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -197,6 +197,7 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
             scene_id=result["scene_id"],
             scene_image_asset=result["scene_image_asset"],
             scene_review_item=result["scene_review_item"],
+            image_assets=result["image_assets"],
             image_review=result["image_review"],
             video_prompts=result["video_prompts"],
             timestamp=ImageReviewRefreshSceneResponse.now_timestamp(),

--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -256,6 +256,7 @@ class ImageReviewRefreshSceneResponse(BaseModel):
     scene_id: str
     scene_image_asset: Dict[str, Any] = Field(default_factory=dict)
     scene_review_item: Dict[str, Any] = Field(default_factory=dict)
+    image_assets: Dict[str, Any] = Field(default_factory=dict)
     image_review: Dict[str, Any] = Field(default_factory=dict)
     video_prompts: Dict[str, Any] = Field(default_factory=dict)
     timestamp: str
@@ -267,8 +268,7 @@ class ImageReviewRefreshSceneResponse(BaseModel):
             .replace(microsecond=0)
             .isoformat()
             .replace("+00:00", "Z")
-        )
-        
+        )       
 class FinalVideoRenderRequest(BaseModel):
     workflow_id: str
     session_id: Optional[str] = None

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1985,8 +1985,11 @@ class WorkflowRunner:
                 raise RuntimeError(
                     f"api image provider returned invalid bytes for scene {scene_id} ({candidate_suffix})"
                 )
-
+        
+            output_path = Path(output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(bytes(image_bytes))
+            
 
             candidate_asset_refs.append(
                 {
@@ -2378,6 +2381,7 @@ class WorkflowRunner:
             "scene_id": normalized_scene_id,
             "scene_image_asset": single_scene_assets,
             "scene_review_item": scene_review_item if image_assets_status not in {"pending", "retrying"} else {},
+            "image_assets": outputs["image_assets"],
             "image_review": updated_image_review,
             "video_prompts": video_prompts,
         }

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -125,28 +125,28 @@ class RunnerSingleSceneImageSupport:
                     "assets": [asset],
                 }
             except Exception as e:
-                if self._runner._is_rate_limit_error(e):
-                    if self._runner._api_image_fallback_to_pillow():
-                        fallback_asset = self.run_single_scene_pillow_image_asset(
-                            ctx=ctx,
-                            outputs=outputs,
-                            scene=scene,
-                            scene_index=scene_index,
-                        )
-                        return {
+                if self._runner._api_image_fallback_to_pillow():
+                    fallback_asset = self.run_single_scene_pillow_image_asset(
+                        ctx=ctx,
+                        outputs=outputs,
+                        scene=scene,
+                        scene_index=scene_index,
+                    )
+                    return {
+                        "enabled": True,
+                        "run_id": ctx.run_id,
+                        "provider": "pillow_storybook_renderer",
+                        "asset_count": 1,
+                        "assets": [fallback_asset],
+                        "fallback": {
                             "enabled": True,
-                            "run_id": ctx.run_id,
-                            "provider": "pillow_storybook_renderer",
-                            "asset_count": 1,
-                            "assets": [fallback_asset],
-                            "fallback": {
-                                "enabled": True,
-                                "source_provider": "api_image_generator",
-                                "fallback_provider": "pillow_storybook_renderer",
-                                "reason": str(e),
-                            },
-                        }
+                            "source_provider": "api_image_generator",
+                            "fallback_provider": "pillow_storybook_renderer",
+                            "reason": str(e),
+                        },
+                    }
 
+                if self._runner._is_rate_limit_error(e):
                     strategy = self._runner._image_429_strategy()
                     if strategy == "pending":
                         return self._runner._build_pending_image_assets_result(
@@ -159,5 +159,5 @@ class RunnerSingleSceneImageSupport:
                 raise RuntimeError(
                     f"single scene image asset generation failed with provider={provider}: {e}"
                 ) from e
-
+        
         raise RuntimeError(f"unknown image provider: {provider}")

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -76,6 +76,10 @@ type ImageReviewSelectResponse = {
   image_assets?: Record<string, unknown>
   video_prompts?: Record<string, unknown>
   timestamp?: string
+  final_video?: Record<string, unknown>
+  audio_segments?: Record<string, unknown>
+  subtitles?: Record<string, unknown>
+  storyboard?: Record<string, unknown>
 }
 
 type ReviewWaitingState =
@@ -164,6 +168,7 @@ type ImageReviewRefreshSceneResponse = {
   scene_id?: string
   scene_image_asset?: Record<string, unknown>
   scene_review_item?: Record<string, unknown>
+  image_assets?: Record<string, unknown>
   image_review?: Record<string, unknown>
   video_prompts?: Record<string, unknown>
   timestamp?: string
@@ -831,19 +836,16 @@ async function selectImageAsset(sceneId: string, assetRef: ImageAssetRef) {
       run_id: data.run_id || currentWorkflowResponse.value.run_id,
       outputs: {
         ...(currentWorkflowResponse.value.outputs || {}),
-        image_review:
-          data.image_review || currentWorkflowResponse.value.outputs?.image_review || {},
         image_assets:
           data.image_assets || currentWorkflowResponse.value.outputs?.image_assets || {},
+        image_review:
+          data.image_review || currentWorkflowResponse.value.outputs?.image_review || {},
         video_prompts:
           data.video_prompts || currentWorkflowResponse.value.outputs?.video_prompts || {},
-        final_video:
-          currentWorkflowResponse.value.outputs?.final_video || {},
       },
     }
 
     applyWorkflowResponse(mergedResponse)
-    await renderFinalVideoIfReady(mergedResponse)
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : '手动选图请求失败'
   } finally {
@@ -860,18 +862,16 @@ function clearImageReviewAutoRefreshTimer() {
 
 async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
   if (!currentWorkflowPayload.value) return
-  if (finalVideoRendering.value) return
+  if (finalVideoRendering.value || finalVideoRenderInFlight.value) return
 
   const outputs = baseResponse.outputs || {}
   const storyboard = outputs.storyboard as Record<string, unknown> | undefined
-  const imageReview = outputs.image_review as Record<string, unknown> | undefined
   const imageAssets = outputs.image_assets as Record<string, unknown> | undefined
   const audioSegments = outputs.audio_segments as Record<string, unknown> | undefined
   const subtitles = outputs.subtitles as Record<string, unknown> | undefined
   const finalVideo = outputs.final_video as Record<string, unknown> | undefined
 
   const scenes = Array.isArray(storyboard?.scenes) ? storyboard.scenes : []
-  const selectedAssets = Array.isArray(imageReview?.selected_assets) ? imageReview.selected_assets : []
   const imageAssetList = Array.isArray(imageAssets?.assets) ? imageAssets.assets : []
   const audioItems = Array.isArray(audioSegments?.items) ? audioSegments.items : []
 
@@ -880,7 +880,6 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
 
   if (finalVideoEnabled && finalVideoStatus === 'generated') return
   if (scenes.length === 0) return
-  if (selectedAssets.length < scenes.length) return
   if (imageAssetList.length < scenes.length) return
   if (audioItems.length === 0) return
 
@@ -895,18 +894,14 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
   }
 
   finalVideoRendering.value = true
+  finalVideoRenderInFlight.value = true
+
   try {
     const response = await fetch(`${apiBaseUrl}/v1/final-video/render`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
-    finalVideoRenderInFlight.value = true
-    try {
-      // 原有 render fetch 逻辑不变
-    } finally {
-      finalVideoRenderInFlight.value = false
-    }
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
@@ -927,6 +922,7 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
 
     applyWorkflowResponse(mergedResponse)
   } finally {
+    finalVideoRenderInFlight.value = false
     finalVideoRendering.value = false
   }
 }
@@ -984,6 +980,8 @@ async function refreshImageReviewScene(sceneId: string) {
     run_id: data.run_id || currentWorkflowResponse.value.run_id,
     outputs: {
       ...(currentWorkflowResponse.value.outputs || {}),
+      image_assets:
+        data.image_assets || currentWorkflowResponse.value.outputs?.image_assets || {},
       image_review:
         data.image_review || currentWorkflowResponse.value.outputs?.image_review || {},
       video_prompts:
@@ -1065,6 +1063,8 @@ async function runWorkflow() {
   renderPlanText.value = ''
   finalVideoText.value = ''
   finalVideoUrl.value = ''
+  finalVideoRendering.value = false
+  finalVideoRenderInFlight.value = false
   stepSummaries.value = []
 
   const form = workflowForm.value
@@ -1208,6 +1208,7 @@ onMounted(() => {
           :final-video-text="finalVideoText"
           :workflow-response="currentWorkflowResponse"
           :render-in-flight="finalVideoRenderInFlight"
+          @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
         />
 
         <WorkflowRunPanel
@@ -1234,6 +1235,7 @@ onMounted(() => {
               :final-video-text="finalVideoText"
               :workflow-response="currentWorkflowResponse"
               :render-in-flight="finalVideoRenderInFlight"
+              @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
             />
           </section>
 

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -25,6 +25,14 @@
             <span>{{ progressLabel }}</span>
           </div>
         </div>
+
+        <button
+          class="render-button"
+          :disabled="!canRender"
+          @click="emit('render')"
+        >
+          {{ renderButtonText }}
+        </button>
       </div>
     </div>
 
@@ -44,6 +52,10 @@ const props = defineProps<{
   renderInFlight: boolean
 }>()
 
+const emit = defineEmits<{
+  (e: 'render'): void
+}>()
+
 function asObj(v: unknown): UnknownRecord | null {
   return v && typeof v === 'object' ? (v as UnknownRecord) : null
 }
@@ -58,7 +70,8 @@ function asNum(v: unknown): number | null {
 
 const outputs = computed(() => asObj(props.workflowResponse?.outputs))
 const storyboard = computed(() => asObj(outputs.value?.storyboard))
-const imageReview = computed(() => asObj(outputs.value?.image_review))
+const imageAssets = computed(() => asObj(outputs.value?.image_assets))
+const audioSegments = computed(() => asObj(outputs.value?.audio_segments))
 const finalVideo = computed(() => asObj(outputs.value?.final_video))
 
 const sceneCount = computed(() => {
@@ -66,28 +79,38 @@ const sceneCount = computed(() => {
   return n && n > 0 ? Math.floor(n) : 0
 })
 
-const selectedCount = computed(() => {
-  const arr = imageReview.value?.selected_assets
-  return Array.isArray(arr) ? arr.length : 0
+const imageAssetCount = computed(() => {
+  const assets = imageAssets.value?.assets
+  return Array.isArray(assets) ? assets.length : 0
+})
+
+const audioItemCount = computed(() => {
+  const items = audioSegments.value?.items
+  return Array.isArray(items) ? items.length : 0
 })
 
 const finalStatus = computed(() => asStr(finalVideo.value?.status).toLowerCase())
 const finalEnabled = computed(() => Boolean(finalVideo.value?.enabled))
 
+const assetsReady = computed(() => {
+  return sceneCount.value > 0 && imageAssetCount.value >= sceneCount.value
+})
+
+const canRender = computed(() => {
+  if (props.finalVideoUrl) return false
+  if (props.renderInFlight || finalStatus.value === 'rendering') return false
+  if (finalEnabled.value && finalStatus.value === 'generated') return false
+  if (!assetsReady.value) return false
+  if (audioItemCount.value === 0) return false
+  return true
+})
+
 const progressPct = computed(() => {
   if (props.finalVideoUrl) return 100
+  if (props.renderInFlight || finalStatus.value === 'rendering') return 90
+  if (!sceneCount.value) return 0
 
-  // render 请求已发出：先给一个真实但保守的“渲染中”区间（不做假计时，只反映状态）
-  if (props.renderInFlight || finalStatus.value === 'rendering') {
-    // 选图完成度决定渲染前置进度（最多到 85%），渲染中固定显示 90%
-    return 90
-  }
-
-  // 没开始渲染：用“选图完成度”作为真实进度
-  const total = sceneCount.value
-  if (total <= 0) return 0
-  const ratio = Math.min(1, Math.max(0, selectedCount.value / total))
-  // 选图阶段最多显示到 85%，避免误导 “快好了但其实还没渲染”
+  const ratio = Math.min(1, Math.max(0, imageAssetCount.value / sceneCount.value))
   return Math.floor(ratio * 85)
 })
 
@@ -95,28 +118,37 @@ const progressLabel = computed(() => {
   if (props.finalVideoUrl) return '已生成'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '视频渲染中'
   if (!sceneCount.value) return '等待 Storyboard'
-  if (selectedCount.value < sceneCount.value) {
-    return `选图中（${selectedCount.value}/${sceneCount.value}）`
-  }
-  // 选图完成但还没渲染
-  if (finalEnabled.value && finalStatus.value === 'skipped') return '等待渲染触发'
-  return '等待渲染触发'
+  if (!assetsReady.value) return `候选图生成中（${imageAssetCount.value}/${sceneCount.value}）`
+  return '等待用户触发渲染'
 })
 
 const placeholderTitle = computed(() => {
   if (props.renderInFlight || finalStatus.value === 'rendering') return '正在生成视频'
   if (!sceneCount.value) return '等待分镜'
-  if (selectedCount.value < sceneCount.value) return '等待选图完成'
+  if (!assetsReady.value) return '等待候选图生成'
   return '等待渲染'
 })
 
 const placeholderDesc = computed(() => {
-  if (props.renderInFlight || finalStatus.value === 'rendering')
+  if (props.renderInFlight || finalStatus.value === 'rendering') {
     return '视频正在合成中，请稍候（音频/字幕/画面正在拼接）。'
-  if (!sceneCount.value) return '请先在 Run 执行一次，生成 storyboard。'
-  if (selectedCount.value < sceneCount.value)
-    return '请先完成每个场景的候选图生成与选择。'
-  return '选图已完成，等待触发 Final Video 渲染。'
+  }
+  if (!sceneCount.value) {
+    return '请先在 Run 执行一次，生成 storyboard。'
+  }
+  if (!assetsReady.value) {
+    return '系统正在准备每个场景的候选图，默认图生成后即可直接渲染，也可以手动改选。'
+  }
+  if (audioItemCount.value === 0) {
+    return '当前缺少音频片段，请先完成音频生成。'
+  }
+  return '候选图已就绪。你可以直接使用默认图，也可以手动改选，然后点击按钮开始渲染。'
+})
+
+const renderButtonText = computed(() => {
+  if (props.renderInFlight || finalStatus.value === 'rendering') return 'Rendering...'
+  if (props.finalVideoUrl) return 'Rendered'
+  return 'Render Final Video'
 })
 </script>
 
@@ -144,7 +176,6 @@ const placeholderDesc = computed(() => {
 .final-video {
   width: 100%;
   display: block;
-  /* 关键：9:16 在网页端“居中留边”，不怪异 */
   background: transparent;
   object-fit: contain;
   max-height: 72vh;
@@ -198,6 +229,25 @@ const placeholderDesc = computed(() => {
 
 .ph-dot {
   opacity: 0.6;
+}
+
+.render-button {
+  margin-top: 18px;
+  min-width: 220px;
+  height: 42px;
+  padding: 0 18px;
+  border: none;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  background: #ffffff;
+  color: #111827;
+}
+
+.render-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .final-json {


### PR DESCRIPTION
**Summary**

- Fix `refresh-scene` response/merge so frontend receives `image_assets`, enabling correct progress (e.g. 0/4 → 4/4) and render readiness.
- Switch Final Video to **manual render** flow: default images are accepted; user can override selections; rendering is triggered only by button click.
- Improve resilience: when API image generation fails (e.g. SiliconFlow 500/429), fallback to pillow renderer when enabled.

**Changes**

- Backend:
  - `ImageReviewRefreshSceneResponse` now includes `image_assets`.
  - `/v1/image-review/refresh-scene` returns `image_assets` to client.
  - `refresh_image_review_scene()` runner result includes `image_assets`.
  - Single-scene image generation fallback: if `API_IMAGE_FALLBACK_TO_PILLOW=true`, fallback is applied on non-429 failures as well.
- Frontend:
  - Merge `image_assets` from refresh-scene response into `currentWorkflowResponse.outputs`.
  - Final video render is manual (button); remove auto render after select.
  - FinalVideoPanel progress uses `image_assets.assets` count; button enabled when assets ready and audio available.

**How to test**

1. Start backend with API image provider (optional) and fallback enabled:

   - `IMAGE_PROVIDER=api_image_generator`
   - `API_IMAGE_ENABLED=true`
   - `API_IMAGE_FALLBACK_TO_PILLOW=true`

2. Frontend: `npm run dev`

3. Run workflow (storyboard-demo).

4. Trigger refresh-scene for all scenes.

   - Expect progress increments `1/4 → 4/4`.

5. Without manual selection, click 

   Render Final Video

   .

   - Expect `/v1/final-video/render` returns 200 and video is playable.

6. Optional: force API failures to verify pillow fallback produces candidates and run continues.

**Notes / Risk**

- This PR changes refresh-scene contract shape (adds `image_assets`). Existing clients should tolerate extra field.
- Fallback behavior now applies beyond rate-limit cases when enabled.