### PR TITLE
test: fix validate candidates import

### DIFF
--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -352,6 +352,8 @@ Please run: make api
 
 **发现日期**：2026-05-22（Step 14 scene render fallback 重构验收时）
 
+**状态**：已修复（2026-05-22）。修复内容：`scripts/validate_candidates_fast.py` 已在脚本内补项目根目录到 `sys.path`，并改为从 `app.services.runner` 导入 `StepContext`；已用 `python scripts/validate_candidates_fast.py` 验证单角色和多角色 candidate JSON 可生成。
+
 **触发条件**：
 
 直接运行会先遇到项目导入路径问题：
@@ -366,7 +368,7 @@ python scripts/validate_candidates_fast.py
 PYTHONPATH=. python scripts/validate_candidates_fast.py
 ```
 
-**当前现象**：
+**修复前现象**：
 
 脚本失败：
 
@@ -382,7 +384,7 @@ ImportError: cannot import name 'StepContext' from 'app.schemas.workflow'
 from app.schemas.workflow import WorkflowInput, StepContext
 ```
 
-**建议修复**：
+**已采用修复**：
 
 - 把脚本导入改为当前结构，例如：
 

--- a/scripts/validate_candidates_fast.py
+++ b/scripts/validate_candidates_fast.py
@@ -3,11 +3,15 @@
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from uuid import uuid4
 
-from app.services.runner import WorkflowRunner
-from app.schemas.workflow import WorkflowInput, StepContext
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.schemas.workflow import WorkflowInput
+from app.services.runner import StepContext, WorkflowRunner
 
 # ---------- 配置 ----------
 duration_sec = 60


### PR DESCRIPTION
## Summary
- Fix `scripts/validate_candidates_fast.py` so it can run directly without manually setting `PYTHONPATH=.`
- Import `StepContext` from `app.services.runner`, where it is currently defined
- Mark TEST-004 as fixed in the post-refactor TODO document

## Validation
- `python scripts/validate_candidates_fast.py`
- `python -m py_compile scripts/validate_candidates_fast.py`
- `git diff --check`

## Notes
- `python scripts/validate_candidates_fast.py` generates local mock outputs under `assets/mock/test_run/`; those files are verification artifacts and are not included in this PR.