### PR TITLE
fix: stabilize image refresh and align silent final video duration

### DIFF
--- a/app/services/image_provider_queue.py
+++ b/app/services/image_provider_queue.py
@@ -157,6 +157,8 @@ class ImageProviderQueue:
                         "relative_path": primary_ref["relative_path"],
                         "public_url": primary_ref["public_url"],
                         "mime_type": primary_ref["mime_type"],
+                        "duration_sec": primary_ref.get("duration_sec"),
+                        "duration_estimate_sec": primary_ref.get("duration_estimate_sec"),
                         "status": "generated",
                         "candidate_asset_refs": candidate_asset_refs,
                     }
@@ -201,6 +203,8 @@ class ImageProviderQueue:
                         "relative_path": primary_ref["relative_path"],
                         "public_url": primary_ref["public_url"],
                         "mime_type": primary_ref["mime_type"],
+                        "duration_sec": primary_ref.get("duration_sec"),
+                        "duration_estimate_sec": primary_ref.get("duration_estimate_sec"),
                         "status": "generated",
                         "candidate_asset_refs": candidate_asset_refs,
                     }
@@ -280,6 +284,7 @@ class ImageProviderQueue:
             )
 
             image_bytes = self._generate_candidate_bytes(provider=provider, task=task)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(bytes(image_bytes))
 
             candidate_asset_refs.append(
@@ -291,6 +296,8 @@ class ImageProviderQueue:
                     "public_url": task.public_url,
                     "mime_type": "image/png",
                     "provider": provider,
+                    "duration_sec": candidate_scene.get("duration_sec"),
+                    "duration_estimate_sec": candidate_scene.get("duration_estimate_sec"),
                 }
             )
 
@@ -346,6 +353,7 @@ class ImageProviderQueue:
             )
 
             image_bytes = self._generate_candidate_bytes(provider=provider, task=task)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(bytes(image_bytes))
 
             candidate_asset_refs.append(
@@ -356,6 +364,8 @@ class ImageProviderQueue:
                     "public_url": task.public_url,
                     "mime_type": "image/png",
                     "provider": provider,
+                    "duration_sec": candidate_scene.get("duration_sec"),
+                    "duration_estimate_sec": candidate_scene.get("duration_estimate_sec"),
                 }
             )
 

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -641,8 +641,15 @@ class RunnerAudioRenderSupport:
                 if duration_sec <= 0:
                     duration_sec = float(item.get("duration_estimate_sec") or 3.0)
             else:
-                # 无音频时默认每张 3 秒
-                duration_sec = 3.0
+                duration_sec = float(image_asset.get("duration_sec") or 0.0)
+                if duration_sec <= 0:
+                    duration_sec = float(
+                        image_asset.get("duration_estimate_sec") or 0.0
+                    )
+                if duration_sec <= 0:
+                    duration_sec = float(ctx.input.duration_sec) / max(
+                        len(image_assets_list), 1
+                    )
 
             escaped_image_path = str(image_path).replace("'", "'\\''")
             concat_lines.append(f"file '{escaped_image_path}'")
@@ -672,11 +679,21 @@ class RunnerAudioRenderSupport:
 
         # ========= 计算总时长 =========
         total_duration_sec = 0.0
-        for item in audio_item_list:
-            duration_sec = float(item.get("duration_sec") or 0.0)
-            if duration_sec <= 0:
-                duration_sec = float(item.get("duration_estimate_sec") or 0.0)
-            total_duration_sec += max(duration_sec, 0.0)
+        if audio_item_list:
+            for item in audio_item_list:
+                duration_sec = float(item.get("duration_sec") or 0.0)
+                if duration_sec <= 0:
+                    duration_sec = float(item.get("duration_estimate_sec") or 0.0)
+                total_duration_sec += max(duration_sec, 0.0)
+        else:
+            for item in image_asset_list:
+                duration_sec = float(item.get("duration_sec") or 0.0)
+                if duration_sec <= 0:
+                    duration_sec = float(item.get("duration_estimate_sec") or 0.0)
+                total_duration_sec += max(duration_sec, 0.0)
+
+            if total_duration_sec <= 0:
+                total_duration_sec = float(ctx.input.duration_sec)
 
         video_run_dir = self._runner._ensure_video_run_dir(ctx.run_id)
 
@@ -868,6 +885,8 @@ class RunnerAudioRenderSupport:
                     str(base_video_path),
                     "-i",
                     str(merged_audio_path),
+                    "-t",
+                    f"{total_duration_sec:.3f}",
                     "-vf",
                     subtitle_filter,
                     "-c:v",
@@ -898,6 +917,8 @@ class RunnerAudioRenderSupport:
                         "-y",
                         "-i",
                         str(base_video_path),
+                        "-t",
+                        f"{total_duration_sec:.3f}",
                         "-vf",
                         subtitle_filter,
                         "-c:v",

--- a/app/services/runner_image_selection_support.py
+++ b/app/services/runner_image_selection_support.py
@@ -37,6 +37,10 @@ class RunnerImageSelectionSupport:
                         "relative_path": selected_asset_ref.get("relative_path"),
                         "public_url": selected_asset_ref.get("public_url"),
                         "mime_type": selected_asset_ref.get("mime_type"),
+                        "duration_sec": item.get("duration_sec")
+                        or selected_asset_ref.get("duration_sec"),
+                        "duration_estimate_sec": item.get("duration_estimate_sec")
+                        or selected_asset_ref.get("duration_estimate_sec"),
                         "selected_asset_ref": dict(selected_asset_ref),
                         "status": "generated",
                         "candidate_asset_refs": item.get("candidate_asset_refs") or [],


### PR DESCRIPTION
## Summary

This PR stabilizes the image refresh flow and fixes silent final video duration alignment.

## Changes

- Create image output directories before writing refreshed candidate images.
- Preserve `duration_sec` metadata through image candidate refs, selected assets, and final image assets.
- Fix silent video rendering so it no longer falls back to a fixed 3 seconds per image.
- Use image asset duration metadata, with `ctx.input.duration_sec / image_count` as fallback.
- Trim final ffmpeg output to `total_duration_sec` to avoid extra concat tail duration.

## Validation

- Python compile passed for updated backend modules.
- `/v1/image-review/refresh` succeeds and returns 12 image assets.
- Refreshed assets now include per-scene duration:

  ```text
  asset durations: [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]