### PR TITLE
fix: trigger final video render after image refresh

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1119,6 +1119,10 @@ async function refreshImageReview() {
     sceneRefreshQueue.value = []
     refreshingImageReview.value = false
   }
+
+  if (workflowForm.value.renderMode === 'auto' && currentWorkflowResponse.value) {
+    void renderFinalVideoIfReady(currentWorkflowResponse.value)
+  }
 }
 async function runWorkflow() {
   clearImageReviewAutoRefreshTimer()


### PR DESCRIPTION
## Summary

This PR ensures that auto render mode continues to final video generation after image refresh completes.

## Changes

- Trigger `renderFinalVideoIfReady()` after `refreshImageReview()` finishes.
- Keep the behavior scoped to `renderMode === 'auto'`.
- Preserve existing safeguards inside `renderFinalVideoIfReady()` to avoid duplicate rendering.

## Validation

- Frontend production build passed.
- Verified that image refresh requests complete successfully.
- Verified that `/v1/final-video/render` is automatically called after refreshed images are ready.
- Verified that the final video appears in the Final Video panel without manually clicking render.

## Notes

This PR only improves the frontend auto refresh → final render flow.

Known backend follow-up:
- Duration-aware story generation and audio alignment need a separate PR.
- Current voiced mode may still produce shorter audio than the selected target duration.