### PR TITLE
Fix: render mode SSoT, audio/voiceover gating, and silent subtitles

### DIFF
--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -139,6 +139,14 @@ class WorkflowInput(BaseModel):
     subtitle_enabled: bool = Field(default=True)
     video_provider: str = Field(default="mock")
     output_mode: str = Field(default="full_video")
+    render_mode: str = Field(
+        default="auto",
+        description="Render strategy: auto or manual",
+    )
+    audio_enabled: bool = Field(
+        default=True,
+        description="Whether audio generation is enabled for this run",
+    )
 
 
 class WorkflowRunRequest(BaseModel):

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -4,7 +4,6 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
@@ -35,9 +34,7 @@ class RunnerAudioRenderSupport:
 
         return voice_mode
 
-    def run_dialogue_script(
-        self, ctx: Any, outputs: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def run_dialogue_script(self, ctx: Any, outputs: Dict[str, Any]) -> Dict[str, Any]:
         sentence_shots = outputs.get("sentence_shots") or {}
         shot_items = sentence_shots.get("items") or []
 
@@ -113,7 +110,9 @@ class RunnerAudioRenderSupport:
 
             character_profiles = self._runner._character_speaker_profiles(ctx)
             main_character_speaker = self._runner._character_speaker_name(ctx)
-            secondary_character_speaker = self._runner._secondary_character_speaker_name(ctx)
+            secondary_character_speaker = (
+                self._runner._secondary_character_speaker_name(ctx)
+            )
 
             for index, shot in enumerate(shot_items, start=1):
                 text = str(shot.get("audio_text") or shot.get("text") or "").strip()
@@ -139,7 +138,9 @@ class RunnerAudioRenderSupport:
                 "speaker_profiles": {
                     "narrator": character_profiles["narrator"],
                     main_character_speaker: character_profiles["main_character"],
-                    secondary_character_speaker: character_profiles["secondary_character"],
+                    secondary_character_speaker: character_profiles[
+                        "secondary_character"
+                    ],
                 },
                 "lines": lines,
             }
@@ -206,7 +207,9 @@ class RunnerAudioRenderSupport:
 
         character_profiles = self._runner._character_speaker_profiles(ctx)
         main_character_speaker = self._runner._character_speaker_name(ctx)
-        secondary_character_speaker = self._runner._secondary_character_speaker_name(ctx)
+        secondary_character_speaker = self._runner._secondary_character_speaker_name(
+            ctx
+        )
 
         for index, scene in enumerate(scenes, start=1):
             text = str(scene.get("narration", "")).strip()
@@ -242,9 +245,7 @@ class RunnerAudioRenderSupport:
             "lines": lines,
         }
 
-    def run_audio_segments(
-        self, ctx: Any, outputs: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def run_audio_segments(self, ctx: Any, outputs: Dict[str, Any]) -> Dict[str, Any]:
         dialogue_script = outputs.get("dialogue_script") or {}
         lines = dialogue_script.get("lines") or []
 
@@ -320,7 +321,9 @@ class RunnerAudioRenderSupport:
                     asset_status = "generated"
                     generation_mode = "real_tts"
 
-                    actual_duration_sec = self._runner._probe_audio_duration_seconds(output_path)
+                    actual_duration_sec = self._runner._probe_audio_duration_seconds(
+                        output_path
+                    )
                     if actual_duration_sec is not None:
                         duration_sec = actual_duration_sec
                         duration_source = "ffprobe"
@@ -395,11 +398,15 @@ class RunnerAudioRenderSupport:
             items.append(item)
             assets.append(asset)
 
-        directory_manifest = self._runner._write_audio_directory_manifest(ctx.run_id, assets)
+        directory_manifest = self._runner._write_audio_directory_manifest(
+            ctx.run_id, assets
+        )
         scene_asset_map = self._runner._group_audio_assets_by_scene(assets)
 
         overall_provider = (
-            self._runner._tts_provider_name() if real_generation_count > 0 else "mock_tts"
+            self._runner._tts_provider_name()
+            if real_generation_count > 0
+            else "mock_tts"
         )
 
         return {
@@ -417,9 +424,7 @@ class RunnerAudioRenderSupport:
             "scene_asset_map": scene_asset_map,
         }
 
-    def run_narration(
-        self, ctx: Any, outputs: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def run_narration(self, ctx: Any, outputs: Dict[str, Any]) -> Dict[str, Any]:
         dialogue_script = outputs.get("dialogue_script") or {}
         dialogue_lines = dialogue_script.get("lines") or []
 
@@ -478,9 +483,7 @@ class RunnerAudioRenderSupport:
             "segments": segments,
         }
 
-    def run_subtitles(
-        self, ctx: Any, outputs: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def run_subtitles(self, ctx: Any, outputs: Dict[str, Any]) -> Dict[str, Any]:
         if not ctx.input.subtitle_enabled:
             return {"enabled": False, "items": [], "srt_preview": ""}
 
@@ -560,13 +563,21 @@ class RunnerAudioRenderSupport:
             for item in image_assets_list
             if item.get("scene_id")
         }
-
+        print("image_assets_list len =", len(image_assets_list))
+        print("audio_items len =", len(audio_items))
         concat_lines: List[str] = []
         video_run_dir = self._runner._ensure_video_run_dir(ctx.run_id)
         concat_file = video_run_dir / "scene_concat.txt"
         last_image_path: Optional[Path] = None
 
-        for item in audio_items:
+        # 如果有音频，用音频驱动时长
+        if audio_items:
+            loop_items = audio_items
+        else:
+            # 无音频时，用图片列表驱动
+            loop_items = image_assets_list
+
+        for item in loop_items:
             shot_id = str(item.get("shot_id") or "")
             scene_id = str(item.get("scene_id") or "")
 
@@ -575,6 +586,10 @@ class RunnerAudioRenderSupport:
                 image_asset = image_by_shot.get(shot_id)
             if image_asset is None and scene_id:
                 image_asset = image_by_scene.get(scene_id)
+            if image_asset is None and not audio_items:
+                # 无音频时 item 本身就是 image_asset
+                image_asset = item
+
             if image_asset is None:
                 continue
 
@@ -582,26 +597,32 @@ class RunnerAudioRenderSupport:
             resolved_relative_path = ""
 
             if isinstance(selected_asset_ref, dict) and selected_asset_ref:
-                resolved_relative_path = str(selected_asset_ref.get("relative_path") or "").strip()
+                resolved_relative_path = str(
+                    selected_asset_ref.get("relative_path") or ""
+                ).strip()
 
             if not resolved_relative_path:
-                resolved_relative_path = str(image_asset.get("relative_path") or "").strip()
+                resolved_relative_path = str(
+                    image_asset.get("relative_path") or ""
+                ).strip()
 
             if not resolved_relative_path:
                 continue
 
             image_path = PROJECT_ROOT / resolved_relative_path
-            duration_sec = float(item.get("duration_sec") or 0.0)
-            if duration_sec <= 0:
-                duration_sec = float(item.get("duration_estimate_sec") or 3.0)
-            if duration_sec <= 0:
+
+            if audio_items:
+                duration_sec = float(item.get("duration_sec") or 0.0)
+                if duration_sec <= 0:
+                    duration_sec = float(item.get("duration_estimate_sec") or 3.0)
+            else:
+                # 无音频时默认每张 3 秒
                 duration_sec = 3.0
 
             escaped_image_path = str(image_path).replace("'", "'\\''")
             concat_lines.append(f"file '{escaped_image_path}'")
             concat_lines.append(f"duration {duration_sec:.3f}")
             last_image_path = image_path
-
         if last_image_path is not None:
             escaped_last_image_path = str(last_image_path).replace("'", "'\\''")
             concat_lines.append(f"file '{escaped_last_image_path}'")
@@ -609,9 +630,7 @@ class RunnerAudioRenderSupport:
         concat_file.write_text("\n".join(concat_lines) + "\n", encoding="utf-8")
         return concat_file
 
-    def run_final_video(
-        self, ctx: Any, outputs: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def run_final_video(self, ctx: Any, outputs: Dict[str, Any]) -> Dict[str, Any]:
         image_assets = outputs.get("image_assets") or {}
         audio_segments = outputs.get("audio_segments") or {}
         subtitles = outputs.get("subtitles") or {}
@@ -637,9 +656,7 @@ class RunnerAudioRenderSupport:
         video_run_dir = self._runner._ensure_video_run_dir(ctx.run_id)
 
         # ========= 生成 base video =========
-        concat_file = self.build_video_concat_file(
-            ctx, image_assets, audio_segments
-        )
+        concat_file = self.build_video_concat_file(ctx, image_assets, audio_segments)
 
         base_video_path = video_run_dir / "base_video.mp4"
 
@@ -717,15 +734,27 @@ class RunnerAudioRenderSupport:
 
         # ========= 写字幕 =========
         subtitle_path = video_run_dir / "subtitles.srt"
-        subtitle_path.write_text(
-            str(subtitles.get("srt_preview", "")).strip() + "\n",
-            encoding="utf-8",
-        )
+        srt_text = str(subtitles.get("srt_preview", "") or "").strip()
+
+        if srt_text:
+            subtitle_path.write_text(srt_text + "\n", encoding="utf-8")
+        else:
+            # silent/skip subtitles 时，避免留下只有 '\n' 的“假非空字幕文件”
+            if subtitle_path.exists():
+                subtitle_path.unlink()
 
         # ========= 合成 final =========
         final_video_path = video_run_dir / "final.mp4"
 
         if has_audio and merged_audio_path:
+            escaped_subtitle_path = (
+                str(subtitle_path)
+                .replace("\\", "\\\\")
+                .replace(":", "\\:")
+                .replace("'", "\\'")
+            )
+
+            subtitle_filter = f"subtitles='{escaped_subtitle_path}'"
             subprocess.run(
                 [
                     "ffmpeg",
@@ -735,7 +764,7 @@ class RunnerAudioRenderSupport:
                     "-i",
                     str(merged_audio_path),
                     "-vf",
-                    f"subtitles={subtitle_path}",
+                    subtitle_filter,
                     "-c:v",
                     "libx264",
                     "-pix_fmt",
@@ -748,23 +777,49 @@ class RunnerAudioRenderSupport:
                 check=True,
             )
         else:
-            subprocess.run(
-                [
-                    "ffmpeg",
-                    "-y",
-                    "-i",
-                    str(base_video_path),
-                    "-vf",
-                    f"subtitles={subtitle_path}",
-                    "-c:v",
-                    "libx264",
-                    "-pix_fmt",
-                    "yuv420p",
-                    str(final_video_path),
-                ],
-                check=True,
-            )
+            # 如果字幕文件不存在或为空，就不要加字幕滤镜
+            if subtitle_path.exists() and subtitle_path.stat().st_size > 0:
+                escaped_subtitle_path = (
+                    str(subtitle_path)
+                    .replace("\\", "\\\\")
+                    .replace(":", "\\:")
+                    .replace("'", "\\'")
+                )
+                subtitle_filter = f"subtitles='{escaped_subtitle_path}'"
 
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-i",
+                        str(base_video_path),
+                        "-vf",
+                        subtitle_filter,
+                        "-c:v",
+                        "libx264",
+                        "-pix_fmt",
+                        "yuv420p",
+                        str(final_video_path),
+                    ],
+                    check=True,
+                )
+            else:
+                print("[final-video] subtitle file missing or empty, skip subtitles")
+
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-i",
+                        str(base_video_path),
+                        "-c:v",
+                        "libx264",
+                        "-pix_fmt",
+                        "yuv420p",
+                        str(final_video_path),
+                    ],
+                    check=True,
+                )
         # ========= 统一 return =========
         return {
             "enabled": True,
@@ -776,12 +831,14 @@ class RunnerAudioRenderSupport:
             "duration_sec": round(total_duration_sec, 3),
             "audio_track_path": (
                 f"assets/mock/video/{ctx.run_id}/merged_audio.mp3"
-                if has_audio else None
+                if has_audio
+                else None
             ),
             "subtitle_path": f"assets/mock/video/{ctx.run_id}/subtitles.srt",
             "audio_enabled": has_audio,
             "audio_mode": "tts" if has_audio else "silent",
         }
+
     def rerender_final_video(
         self,
         *,

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -490,6 +490,31 @@ class RunnerAudioRenderSupport:
         audio_segments = outputs.get("audio_segments") or {}
         items_source = audio_segments.get("items") or []
 
+        # ---- fallback: silent 场景也要能生成字幕（用 storyboard.scenes 驱动时间轴）----
+        if not items_source:
+            storyboard = outputs.get("storyboard") or {}
+            scenes = storyboard.get("scenes") or []
+            if isinstance(scenes, list) and scenes:
+                synthesized = []
+                for scene in scenes:
+                    if not isinstance(scene, dict):
+                        continue
+                    text = str(scene.get("narration") or "").strip()
+                    if not text:
+                        continue
+                    duration_sec = float(scene.get("duration_sec") or 0.0)
+                    if duration_sec <= 0:
+                        duration_sec = 3.0
+                    synthesized.append(
+                        {
+                            "text": text,
+                            "duration_sec": duration_sec,
+                            "scene_id": scene.get("scene_id"),
+                            "shot_id": scene.get("shot_id"),
+                        }
+                    )
+                items_source = synthesized
+
         items: List[Dict[str, Any]] = []
         current_start = 0.0
         srt_lines: List[str] = []
@@ -746,6 +771,86 @@ class RunnerAudioRenderSupport:
         # ========= 合成 final =========
         final_video_path = video_run_dir / "final.mp4"
 
+        # ====== 若字幕时间轴超过视频时长：按比例压缩到 base_video 实际时长（silent/有声都适用）======
+        def _ffprobe_duration_sec(video_path: Path) -> float:
+            try:
+                out = subprocess.check_output(
+                    [
+                        "ffprobe",
+                        "-hide_banner",
+                        "-loglevel",
+                        "error",
+                        "-show_entries",
+                        "format=duration",
+                        "-of",
+                        "default=noprint_wrappers=1:nokey=1",
+                        str(video_path),
+                    ],
+                    text=True,
+                ).strip()
+                return float(out) if out else 0.0
+            except Exception:
+                return 0.0
+
+        def _parse_ts(ts: str) -> float:
+            hh, mm, rest = ts.split(":")
+            ss, ms = rest.split(",")
+            return int(hh) * 3600 + int(mm) * 60 + int(ss) + int(ms) / 1000.0
+
+        def _fmt_ts(sec: float) -> str:
+            if sec < 0:
+                sec = 0.0
+            ms = int(round((sec - int(sec)) * 1000))
+            total = int(sec)
+            hh = total // 3600
+            mm = (total % 3600) // 60
+            ss = total % 60
+            return f"{hh:02d}:{mm:02d}:{ss:02d},{ms:03d}"
+
+        def _rescale_srt_to_duration(srt_path: Path, target_duration: float) -> None:
+            if target_duration <= 0:
+                return
+            if not srt_path.exists():
+                return
+            txt = srt_path.read_text(encoding="utf-8", errors="ignore")
+            if not txt.strip():
+                return
+
+            lines = txt.splitlines()
+            last_end = 0.0
+            for line in lines:
+                if "-->" in line:
+                    try:
+                        end = line.split("-->")[1].strip()
+                        last_end = max(last_end, _parse_ts(end))
+                    except Exception:
+                        pass
+
+            # 已经不超过视频时长就不处理
+            if last_end <= 0 or last_end <= target_duration + 0.01:
+                return
+
+            scale = target_duration / last_end
+
+            out_lines = []
+            for line in lines:
+                if "-->" not in line:
+                    out_lines.append(line)
+                    continue
+                try:
+                    a, b = line.split("-->")
+                    start = _parse_ts(a.strip()) * scale
+                    end = _parse_ts(b.strip()) * scale
+                    if end <= start:
+                        end = start + 0.2
+                    out_lines.append(f"{_fmt_ts(start)} --> {_fmt_ts(end)}")
+                except Exception:
+                    out_lines.append(line)
+
+            srt_path.write_text("\n".join(out_lines).rstrip() + "\n", encoding="utf-8")
+
+        video_duration = _ffprobe_duration_sec(base_video_path)
+        _rescale_srt_to_duration(subtitle_path, video_duration)
         if has_audio and merged_audio_path:
             escaped_subtitle_path = (
                 str(subtitle_path)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -188,8 +188,6 @@ type ReviewPlaceholderItem = {
   state: 'waiting' | 'refreshing' | 'done'
 }
 
-type RenderMode = 'auto' | 'manual'
-const renderMode = ref<RenderMode>('auto')
 const userHasInteractedWithImages = ref(false)
 
 const DEFAULT_WORKFLOW_FORM: WorkflowRunFormState = {
@@ -220,6 +218,8 @@ const DEFAULT_WORKFLOW_FORM: WorkflowRunFormState = {
   secondaryCharacterSpecies: '',
   secondaryCharacterVisualTraits: '',
   secondaryCharacterForbiddenTraits: '',
+  renderMode: 'auto',
+  audioEnabled: true,
 }
 
 const STEP_OPTIONS: Array<{ label: string; value: StepName }> = [
@@ -281,6 +281,14 @@ function pushRecentFinalVideoUrl(url: string) {
 }
 const finalVideoRendering = ref(false)
 const workflowForm = ref<WorkflowRunFormState>({ ...DEFAULT_WORKFLOW_FORM })
+function onUpdateFormState(next: WorkflowRunFormState) {
+  console.log('[parent] onUpdateFormState audioEnabled=', next.audioEnabled, 'voiceoverEnabled=', next.voiceoverEnabled)
+  workflowForm.value = next
+}
+
+function onUpdateSelectedSteps(next: StepName[]) {
+  selectedSteps.value = next
+}
 const characterCandidatesText = ref('')
 const characterManifestText = ref('')
 
@@ -325,11 +333,13 @@ const isWorkflowReadyForRender = computed(() => {
   const scenes = Array.isArray(storyboard?.scenes) ? storyboard.scenes : []
   const imageAssetList = Array.isArray(imageAssets?.assets) ? imageAssets.assets : []
   const audioItems = Array.isArray(audioSegments?.items) ? audioSegments.items : []
+  const audioEnabled = audioSegments?.enabled === true
+  const audioOk = !audioEnabled || audioItems.length > 0
 
   return (
     scenes.length > 0 &&
     imageAssetList.length >= scenes.length &&
-    audioItems.length > 0
+    audioOk
   )
 })
 
@@ -351,7 +361,7 @@ watch(
   () => isWorkflowReadyForRender.value,
   (ready) => {
     if (!ready) return
-    if (renderMode.value !== 'auto') return
+    if (workflowForm.value.renderMode !== 'auto') return
     if (!currentWorkflowResponse.value) return
 
     renderFinalVideoIfReady(currentWorkflowResponse.value)
@@ -913,7 +923,6 @@ async function selectImageAsset(sceneId: string, assetRef: ImageAssetRef) {
 
     applyWorkflowResponse(mergedResponse)
     userHasInteractedWithImages.value = true
-    renderMode.value = 'manual'
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : '手动选图请求失败'
   } finally {
@@ -1148,7 +1157,8 @@ async function runWorkflow() {
   activeTab.value = 'review'
 
   const form = workflowForm.value
-
+  console.log('RENDER MODE SENT', form.renderMode)
+  console.log('AUDIO ENABLED SENT', form.audioEnabled)
   // ---- characters: manual override (when enabled) ----
   const manualCharacters: StructuredCharacterInput[] = form.structuredCharactersEnabled
     ? [
@@ -1276,13 +1286,15 @@ async function runWorkflow() {
     visual_style: form.visualStyle,
     character_style: form.characterStyle,
     voice_style: form.voiceStyle,
-    voiceover_enabled: form.voiceoverEnabled,
+    voiceover_enabled: form.audioEnabled ? form.voiceoverEnabled : false,
     voice_mode: form.voiceMode,
     duration_sec: form.durationSec,
     language: form.language,
     subtitle_enabled: form.subtitleEnabled,
     video_provider: form.videoProvider,
     output_mode: form.outputMode,
+    render_mode: form.renderMode,
+    audio_enabled: form.audioEnabled,
   }
 
   if (form.voiceMode === 'multi') {
@@ -1320,11 +1332,17 @@ async function runWorkflow() {
     }
   }
 
+  const stepsSet = new Set(selectedSteps.value)
+
+  if (form.subtitleEnabled) {
+    stepsSet.add('subtitles')
+  }
+
   const payload = {
     workflow_id: 'storybook-demo',
     session_id: sessionId,
     input: inputPayload,
-    steps: selectedSteps.value.map((name) => ({ name })),
+    steps: Array.from(stepsSet).map((name) => ({ name })),
   }
   currentWorkflowPayload.value = payload as WorkflowRunPayload
 
@@ -1444,8 +1462,8 @@ async function runWorkflow() {
           :form-state="workflowForm"
           :selected-steps="selectedSteps"
           :step-options="STEP_OPTIONS"
-          @update:form-state="workflowForm = $event"
-          @update:selected-steps="selectedSteps = $event"
+          @update:form-state="onUpdateFormState"
+          @update:selected-steps="onUpdateSelectedSteps"
           @run="runWorkflow"
         />
       </section>
@@ -1454,24 +1472,8 @@ async function runWorkflow() {
           <section class="result-panel final-video-hero">
             <div class="render-mode-switch">
               <span class="label">Render Mode:</span>
-              <label class="mode-option">
-                <input
-                  type="radio"
-                  value="auto"
-                  v-model="renderMode"
-                />
-                Auto
-              </label>
-
-              <label class="mode-option">
-                <input
-                  type="radio"
-                  value="manual"
-                  v-model="renderMode"
-                />
-                Manual
-              </label>
-            </div>    
+              <span class="value">{{ workflowForm.renderMode }}</span>
+            </div>   
             <FinalVideoPanel
               :final-video-url="finalVideoUrl"
               :final-video-text="finalVideoText"
@@ -1479,11 +1481,11 @@ async function runWorkflow() {
               :render-in-flight="finalVideoRenderInFlight"
               :loading="loading || refreshingImageReview || finalVideoRenderInFlight"
               @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
-              :show-render-button="renderMode === 'auto'"
+              :show-render-button="workflowForm.renderMode === 'auto'"
             />
             <!-- Manual 主操作按钮 -->
             <div
-              v-if="renderMode === 'manual'"
+              v-if="workflowForm.renderMode === 'manual'"
               class="manual-render-wrapper"
             >
               <button

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -40,6 +40,8 @@ export type WorkflowRunFormState = {
   secondaryCharacterSpecies: string
   secondaryCharacterVisualTraits: string
   secondaryCharacterForbiddenTraits: string
+  renderMode: 'auto' | 'manual'
+  audioEnabled: boolean
 }
 
 const props = defineProps<{
@@ -145,7 +147,6 @@ function applyPresetSingle() {
   console.log('[preset] single clicked')
   emit('update:formState', {
     ...props.formState,
-    voiceoverEnabled: true,
     subtitleEnabled: true,
     voiceMode: 'single',
 
@@ -170,7 +171,6 @@ function applyPresetCharacter() {
   console.log('[preset] character clicked')
   emit('update:formState', {
     ...props.formState,
-    voiceoverEnabled: true,
     subtitleEnabled: true,
     voiceMode: 'character',
 
@@ -191,7 +191,6 @@ function applyPresetMulti() {
   console.log('[preset] multi clicked')
   emit('update:formState', {
     ...props.formState,
-    voiceoverEnabled: true,
     subtitleEnabled: true,
     voiceMode: 'multi',
 
@@ -396,13 +395,16 @@ function getTopicManualMismatchWarning(): string {
 
         <label class="checkbox-field">
           <input
-            :checked="formState.voiceoverEnabled"
+            :checked="formState.audioEnabled ? formState.voiceoverEnabled : false"
+            :disabled="!formState.audioEnabled"
             type="checkbox"
             @change="
-              updateFormState(
-                'voiceoverEnabled',
-                ($event.target as HTMLInputElement).checked
-              )
+              emit('update:formState', {
+                ...props.formState,
+                voiceoverEnabled: props.formState.audioEnabled
+                  ? ($event.target as HTMLInputElement).checked
+                  : false,
+              })
             "
           />
           <span>Enable Voiceover</span>
@@ -420,7 +422,50 @@ function getTopicManualMismatchWarning(): string {
             <option value="multi">multi · 亲子双人轮流</option>
             <option value="character">character · 角色配音</option>
           </select>
+          <div class="mode-config">
+            <div class="config-label">Render Mode</div>
 
+            <label>
+              <input
+                type="radio"
+                value="auto"
+                :checked="formState.renderMode === 'auto'"
+                @change="updateFormState('renderMode', 'auto')"
+              />
+              Auto
+            </label>
+
+            <label>
+              <input
+                type="radio"
+                value="manual"
+                :checked="formState.renderMode === 'manual'"
+                @change="updateFormState('renderMode', 'manual')"
+              />
+              Manual
+            </label>
+          </div>
+
+          <div class="audio-config">
+            <label>
+              <input
+                type="checkbox"
+                :checked="formState.audioEnabled"
+                @change="
+                  (e) => {
+                    const checked = (e.target as HTMLInputElement).checked
+                    emit('update:formState', {
+                      ...props.formState,
+                      audioEnabled: checked,
+                      // 你同意的语义：关音频 = 关配音
+                      voiceoverEnabled: checked ? true : false,
+                    })
+                  }
+                "
+              />
+              Enable Audio
+            </label>
+          </div>
           <div class="quickStart">
             <div class="quickStartTitle">Quick Start · 快捷模板</div>
             <p v-if="getTopicManualMismatchWarning()" class="warn">

--- a/scripts/acceptance_silent_audio_subtitle.py
+++ b/scripts/acceptance_silent_audio_subtitle.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VIDEO_ROOT = REPO_ROOT / "assets" / "mock" / "video"
+
+
+@dataclass
+class CaseConfig:
+    name: str
+    audio_enabled: bool
+    voiceover_enabled: bool
+    subtitle_enabled: bool
+    render_mode: str  # "auto" or "manual"
+
+
+def _run(
+    cmd: List[str], *, cwd: Optional[Path] = None, check: bool = True
+) -> subprocess.CompletedProcess:
+    p = subprocess.run(
+        cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True
+    )
+    if check and p.returncode != 0:
+        raise RuntimeError(
+            "Command failed:\n"
+            f"  cmd: {' '.join(cmd)}\n"
+            f"  code: {p.returncode}\n"
+            f"  stdout:\n{p.stdout}\n"
+            f"  stderr:\n{p.stderr}\n"
+        )
+    return p
+
+
+def _curl_json(
+    api_base: str, path: str, payload: Dict[str, Any], timeout_sec: int = 180
+) -> Dict[str, Any]:
+    tmp = Path("/tmp/_acceptance_req.json")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    cmd = [
+        "curl",
+        "-sS",
+        "--max-time",
+        str(timeout_sec),
+        "-X",
+        "POST",
+        f"{api_base}{path}",
+        "-H",
+        "Content-Type: application/json",
+        "--data",
+        f"@{str(tmp)}",
+    ]
+    p = _run(cmd, check=False)
+    raw = (p.stdout or "").strip()
+    if p.returncode != 0:
+        raise RuntimeError(
+            f"curl failed ({p.returncode}):\n{p.stderr}\nstdout:\n{p.stdout}"
+        )
+    try:
+        return json.loads(raw) if raw else {}
+    except Exception:
+        raise RuntimeError(f"Non-JSON response from {path}:\n{raw[:2000]}")
+
+
+def _extract_final_video(resp: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Support multiple shapes:
+      A) {"final_video": {...}}
+      B) {"outputs": {"final_video": {...}}}
+      C) {"finalVideo": {...}}
+      D) {"outputs": {"finalVideo": {...}}}
+    """
+    if isinstance(resp.get("final_video"), dict):
+        return resp["final_video"]  # type: ignore[return-value]
+    if isinstance(resp.get("finalVideo"), dict):
+        return resp["finalVideo"]  # type: ignore[return-value]
+
+    outs = resp.get("outputs")
+    if isinstance(outs, dict):
+        if isinstance(outs.get("final_video"), dict):
+            return outs["final_video"]  # type: ignore[return-value]
+        if isinstance(outs.get("finalVideo"), dict):
+            return outs["finalVideo"]  # type: ignore[return-value]
+
+    return {}
+
+
+def _ffprobe_format_duration(video_path: Path) -> float:
+    cmd = [
+        "ffprobe",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-show_format",
+        "-of",
+        "json",
+        str(video_path),
+    ]
+    p = _run(cmd, check=True)
+    data = json.loads(p.stdout or "{}")
+    fmt = data.get("format", {}) or {}
+    try:
+        return float(fmt.get("duration") or 0.0)
+    except Exception:
+        return 0.0
+
+
+def _ffprobe_audio_stream_count(video_path: Path) -> int:
+    cmd = [
+        "ffprobe",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-select_streams",
+        "a",
+        "-show_streams",
+        "-of",
+        "json",
+        str(video_path),
+    ]
+    p = _run(cmd, check=True)
+    data = json.loads(p.stdout or "{}")
+    streams = data.get("streams", []) or []
+    return len(streams)
+
+
+_SRT_TS_RE = re.compile(
+    r"(\d\d):(\d\d):(\d\d),(\d\d\d)\s*-->\s*(\d\d):(\d\d):(\d\d),(\d\d\d)"
+)
+
+
+def _srt_last_end_sec(srt_text: str) -> float:
+    last = 0.0
+    for m in _SRT_TS_RE.finditer(srt_text):
+        eh, em, es, ems = m.group(5), m.group(6), m.group(7), m.group(8)
+        sec = int(eh) * 3600 + int(em) * 60 + int(es) + int(ems) / 1000.0
+        if sec > last:
+            last = sec
+    return last
+
+
+def _assert(cond: bool, msg: str) -> None:
+    if not cond:
+        raise AssertionError(msg)
+
+
+def _build_run_payload(case: CaseConfig, session_id: str, topic: str) -> Dict[str, Any]:
+    steps = [
+        {"name": "story"},
+        {"name": "storyboard"},
+        {"name": "image_prompts"},
+        {"name": "image_assets"},
+        {"name": "video_prompts"},
+    ]
+
+    # ✅ 只有在需要“有声+旁白”的 case 才跑音频链路
+    if case.audio_enabled and case.voiceover_enabled:
+        steps += [
+            {"name": "dialogue_script"},
+            {"name": "audio_segments"},
+            {"name": "narration"},
+        ]
+
+    # subtitles：两种 case 都要（silent 也可以有字幕）
+    if case.subtitle_enabled:
+        steps.append({"name": "subtitles"})
+
+    steps += [
+        {"name": "render_plan"},
+        {"name": "final_video"},
+    ]
+
+    return {
+        "workflow_id": "storybook-demo",
+        "session_id": session_id,
+        "input": {
+            "topic": topic,
+            "render_mode": case.render_mode,
+            "audio_enabled": case.audio_enabled,
+            "voiceover_enabled": case.voiceover_enabled,
+            "subtitle_enabled": case.subtitle_enabled,
+            "video_provider": "mock",
+            "language": "zh-CN",
+            "audience": "children",
+            "tone": "warm",
+            "visual_style": "storybook",
+            "character_style": "animal",
+            "voice_style": "warm_female",
+            "voice_mode": "single",
+            "duration_sec": 60,
+            "output_mode": "full_video",
+            "structured_characters_enabled": False,
+            "character_ids": [],
+        },
+        "steps": steps,
+    }
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _ensure_image_assets(
+    api_base: str, run_data: Dict[str, Any], workflow_input: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    image_assets is deferred in runner; refresh may return pending/retrying/0 assets.
+    We poll refresh until assets are ready (asset_count >= scene_count) or timeout.
+    """
+    run_id = str(run_data["run_id"])
+    _ensure_dir(REPO_ROOT / "assets" / "mock" / "image" / run_id)
+
+    storyboard = (run_data.get("outputs", {}) or {}).get("storyboard", {}) or {}
+    scenes = storyboard.get("scenes") or []
+    scene_count = len(scenes) if isinstance(scenes, list) else 0
+    min_expected = max(1, scene_count)
+
+    refresh_req = {
+        "workflow_id": run_data.get("workflow_id") or "storybook-demo",
+        "session_id": run_data.get("session_id"),
+        "run_id": run_id,
+        "storyboard": storyboard,
+        # ✅ IMPORTANT: must pass workflow_input with topic
+        "workflow_input": workflow_input,
+        "image_review": (run_data.get("outputs", {}) or {}).get("image_review", {})
+        or {},
+        "video_provider": workflow_input.get("video_provider", "mock"),
+    }
+
+    max_attempts = int(os.environ.get("ACCEPTANCE_REFRESH_ATTEMPTS", "12"))
+    sleep_sec = float(os.environ.get("ACCEPTANCE_REFRESH_SLEEP_SEC", "5"))
+
+    last_assets: Dict[str, Any] = {}
+    for attempt in range(1, max_attempts + 1):
+        resp = _curl_json(
+            api_base, "/v1/image-review/refresh", refresh_req, timeout_sec=300
+        )
+        assets = resp.get("image_assets", {}) or {}
+        last_assets = assets
+
+        status = str(assets.get("status") or "").strip().lower()
+        asset_count = int(assets.get("asset_count") or 0)
+
+        print(
+            f"refresh attempt {attempt}/{max_attempts}: status={status or 'n/a'} asset_count={asset_count}/{min_expected}"
+        )
+
+        if asset_count >= min_expected and status not in {"pending", "retrying"}:
+            return assets
+
+        time.sleep(sleep_sec)
+
+    raise AssertionError(
+        f"image_assets not generated after {max_attempts} attempts "
+        f"(expected>={min_expected}, got={int(last_assets.get('asset_count') or 0)}, status={last_assets.get('status')})"
+    )
+
+
+def _render_final(
+    api_base: str,
+    run_data: Dict[str, Any],
+    workflow_input: Dict[str, Any],
+    image_assets: Dict[str, Any],
+) -> Dict[str, Any]:
+    subtitles = (run_data.get("outputs", {}) or {}).get("subtitles", {}) or {}
+    render_req = {
+        "workflow_id": run_data.get("workflow_id") or "storybook-demo",
+        "session_id": run_data.get("session_id"),
+        "run_id": str(run_data["run_id"]),
+        # ✅ IMPORTANT: must pass workflow_input with topic
+        "workflow_input": workflow_input,
+        "image_assets": image_assets,
+        "audio_segments": (run_data.get("outputs", {}) or {}).get("audio_segments", {})
+        or {},
+        "subtitles": subtitles if isinstance(subtitles, dict) else {"srt_preview": ""},
+    }
+    resp = _curl_json(api_base, "/v1/final-video/render", render_req, timeout_sec=300)
+
+    fv = _extract_final_video(resp)
+    if not fv:
+        raise AssertionError(
+            "final_video missing in /v1/final-video/render response.\n"
+            f"response keys={list(resp.keys())}\n"
+            f"response preview:\n{json.dumps(resp, ensure_ascii=False, indent=2)[:2000]}"
+        )
+    return fv
+
+
+def _case_run(api_base: str, case: CaseConfig, idx: int) -> None:
+    session_id = f"acceptance-{case.name}-{int(time.time())}-{idx}"
+    topic = f"acceptance {case.name} audio={case.audio_enabled} voiceover={case.voiceover_enabled}"
+    payload = _build_run_payload(case, session_id, topic)
+    workflow_input = payload["input"]  # ✅ keep original input (contains topic)
+
+    print(f"\n=== RUN CASE: {case.name} ===")
+    run_data = _curl_json(api_base, "/v1/workflow/run", payload, timeout_sec=300)
+    run_id = str(run_data.get("run_id") or "")
+    _assert(run_id.startswith("run_"), f"invalid run_id: {run_id}")
+    print("run_id:", run_id)
+
+    image_assets = _ensure_image_assets(api_base, run_data, workflow_input)
+    final_video = _render_final(api_base, run_data, workflow_input, image_assets)
+
+    status = str(final_video.get("status") or "").lower()
+    _assert(
+        status == "generated",
+        f"final_video not generated (status={status}, final_video={final_video})",
+    )
+
+    video_dir = VIDEO_ROOT / run_id
+    mp4 = video_dir / "final.mp4"
+    srt = video_dir / "subtitles.srt"
+
+    _assert(mp4.exists(), f"final.mp4 missing: {mp4}")
+    _assert(mp4.stat().st_size > 50_000, f"final.mp4 too small: {mp4.stat().st_size}")
+
+    audio_cnt = _ffprobe_audio_stream_count(mp4)
+    if case.audio_enabled and case.voiceover_enabled:
+        _assert(audio_cnt >= 1, f"expected audio stream, got {audio_cnt}")
+    else:
+        _assert(audio_cnt == 0, f"expected NO audio stream, got {audio_cnt}")
+
+    if case.subtitle_enabled:
+        _assert(srt.exists(), f"subtitles.srt missing: {srt}")
+        srt_txt = srt.read_text(encoding="utf-8", errors="ignore")
+        _assert(len(srt_txt.strip()) > 0, "subtitles.srt empty")
+
+        dur = _ffprobe_format_duration(mp4)
+        last_end = _srt_last_end_sec(srt_txt)
+        _assert(
+            last_end <= dur + 0.35,
+            f"SRT end time exceeds video duration (last_end={last_end:.3f}, dur={dur:.3f})",
+        )
+
+    print(
+        "OK:",
+        f"audio_streams={audio_cnt}",
+        f"subtitles={'on' if case.subtitle_enabled else 'off'}",
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--api-base", default=os.environ.get("API_BASE_URL", "http://127.0.0.1:8004")
+    )
+    args = ap.parse_args()
+
+    api_base = str(args.api_base).rstrip("/")
+    cases = [
+        CaseConfig(
+            name="silent_subtitles",
+            audio_enabled=False,
+            voiceover_enabled=False,
+            subtitle_enabled=True,
+            render_mode="auto",
+        ),
+        CaseConfig(
+            name="audio_voiceover_subtitles",
+            audio_enabled=True,
+            voiceover_enabled=True,
+            subtitle_enabled=True,
+            render_mode="auto",
+        ),
+    ]
+
+    try:
+        for i, case in enumerate(cases, 1):
+            _case_run(api_base, case, i)
+        print("\nALL ACCEPTANCE CHECKS PASSED ✅")
+        return 0
+    except Exception as e:
+        print("\nACCEPTANCE FAILED ❌")
+        print(str(e))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- - - Summary
   This PR fixes multiple regressions and edge cases across the Project4 workflow:
    
  - Make render mode a single source of truth (Run config → Review display) to prevent manual/auto mismatches.
      - Stabilize audio/voiceover toggles to avoid invalid combinations and “audio enabled but no voiceover” states.
  - Support subtitles in silent runs and ensure subtitle timing fits the actual video duration.
      - Add an end-to-end acceptance script to reduce manual verification cost.
    
      Changes
       Backend
    
      - Add `render_mode` and `audio_enabled` to `WorkflowInput` (with defaults) so backend understands the new run config fields.
  - Enable subtitles generation in silent runs (no audio segments) via a storyboard-based fallback.
      - Fit SRT timing to the actual mp4 duration so subtitles don’t “freeze” on the first line when video is short.

      Frontend

      - Render mode: remove the second renderMode state on the Review page; Review is display-only and follows the Run config (`workflowForm.renderMode`).
  - Audio/voiceover gating:
        - Audio OFF → voiceover forced OFF + disabled
        - Audio ON → voiceover defaults ON (user can disable)
        - Payload safety: `voiceover_enabled = audio_enabled ? voiceover_enabled : false`

      Tests

      - Add 
    
    ```
        scripts/acceptance_silent_audio_subtitle.py
    ```
    
     E2E checks:
    
        - silent + subtitles: mp4 has no audio stream, subtitles exist, SRT end ≤ video duration
        - audio + voiceover + subtitles: mp4 has audio stream, subtitles exist, SRT end ≤ video duration
        - Includes refresh polling for deferred image_assets and passes `workflow_input` to refresh/render.
    
      Commits
    
      - 3c88bcc: fix: subtitles support for silent runs and fit srt to video duration
      - 53b29ca: fix: use run config as single source of truth for render mode
      - 48f12fd: fix: enforce audio/voiceover dependency and prevent invalid payload
      - 4f2fd60: test: add acceptance for silent/audio + subtitles (E2E)
    
      How to Test
    
      1. Start backend (port 8004) and frontend (if needed).
      2. Run E2E acceptance:
    
      ```
      python scripts/acceptance_silent_audio_subtitle.py
      ```
    
      Expected output ends with:
    
      ```
      ALL ACCEPTANCE CHECKS PASSED ✅
      ```
    
      Manual sanity (optional)
    
      - Run tab: choose Manual → Review shows “manual” and exposes the purple “Generate Final Video” button; no auto-render occurs until clicking.
      - Run tab: choose Auto → Review auto-renders after image refresh finishes.
      - Silent mode: no audio track, subtitles still present and update over time.
    
      Follow-ups (UI)
       Layout cleanup for Run tab (control grouping/spacing) will be handled in a separate PR to avoid mixing behavior changes with styling.