### PR TITLE
fix: align image review refresh contract

### DIFF
--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -228,7 +228,7 @@ class ImageReviewRefreshRequest(BaseModel):
     # 可选传入角色 manifest；老客户端可能不传，endpoint 用 getattr 兜底
     character_manifest: Optional[Dict] = None
     # 可选传入 image_prompts（多角色刷新闭环场景）；老客户端可能不传，endpoint 用 getattr 兜底
-    image_prompts: Optional[List[Dict]] = None
+    image_prompts: Optional[Dict[str, Any] | List[Dict[str, Any]]] = None
     video_provider: str = Field(default="mock")
 
 

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1269,6 +1269,8 @@ class WorkflowRunner:
         storyboard: Dict[str, Any],
         workflow_input: Dict[str, Any],
         image_review: Dict[str, Any],
+        character_manifest: Optional[Dict[str, Any]] = None,
+        image_prompts: Optional[Any] = None,
         video_provider: str = "mock",
     ) -> Dict[str, Any]:
         normalized_run_id = str(run_id or "").strip()
@@ -1334,9 +1336,23 @@ class WorkflowRunner:
         if stored_sentence_shots:
             outputs["sentence_shots"] = stored_sentence_shots
 
+        explicit_character_manifest = (
+            dict(character_manifest)
+            if isinstance(character_manifest, dict) and character_manifest
+            else {}
+        )
+        stored_character_manifest = stored_context.get("character_manifest") or {}
+        resolved_character_manifest = (
+            explicit_character_manifest or stored_character_manifest
+        )
+        if resolved_character_manifest:
+            outputs["character_manifest"] = resolved_character_manifest
+
+        explicit_image_prompts = self._normalize_image_prompts_payload(image_prompts)
         stored_image_prompts = stored_context.get("image_prompts") or {}
-        if stored_image_prompts:
-            outputs["image_prompts"] = stored_image_prompts
+        resolved_image_prompts = explicit_image_prompts or stored_image_prompts
+        if resolved_image_prompts:
+            outputs["image_prompts"] = resolved_image_prompts
 
         previous_image_review = image_review or stored_context.get("image_review") or {}
         if previous_image_review:
@@ -1373,6 +1389,14 @@ class WorkflowRunner:
             "image_review": updated_image_review,
             "video_prompts": video_prompts,
         }
+
+    @staticmethod
+    def _normalize_image_prompts_payload(image_prompts: Any) -> Dict[str, Any]:
+        if isinstance(image_prompts, dict):
+            return dict(image_prompts)
+        if isinstance(image_prompts, list):
+            return {"prompts": list(image_prompts)}
+        return {}
 
     def _run_story(self, ctx: StepContext, outputs: Dict[str, Any]) -> Dict[str, Any]:
         return self._story_support.run_story(ctx, outputs)

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -77,7 +77,7 @@ make api
 python scripts/acceptance.py
 ```
 
-**当前现象**：
+**修复前现象**：
 
 脚本前几个 samples API 检查通过，但在 `/v1/workflow/run` 后失败：
 
@@ -405,6 +405,8 @@ from app.services.runner import StepContext, WorkflowRunner
 
 **发现日期**：2026-05-22（Step 19 image review refresh-scene 重构时）
 
+**状态**：已修复（2026-05-22）。修复内容：`WorkflowRunner.refresh_image_review(...)` 已接收 `character_manifest` / `image_prompts`，并把 list 形态的 `image_prompts` 归一化为内部使用的 `{"prompts": [...]}`；已补 `scripts/verify_bug003_image_review_refresh_contract.py` 覆盖显式 payload 和 stored context fallback。
+
 **触发条件**：
 
 调用 `app/main.py` 中的 `/v1/image-review/refresh` endpoint。
@@ -427,7 +429,7 @@ _runner.refresh_image_review(
 )
 ```
 
-但当前 `WorkflowRunner.refresh_image_review(...)` 方法签名里没有：
+但修复前 `WorkflowRunner.refresh_image_review(...)` 方法签名里没有：
 
 ```python
 character_manifest
@@ -458,20 +460,20 @@ image_prompts: Optional[List[Dict]] = None
 
 使用 image prompts，修复时也需要确认前后端实际传输结构，避免只修签名不修数据形状。
 
-**建议修复**：
+**已采用修复**：
 
 - 给 `WorkflowRunner.refresh_image_review(...)` 增加可选参数：
 
 ```python
 character_manifest: Optional[Dict[str, Any]] = None
-image_prompts: Optional[Dict[str, Any]] = None
+image_prompts: Optional[Any] = None
 ```
 
 - 在 refresh outputs 构建时，优先使用显式传入值，其次使用 session stored context：
 
 ```python
-stored_character_manifest = dict(character_manifest or {}) or stored_context.get("character_manifest") or {}
-stored_image_prompts = dict(image_prompts or {}) or stored_context.get("image_prompts") or {}
+resolved_character_manifest = explicit_character_manifest or stored_character_manifest
+resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 ```
 
 - 如果前端传的是 list 形态 image prompts，需要在 API 层或 runner 层统一归一化为 `{"prompts": [...]}`。

--- a/scripts/verify_bug003_image_review_refresh_contract.py
+++ b/scripts/verify_bug003_image_review_refresh_contract.py
@@ -1,0 +1,247 @@
+"""Contract verification for image-review refresh payload handoff.
+
+Verifies /v1/image-review/refresh can pass character_manifest and image_prompts
+through WorkflowRunner.refresh_image_review without real image generation.
+
+Usage:
+    python scripts/verify_bug003_image_review_refresh_contract.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.schemas.workflow import ImageReviewRefreshRequest
+from app.services.runner import WorkflowRunner
+
+
+SCENE = {
+    "scene_id": "scene_01",
+    "scene_title": "一起过河",
+    "visual_description": "小兔子和小乌龟站在河边。",
+    "narration": "两个朋友来到河边。",
+    "duration_sec": 10,
+    "characters": [
+        {
+            "character_id": "char_primary_01",
+            "display_name": "小兔子",
+            "role_type": "primary",
+        }
+    ],
+}
+
+ASSET_REF = {
+    "scene_id": "scene_01",
+    "file_name": "scene_01__candidate_a.png",
+    "relative_path": "assets/mock/image/run_verify_bug003/scene_01__candidate_a.png",
+    "public_url": "/assets/mock/image/run_verify_bug003/scene_01__candidate_a.png",
+    "mime_type": "image/png",
+    "provider": "pillow_storybook_renderer",
+}
+
+EXPLICIT_CHARACTER_MANIFEST = {
+    "characters": [
+        {
+            "character_id": "char_primary_01",
+            "display_name": "小兔子",
+            "role_type": "primary",
+        }
+    ]
+}
+
+STORED_CHARACTER_MANIFEST = {
+    "characters": [
+        {
+            "character_id": "char_old",
+            "display_name": "旧角色",
+            "role_type": "primary",
+        }
+    ]
+}
+
+PROMPT_ITEM = {
+    "scene_id": "scene_01",
+    "prompt": "explicit storybook prompt",
+    "characters": SCENE["characters"],
+}
+
+STORED_IMAGE_PROMPTS = {
+    "prompts": [
+        {
+            "scene_id": "scene_01",
+            "prompt": "stored storybook prompt",
+        }
+    ]
+}
+
+
+def make_workflow_input() -> dict:
+    return {
+        "topic": "写一个关于小兔子和小乌龟过河的故事",
+        "duration_sec": 60,
+        "video_provider": "mock",
+    }
+
+
+def make_image_review() -> dict:
+    return {
+        "enabled": True,
+        "mode": "selection_contract",
+        "provider": "pillow_storybook_renderer",
+        "selected_count": 0,
+        "selected_assets": [],
+    }
+
+
+def make_generated_assets(run_id: str) -> dict:
+    return {
+        "enabled": True,
+        "run_id": run_id,
+        "provider": "pillow_storybook_renderer",
+        "asset_count": 1,
+        "assets": [
+            {
+                "scene_id": "scene_01",
+                "scene_title": "一起过河",
+                "characters": SCENE["characters"],
+                "character_ids": ["char_primary_01"],
+                "prompt": "storybook prompt",
+                "selected_asset_ref": dict(ASSET_REF),
+                "file_name": ASSET_REF["file_name"],
+                "relative_path": ASSET_REF["relative_path"],
+                "public_url": ASSET_REF["public_url"],
+                "mime_type": ASSET_REF["mime_type"],
+                "status": "generated",
+                "candidate_asset_refs": [dict(ASSET_REF)],
+                "selection_source": "auto_filter",
+                "selection_reason": "selected by fake adapter",
+                "candidate_scores": [],
+            }
+        ],
+    }
+
+
+def save_stored_context(runner: WorkflowRunner, run_id: str) -> None:
+    runner._session.save_run_context(
+        workflow_id="wf_stored_bug003",
+        session_id="sess_stored_bug003",
+        run_id=run_id,
+        outputs={
+            "storyboard": {"scenes": [SCENE]},
+            "character_manifest": STORED_CHARACTER_MANIFEST,
+            "image_prompts": STORED_IMAGE_PROMPTS,
+            "image_review": make_image_review(),
+        },
+        workflow_input=make_workflow_input(),
+    )
+
+
+def run_refresh(runner: WorkflowRunner, run_id: str, **overrides) -> tuple[dict, dict]:
+    captured = {}
+
+    def fake_run_image_assets(ctx, outputs):
+        captured["ctx"] = ctx
+        captured["outputs"] = outputs
+        return make_generated_assets(run_id)
+
+    runner._run_image_assets = fake_run_image_assets
+    result = runner.refresh_image_review(
+        workflow_id="wf_request_bug003",
+        session_id=None,
+        run_id=run_id,
+        storyboard=overrides.pop("storyboard", {"scenes": [SCENE]}),
+        workflow_input=overrides.pop("workflow_input", make_workflow_input()),
+        image_review=overrides.pop("image_review", make_image_review()),
+        video_provider="mock",
+        **overrides,
+    )
+    return result, captured
+
+
+def verify_explicit_payload_wins() -> None:
+    runner = WorkflowRunner()
+    run_id = "run_verify_bug003_explicit"
+    save_stored_context(runner, run_id)
+
+    result, captured = run_refresh(
+        runner,
+        run_id,
+        character_manifest=EXPLICIT_CHARACTER_MANIFEST,
+        image_prompts=[PROMPT_ITEM],
+    )
+
+    outputs = captured["outputs"]
+    assert captured["ctx"].session_id == "sess_stored_bug003"
+    assert outputs["character_manifest"] == EXPLICIT_CHARACTER_MANIFEST
+    assert outputs["image_prompts"] == {"prompts": [PROMPT_ITEM]}
+    assert result["image_assets"]["asset_count"] == 1
+    assert result["image_review"]["selected_count"] == 1
+    assert isinstance(result["video_prompts"].get("prompts"), list)
+
+    stored_context = runner._session.get_run_context(run_id) or {}
+    assert stored_context["character_manifest"] == EXPLICIT_CHARACTER_MANIFEST
+    assert stored_context["image_prompts"] == {"prompts": [PROMPT_ITEM]}
+
+
+def verify_stored_payload_fallback() -> None:
+    runner = WorkflowRunner()
+    run_id = "run_verify_bug003_stored"
+    save_stored_context(runner, run_id)
+
+    result, captured = run_refresh(
+        runner,
+        run_id,
+        storyboard={},
+        workflow_input={},
+        image_review={},
+        character_manifest=None,
+        image_prompts=None,
+    )
+
+    outputs = captured["outputs"]
+    assert outputs["storyboard"]["scenes"] == [SCENE]
+    assert outputs["character_manifest"] == STORED_CHARACTER_MANIFEST
+    assert outputs["image_prompts"] == STORED_IMAGE_PROMPTS
+    assert result["workflow_id"] == "wf_request_bug003"
+    assert result["session_id"] == "sess_stored_bug003"
+
+
+def verify_request_schema_accepts_prompt_shapes() -> None:
+    base_payload = {
+        "workflow_id": "wf_schema_bug003",
+        "run_id": "run_schema_bug003",
+        "storyboard": {"scenes": [SCENE]},
+        "workflow_input": make_workflow_input(),
+        "image_review": make_image_review(),
+    }
+
+    list_request = ImageReviewRefreshRequest(
+        **base_payload,
+        image_prompts=[PROMPT_ITEM],
+    )
+    assert list_request.image_prompts == [PROMPT_ITEM]
+
+    dict_request = ImageReviewRefreshRequest(
+        **base_payload,
+        image_prompts={"prompts": [PROMPT_ITEM]},
+    )
+    assert dict_request.image_prompts == {"prompts": [PROMPT_ITEM]}
+
+
+def main() -> int:
+    verify_request_schema_accepts_prompt_shapes()
+    verify_explicit_payload_wins()
+    verify_stored_payload_fallback()
+    print("[OK] refresh request schema accepts list and dict prompt payloads")
+    print("[OK] explicit refresh payload is accepted and normalized")
+    print("[OK] stored run context remains the fallback")
+    print("PASS: BUG-003 image-review refresh contract verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Allow `/v1/image-review/refresh` to pass `character_manifest` and `image_prompts` through `WorkflowRunner.refresh_image_review`
- Normalize list-shaped `image_prompts` into the internal `{"prompts": [...]}` format
- Update the post-refactor TODO entry for BUG-003 as fixed
- Add an in-process verification script for the refresh contract

## Validation
- `python scripts/verify_bug003_image_review_refresh_contract.py`
- `python scripts/verify_step19_image_review_refresh_scene.py`
- `python scripts/verify_step18_image_review_selection.py`
- `python -m py_compile app/main.py app/schemas/workflow.py app/services/runner.py scripts/verify_bug003_image_review_refresh_contract.py`
- `make check`
- `git diff --check`