### PR TITLE
feat(frontend): add character voice mode and map structured characters

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1189,6 +1189,18 @@ async function runWorkflow() {
 
   // 关键：是否启用结构化角色，不再由 checkbox 决定
   const enableStructuredCharacters = finalCharacters.length > 0
+
+  const primaryCharacter =
+    finalCharacters.find((item) => item.role_type === 'primary') || finalCharacters[0]
+
+  const secondaryCharacter = finalCharacters.find(
+    (item) => item.role_type === 'secondary',
+  )
+
+  const mainCharacterDisplay = String(primaryCharacter?.display_name || '').trim()
+  const mainCharacterSpecies = String(primaryCharacter?.species || '').trim()
+  const secondaryCharacterDisplay = String(secondaryCharacter?.display_name || '').trim()
+  const secondaryCharacterSpecies = String(secondaryCharacter?.species || '').trim()
   
   const sessionId =
   form.sessionId.trim() || `demo-session-${Date.now().toString(36)}`
@@ -1202,6 +1214,19 @@ async function runWorkflow() {
       tone: form.tone,
       visual_style: form.visualStyle,
       character_style: form.characterStyle,
+      main_character: mainCharacterSpecies || mainCharacterDisplay,
+      main_character_display: mainCharacterDisplay,
+      main_character_species: mainCharacterSpecies || 'rabbit',
+      secondary_character: secondaryCharacterSpecies || secondaryCharacterDisplay,
+      secondary_character_display: secondaryCharacterDisplay,
+      secondary_character_species: secondaryCharacterSpecies || 'turtle',
+      character_speaker_profiles: enableStructuredCharacters
+        ? {
+            narrator: form.narratorVoiceStyle,
+            main_character: form.childVoiceStyle,
+            secondary_character: form.motherVoiceStyle,
+          }
+        : {},
       ...(enableStructuredCharacters
         ? {
             structured_characters_enabled: true,

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -181,8 +181,9 @@ function updateSelectedStep(step: StepName, checked: boolean) {
             class="input"
             @change="updateFormState('voiceMode', ($event.target as HTMLSelectElement).value)"
           >
-            <option value="single">single</option>
-            <option value="multi">multi</option>
+            <option value="single">single · 单人旁白</option>
+            <option value="multi">multi · 亲子双人轮流</option>
+            <option value="character">character · 角色配音</option>
           </select>
         </label>
 
@@ -198,8 +199,8 @@ function updateSelectedStep(step: StepName, checked: boolean) {
           />
         </label>
 
-        <label v-if="formState.voiceMode === 'multi'" class="field">
-          <span>Mother Voice</span>
+        <label v-if="formState.voiceMode === 'multi' || formState.voiceMode === 'character'" class="field">
+          <span>{{ formState.voiceMode === 'character' ? 'Secondary Character Voice' : 'Mother Voice' }}</span>
           <input
             :value="formState.motherVoiceStyle"
             class="input"
@@ -210,8 +211,8 @@ function updateSelectedStep(step: StepName, checked: boolean) {
           />
         </label>
 
-        <label v-if="formState.voiceMode === 'multi'" class="field">
-          <span>Child Voice</span>
+        <label v-if="formState.voiceMode === 'multi' || formState.voiceMode === 'character'" class="field">
+          <span>{{ formState.voiceMode === 'character' ? 'Main Character Voice' : 'Child Voice' }}</span>
           <input
             :value="formState.childVoiceStyle"
             class="input"


### PR DESCRIPTION
## Summary
- Add `character` option to Voice Mode selector (single / multi / character)
- When Structured Characters are enabled, map primary/secondary character info to:
  - `main_character`, `main_character_display`, `main_character_species`
  - `secondary_character`, `secondary_character_display`, `secondary_character_species`
  - `character_speaker_profiles` (narrator/main/secondary voices)

## Why
- `multi` is a parent/child alternating mode and is not character-based.
- `character` makes role-based TTS explicit and stable.

## Verification
- `npm run build`
- Run workflow in UI with:
  - Voice Mode = character
  - Structured Characters = enabled (rabbit + turtle)
  - Distinct narrator/main/secondary voice styles
- Confirm `run` payload contains `voice_mode: "character"` and `character_speaker_profiles`