### PR TITLE
fix(frontend): topic-driven characters and session id de-dupe

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -207,15 +207,15 @@ const DEFAULT_WORKFLOW_FORM: WorkflowRunFormState = {
   videoProvider: 'mock',
   outputMode: 'full_video',
 
-  structuredCharactersEnabled: true,
-  primaryCharacterDisplayName: '小兔子',
-  primaryCharacterSpecies: 'rabbit',
-  primaryCharacterVisualTraits: 'long upright ears, white fur, red scarf',
-  primaryCharacterForbiddenTraits: 'cat ears, turtle shell',
-  secondaryCharacterDisplayName: '小乌龟',
-  secondaryCharacterSpecies: 'turtle',
-  secondaryCharacterVisualTraits: 'round shell, short legs, green shell',
-  secondaryCharacterForbiddenTraits: 'rabbit ears, cat ears',
+  structuredCharactersEnabled: false,
+  primaryCharacterDisplayName: '',
+  primaryCharacterSpecies: '',
+  primaryCharacterVisualTraits: '',
+  primaryCharacterForbiddenTraits: '',
+  secondaryCharacterDisplayName: '',
+  secondaryCharacterSpecies: '',
+  secondaryCharacterVisualTraits: '',
+  secondaryCharacterForbiddenTraits: '',
 }
 
 const STEP_OPTIONS: Array<{ label: string; value: StepName }> = [
@@ -1105,18 +1105,30 @@ async function runWorkflow() {
           : []),
       ]
     : []
+  
+  const sessionId =
+  form.sessionId.trim() || `demo-session-${Date.now().toString(36)}`
+
+  const enableStructuredCharacters =
+    form.structuredCharactersEnabled && structuredCharacters.length > 0
 
   const payload = {
     workflow_id: 'storybook-demo',
-    session_id: form.sessionId.trim() || 'demo-session-001',
+    session_id: sessionId,
     input: {
       topic: form.topic.trim(),
       audience: form.audience,
       tone: form.tone,
       visual_style: form.visualStyle,
       character_style: form.characterStyle,
-      structured_characters_enabled: form.structuredCharactersEnabled,
-      characters: structuredCharacters,
+      ...(enableStructuredCharacters
+        ? {
+            structured_characters_enabled: true,
+            characters: structuredCharacters,
+          }
+        : {
+            structured_characters_enabled: false,
+          }),
       voice_style: form.voiceStyle,
       voiceover_enabled: form.voiceoverEnabled,
       voice_mode: form.voiceMode,


### PR DESCRIPTION
**Description**

  - Default mode no longer sends fixed structured characters (rabbit/turtle) when user only provides a topic.
  - Generate a unique session_id when the user does not provide one to avoid reusing demo-session state.
  - Structured characters are sent only when explicitly enabled and non-empty.

  **Test Plan**

  1. Run with topic: “小猫在太空修飞船” and structured characters disabled
     - Request payload shows `structured_characters_enabled=false` and **no fixed rabbit/turtle characters**.
  2. Refresh page / run again without sessionId
     - session_id differs between runs.
  3. Enable structured characters and set explicit species
     - payload includes `structured_characters_enabled=true` and `characters=[...]`.