### PR TITLE
feat(character): infer topic-driven primary manifest when structured disabled

### DIFF
--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -27,6 +27,7 @@ from app.services.image_provider_queue import ImageProviderQueue
 from app.services.image_provider_adapter import ApiImageGeneratorAdapter
 from app.services.image_provider_types import ImageGenerationTask
 from app.services.runner_single_scene_image_support import RunnerSingleSceneImageSupport
+from app.services.topic_character_infer import infer_primary_character_manifest
 
 
 class UnknownStepError(Exception):
@@ -806,6 +807,12 @@ class WorkflowRunner:
         character_candidates = self._build_character_candidates(req.input)
         character_manifest = self._build_character_manifest(req.input, character_candidates)
 
+        # P0-05: structured_characters_enabled=false 时，按 topic 自动补 primary manifest
+        if (not req.input.structured_characters_enabled) and (not character_manifest):
+            inferred_primary = infer_primary_character_manifest(req.input.topic)
+            if inferred_primary is not None:
+                character_manifest = [inferred_primary]
+                
         aggregated_outputs: Dict[str, Any] = {
             "character_candidates": {
                 "enabled": bool(req.input.structured_characters_enabled),
@@ -813,7 +820,7 @@ class WorkflowRunner:
                 "items": character_candidates,
             },
             "character_manifest": {
-                "enabled": bool(req.input.structured_characters_enabled),
+                "enabled": bool(req.input.structured_characters_enabled) or bool(character_manifest),
                 "count": len(character_manifest),
                 "characters": character_manifest,
             },

--- a/app/services/topic_character_infer.py
+++ b/app/services/topic_character_infer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def infer_primary_character_manifest(topic: str) -> Optional[Dict[str, Any]]:
+    """
+    Infer a minimal primary character manifest from topic text.
+
+    Returns a dict compatible with runner's character_manifest items:
+      {
+        "id": "primary-1",
+        "role_type": "primary",
+        "display_name": "小猫",
+        "species": "cat",
+        "visual_traits": "...",
+        "forbidden_traits": "..."
+      }
+    """
+    t = (topic or "").strip()
+    if not t:
+        return None
+
+    lower = t.lower()
+
+    # --- cat ---
+    if ("猫" in t) or ("cat" in lower) or ("kitten" in lower):
+        return {
+            "id": "primary-1",
+            "role_type": "primary",
+            "display_name": "小猫",
+            "species": "cat",
+            "visual_traits": (
+                "domestic kitten, round cat face, short muzzle, moderate-sized triangular ears, "
+                "visible whiskers, cat-like paws, long cat tail"
+            ),
+            "forbidden_traits": (
+                "fox snout, fennec fox ears, raccoon mask, mouse face, rabbit ears, turtle shell"
+            ),
+        }
+
+    # --- dog ---
+    if ("狗" in t) or ("dog" in lower) or ("puppy" in lower):
+        return {
+            "id": "primary-1",
+            "role_type": "primary",
+            "display_name": "小狗",
+            "species": "dog",
+            "visual_traits": "cute puppy, round friendly face, dog-like paws, dog tail, moderate ears",
+            "forbidden_traits": "fox snout, raccoon mask, mouse face, rabbit ears, turtle shell",
+        }
+
+    # --- rabbit ---
+    if ("兔" in t) or ("rabbit" in lower) or ("bunny" in lower):
+        return {
+            "id": "primary-1",
+            "role_type": "primary",
+            "display_name": "小兔子",
+            "species": "rabbit",
+            "visual_traits": "cute bunny, long rabbit ears, round face, fluffy fur",
+            "forbidden_traits": "cat ears, fox snout, turtle shell, raccoon mask, mouse face",
+        }
+
+    # --- turtle ---
+    if ("乌龟" in t) or ("龟" in t) or ("turtle" in lower):
+        return {
+            "id": "primary-1",
+            "role_type": "primary",
+            "display_name": "小乌龟",
+            "species": "turtle",
+            "visual_traits": "cute small turtle, clear round shell, short legs, turtle face",
+            "forbidden_traits": "rabbit ears, cat ears, fox snout, raccoon mask, mouse face",
+        }
+
+    # --- seal ---
+    if ("海豹" in t) or ("seal" in lower):
+        return {
+            "id": "primary-1",
+            "role_type": "primary",
+            "display_name": "小海豹",
+            "species": "seal",
+            "visual_traits": "cute baby seal, round face, big eyes, smooth gray fur, short flippers",
+            "forbidden_traits": "fox snout, raccoon mask, mouse face, rabbit ears, turtle shell",
+        }
+
+    # --- robot ---
+    if ("机器人" in t) or ("robot" in lower):
+        return {
+            "id": "primary-1",
+            "role_type": "primary",
+            "display_name": "小机器人",
+            "species": "robot",
+            "visual_traits": "cute small robot, rounded body, friendly screen face, simple limbs, clean design",
+            "forbidden_traits": "animal ears, fur, whiskers, snout",
+        }
+
+    return None


### PR DESCRIPTION
- What: Infer primary character manifest from topic when structured characters are disabled; use it to strengthen image prompt anchor.
- Why: Previously manifest stayed empty → prompts fell back to generic “animal protagonist” → character drift.
- Validation:
  - Verified topic=小猫… → manifest enabled/count=1 and prompt includes 小猫(cat)+traits
  - Verified topic=小机器人… → manifest enabled/count=1 and prompt includes 小机器人(robot)+traits
  - `python -m py_compile` passed

