### PR TITLE
fix(voice): presets + payload alignment for multi/character modes

### DIFF
--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -169,6 +169,7 @@ class RunnerAudioRenderSupport:
 
         if voice_mode == "multi":
             alternating_speakers = ["mother", "child"]
+            speaker_cursor = 0
 
             for index, scene in enumerate(scenes, start=1):
                 text = str(scene.get("narration", "")).strip()
@@ -181,8 +182,10 @@ class RunnerAudioRenderSupport:
 
                 for seg_index, segment in enumerate(segments, start=1):
                     speaker = alternating_speakers[
-                        (seg_index - 1) % len(alternating_speakers)
+                        speaker_cursor % len(alternating_speakers)
                     ]
+                    speaker_cursor += 1
+
                     final_text = f"{segment}。"
                     lines.append(
                         {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1220,13 +1220,14 @@ async function runWorkflow() {
       secondary_character: secondaryCharacterSpecies || secondaryCharacterDisplay,
       secondary_character_display: secondaryCharacterDisplay,
       secondary_character_species: secondaryCharacterSpecies || 'turtle',
-      character_speaker_profiles: enableStructuredCharacters
-        ? {
-            narrator: form.narratorVoiceStyle,
-            main_character: form.childVoiceStyle,
-            secondary_character: form.motherVoiceStyle,
-          }
-        : {},
+      character_speaker_profiles:
+        form.voiceMode === 'character'
+          ? {
+              narrator: form.narratorVoiceStyle,
+              main_character: form.childVoiceStyle,
+              secondary_character: form.motherVoiceStyle,
+            }
+          : {},
       ...(enableStructuredCharacters
         ? {
             structured_characters_enabled: true,
@@ -1238,11 +1239,15 @@ async function runWorkflow() {
       voice_style: form.voiceStyle,
       voiceover_enabled: form.voiceoverEnabled,
       voice_mode: form.voiceMode,
-      speaker_profiles: {
-        narrator: form.narratorVoiceStyle,
-        mother: form.motherVoiceStyle,
-        child: form.childVoiceStyle,
-      },
+      ...(form.voiceMode === 'character'
+        ? {}
+        : {
+            speaker_profiles: {
+              narrator: form.narratorVoiceStyle,
+              mother: form.motherVoiceStyle,
+              child: form.childVoiceStyle,
+            },
+          }),
       duration_sec: form.durationSec,
       language: form.language,
       subtitle_enabled: form.subtitleEnabled,

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -82,6 +82,72 @@ function updateSelectedStep(step: StepName, checked: boolean) {
     current.filter((item) => item !== step)
   )
 }
+
+function applyPresetCharacter() {
+  console.log('[preset] character clicked')
+  emit('update:formState', {
+    ...props.formState,
+    voiceoverEnabled: true,
+    subtitleEnabled: true,
+    voiceMode: 'character',
+
+    narratorVoiceStyle: 'warm_female',
+    motherVoiceStyle: 'warm_male',
+    childVoiceStyle: 'gentle_child',
+
+    structuredCharactersEnabled: true,
+    primaryCharacterDisplayName: '小兔子',
+    primaryCharacterSpecies: 'rabbit',
+    secondaryCharacterDisplayName: '小乌龟',
+    secondaryCharacterSpecies: 'turtle',
+  })
+  applyPresetFullSteps()
+}
+
+function applyPresetMulti() {
+  console.log('[preset] multi clicked')
+  emit('update:formState', {
+    ...props.formState,
+    voiceoverEnabled: true,
+    subtitleEnabled: true,
+    voiceMode: 'multi',
+
+    narratorVoiceStyle: 'warm_female',
+    motherVoiceStyle: 'warm_female',
+    childVoiceStyle: 'gentle_child',
+  })
+  applyPresetFullSteps()
+}
+
+function applyPresetFullSteps() {
+  emit('update:selectedSteps', [
+    'story',
+    'storyboard',
+    'image_prompts',
+    'image_assets',
+    'video_prompts',
+    'dialogue_script',
+    'audio_segments',
+    'narration',
+    'subtitles',
+    'render_plan',
+    'final_video',
+  ])
+}
+
+function applyPresetMinimalSteps() {
+  console.log('[preset] minimal clicked')
+  // 最简步骤：减少等待（只保留必要产物）
+  emit('update:selectedSteps', [
+    'story',
+    'storyboard',
+    'dialogue_script',
+    'audio_segments',
+    'narration',
+    'subtitles',
+  ])
+}
+
 </script>
 
 <template>
@@ -176,6 +242,19 @@ function updateSelectedStep(step: StepName, checked: boolean) {
 
         <label class="field">
           <span>Voice Mode</span>
+
+          <div class="presetRow">
+            <button type="button" class="presetBtn" @click="applyPresetCharacter">
+              Preset · 角色配音（兔子/乌龟）
+            </button>
+            <button type="button" class="presetBtn" @click="applyPresetMulti">
+              Preset · 亲子轮流（妈妈/宝宝）
+            </button>
+            <button type="button" class="presetBtn subtle" @click="applyPresetMinimalSteps">
+              Preset · 最简验证（不出候选图/不出视频）
+            </button>
+          </div>
+
           <select
             :value="formState.voiceMode"
             class="input"
@@ -598,4 +677,23 @@ function updateSelectedStep(step: StepName, checked: boolean) {
   color: #dc2626;
   font-size: 14px;
 }
+
+.presetRow{
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
+  margin:6px 0 8px 0;
+}
+.presetBtn{
+  border:1px solid rgba(0,0,0,0.12);
+  border-radius:10px;
+  padding:6px 10px;
+  font-size:12px;
+  cursor:pointer;
+  background:#fff;
+}
+.presetBtn.subtle{
+  opacity:0.8;
+}
+
 </style>


### PR DESCRIPTION
What

- Add voice mode presets (character / multi / minimal steps) in WorkflowRunPanel
- Improve run payload mapping for voice mode (avoid manual config burden)

Why

- Reduce user configuration friction and make validation repeatable
- Align frontend controls with backend voice_mode semantics

How to test

- In Run tab, click preset buttons and verify form updates
- Run workflow and confirm request payload includes expected voice_mode and profiles
- For multi: verify audio dir contains both mother_*.mp3 and child_*.mp3 (after backend fix)
- For character: verify audio dir contains narrator + main/secondary speakers

Notes

- This PR focuses on UX/payload wiring; image generation logic unchanged