### PR TITLE
Click Run shows immediate indeterminate progress; Review keeps FinalVideo hero visible while in-flight.

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1121,6 +1121,14 @@ async function runWorkflow() {
   }
   currentWorkflowPayload.value = payload as WorkflowRunPayload
 
+  // ✅ 点击 Run 立刻给 UI 反馈（跨 tab 都能感知）
+  loading.value = true
+  errorMessage.value = ''
+  finalVideoText.value = ''
+  finalVideoUrl.value = ''
+  finalVideoRenderInFlight.value = false
+  finalVideoRendering.value = false
+
   try {
     const response = await fetch(`${apiBaseUrl}/v1/workflow/run`, {
       method: 'POST',
@@ -1209,6 +1217,7 @@ onMounted(() => {
           :workflow-response="currentWorkflowResponse"
           :render-in-flight="finalVideoRenderInFlight"
           @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
+          :loading="loading || refreshingImageReview || finalVideoRenderInFlight"
         />
 
         <WorkflowRunPanel
@@ -1224,44 +1233,48 @@ onMounted(() => {
         />
       </section>
       <section v-if="activeTab === 'review'">
-        <p v-if="!hasReviewContent" class="empty-state">
+        <template v-if="hasReviewContent || loading || refreshingImageReview || finalVideoRenderInFlight">
+  <section class="result-panel final-video-hero">
+    <FinalVideoPanel
+      :final-video-url="finalVideoUrl"
+      :final-video-text="finalVideoText"
+      :workflow-response="currentWorkflowResponse"
+      :render-in-flight="finalVideoRenderInFlight"
+      :loading="loading || refreshingImageReview || finalVideoRenderInFlight"
+      @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
+    />
+  </section>
+
+  <!-- 有内容才显示选图和结果；没内容但在跑时，只显示 FinalVideoPanel 占位 -->
+  <template v-if="hasReviewContent">
+    <InteractiveImageReview
+      :items="imageReviewItems"
+      :placeholders="reviewPlaceholders"
+      :api-base-url="apiBaseUrl"
+      :loading="loading || refreshingImageReview"
+      :selecting-scene-id="selectingSceneId || sceneRefreshingId"
+      @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
+    />
+
+    <WorkflowResultsPanel
+      :story-text="storyText"
+      :storyboard-text="storyboardText"
+      :image-prompts-text="imagePromptsText"
+      :image-assets-text="imageAssetsText"
+      :image-review-text="imageReviewText"
+      :video-prompts-text="videoPromptsText"
+      :narration-text="narrationText"
+      :subtitles-text="subtitlesText"
+      :render-plan-text="renderPlanText"
+      :character-candidates-text="characterCandidatesText"
+      :character-manifest-text="characterManifestText"
+    />
+  </template>
+        </template>
+
+        <p v-else class="empty-state">
           请先在 Run 页签执行一次 workflow，然后回到 Review 查看选图和结果。
         </p>
-
-        <template v-else>
-          <section class="result-panel final-video-hero">
-            <FinalVideoPanel
-              :final-video-url="finalVideoUrl"
-              :final-video-text="finalVideoText"
-              :workflow-response="currentWorkflowResponse"
-              :render-in-flight="finalVideoRenderInFlight"
-              @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
-            />
-          </section>
-
-          <InteractiveImageReview
-            :items="imageReviewItems"
-            :placeholders="reviewPlaceholders"
-            :api-base-url="apiBaseUrl"
-            :loading="loading || refreshingImageReview"
-            :selecting-scene-id="selectingSceneId || sceneRefreshingId"
-            @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
-          />
-
-          <WorkflowResultsPanel
-            :story-text="storyText"
-            :storyboard-text="storyboardText"
-            :image-prompts-text="imagePromptsText"
-            :image-assets-text="imageAssetsText"
-            :image-review-text="imageReviewText"
-            :video-prompts-text="videoPromptsText"
-            :narration-text="narrationText"
-            :subtitles-text="subtitlesText"
-            :render-plan-text="renderPlanText"
-            :character-candidates-text="characterCandidatesText"
-            :character-manifest-text="characterManifestText"
-          />
-        </template>
       </section>
       <section v-if="activeTab === 'assets'">
         <SampleAssetsPanel

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -16,8 +16,11 @@
         <div class="ph-desc">{{ placeholderDesc }}</div>
 
         <div class="ph-progress">
-          <div class="ph-bar">
-            <div class="ph-bar-fill" :style="{ width: progressPct + '%' }"></div>
+          <div class="ph-bar" :class="{ indeterminate }">
+            <div
+              class="ph-bar-fill"
+              :style="indeterminate ? {} : { width: progressPct + '%' }"
+            ></div>
           </div>
           <div class="ph-meta">
             <span>{{ progressPct }}%</span>
@@ -50,6 +53,7 @@ const props = defineProps<{
   finalVideoText: string
   workflowResponse: UnknownRecord | null
   renderInFlight: boolean
+  loading: boolean
 }>()
 
 const emit = defineEmits<{
@@ -73,6 +77,13 @@ const storyboard = computed(() => asObj(outputs.value?.storyboard))
 const imageAssets = computed(() => asObj(outputs.value?.image_assets))
 const audioSegments = computed(() => asObj(outputs.value?.audio_segments))
 const finalVideo = computed(() => asObj(outputs.value?.final_video))
+
+const indeterminate = computed(() => {
+  if (props.finalVideoUrl) return false
+  if (props.renderInFlight || finalStatus.value === 'rendering') return false
+  // runWorkflow 请求中，或 refresh 正在跑，但还没有任何 image_assets
+  return props.loading  && imageAssetCount.value === 0
+})
 
 const sceneCount = computed(() => {
   const n = asNum(storyboard.value?.scene_count)
@@ -115,6 +126,7 @@ const progressPct = computed(() => {
 })
 
 const progressLabel = computed(() => {
+  if (indeterminate.value) return '准备中…'
   if (props.finalVideoUrl) return '已生成'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '视频渲染中'
   if (!sceneCount.value) return '等待 Storyboard'
@@ -216,6 +228,55 @@ const renderButtonText = computed(() => {
   background: linear-gradient(90deg, #6ea8fe 0%, #9f7aea 60%, #a78bfa 100%);
   border-radius: 999px;
   transition: width 180ms ease-out;
+}
+
+.ph-bar {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ✅ 企业风格：全宽的 indeterminate 背景 shimmer */
+.ph-bar.indeterminate::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  /* 低对比度、低饱和：不抢真实进度 */
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(255, 255, 255, 0.14) 20%,
+    rgba(255, 255, 255, 0.06) 40%,
+    rgba(255, 255, 255, 0.06) 100%
+  );
+  background-size: 240px 100%;
+  animation: ph-indeterminate 1.1s linear infinite;
+}
+
+/* ✅ 真实进度条仍然用 fill（你原来的渐变） */
+.ph-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #6ea8fe 0%, #9f7aea 60%, #a78bfa 100%);
+  border-radius: 999px;
+  transition: width 180ms ease-out;
+  position: relative;
+  z-index: 1;
+}
+
+/* ✅ indeterminate 时，不显示 fill（避免“假进度”） */
+.ph-bar.indeterminate .ph-bar-fill {
+  width: 0 !important;
+}
+
+@keyframes ph-indeterminate {
+  from {
+    background-position: -240px 0;
+  }
+  to {
+    background-position: 240px 0;
+  }
 }
 
 .ph-meta {


### PR DESCRIPTION
- ------

  ### What

  - Show **immediate indeterminate progress** in FinalVideo hero when user clicks **Run** (no waiting for run response).
  - Keep FinalVideo hero visible on **Review** while workflow is in-flight, so the page never looks “empty” during pending requests.

  ### Why

  - Improve perceived responsiveness: user gets instant feedback after clicking Run.
  - Ensure cross-tab continuity: Review should reflect global run state instead of showing a blank/empty placeholder.

  ### How

  - Set `loading.value = true` at the start of `runWorkflow()` and reset in `finally`.
  - In Review tab, render FinalVideo hero when `hasReviewContent || loading || refreshingImageReview || finalVideoRenderInFlight`.

  ### Test Plan

  1. Click **Run** → FinalVideo hero shows shimmer/“准备中…” immediately (before `/v1/workflow/run` returns).
  2. Switch to **Review** while run is pending → FinalVideo hero still visible (no empty-state blocking).
  3. After run completes → refresh-scene progresses normally; rendering flow unchanged.

  ### Scope

  - Frontend only: `frontend/src/App.vue` (+ FinalVideoPanel logic unchanged except consuming `loading` as before).