### PR TITLE
test: add image provider backend precheck

### DIFF
--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -301,6 +301,8 @@ Failed to fetch
 
 **发现日期**：2026-05-22（Step 14 scene render fallback 重构验收时）
 
+**状态**：已修复（2026-05-22）。修复内容：`scripts/acceptance_image_provider.py` 已在发起 workflow 请求前检查 `GET /health`；后端未启动、健康检查非 200、响应非 JSON 或 `status != ok` 时，会给出明确失败提示和 `Please run: make api` 前置条件。
+
 **触发条件**：
 
 直接运行：
@@ -309,7 +311,7 @@ Failed to fetch
 python scripts/acceptance_image_provider.py --mode pillow
 ```
 
-**当前现象**：
+**修复前现象**：
 
 如果本地 `make api` 没有在 `127.0.0.1:8004` 启动，脚本会直接请求 `/v1/workflow/run` 并失败：
 
@@ -327,7 +329,7 @@ PermissionError: [Errno 1] Operation not permitted
 
 `scripts/acceptance_image_provider.py` 是接口级验收脚本，默认假设后端服务已经启动，但脚本没有在发请求前做 health check / readiness check，也没有给出“请先启动 make api”的友好提示。
 
-**建议修复**：
+**已采用修复**：
 
 - 在脚本开头请求一个轻量健康检查接口，或至少探测 `base_url` 是否可连接。
 - 如果服务未启动，输出明确提示，例如：

--- a/scripts/acceptance_image_provider.py
+++ b/scripts/acceptance_image_provider.py
@@ -18,6 +18,34 @@ def _ok(msg: str) -> None:
     print(f"[OK] {msg}")
 
 
+def _check_backend_ready(base_url: str, timeout: int = 5) -> None:
+    try:
+        response = requests.get(f"{base_url}/health", timeout=timeout)
+    except requests.RequestException as exc:
+        _fail(
+            f"Backend is not running at {base_url}.\n"
+            f"Please run: make api\n"
+            f"Original error: {exc}"
+        )
+
+    if response.status_code != 200:
+        _fail(
+            f"Backend health check failed at {base_url}/health "
+            f"http_status={response.status_code}, body={response.text}\n"
+            f"Please run: make api"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        _fail(f"Backend health response is not JSON: {exc}")
+
+    if body.get("status") != "ok":
+        _fail(f"Backend health response is not ok: {body}")
+
+    _ok("/health")
+
+
 def _post_json(base_url: str, path: str, payload: Dict[str, Any], timeout: int = 20) -> Dict[str, Any]:
     response = requests.post(
         f"{base_url}{path}",
@@ -197,6 +225,7 @@ def main() -> None:
     args = parser.parse_args()
 
     base_url = args.base_url.rstrip("/")
+    _check_backend_ready(base_url)
 
     if args.mode == "pillow":
         response = _run_then_refresh(base_url, "image-provider-pillow")


### PR DESCRIPTION
## Summary
- Add a `/health` readiness check before `acceptance_image_provider.py` sends workflow requests
- Show a clear `Please run: make api` message when the backend is not reachable or not healthy
- Mark TEST-003 as fixed in the post-refactor TODO document

## Validation
- `python -m py_compile scripts/acceptance_image_provider.py`
- `git diff --check`
- `python scripts/acceptance_image_provider.py --mode pillow`

## Notes
- The final validation command was run with the backend stopped. It now fails with the expected friendly precheck message instead of a low-level connection error.