### PR TITLE
fix: return refresh scene error detail

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -50,6 +50,20 @@ def health():
     return {"status": "ok"}
 
 
+def _refresh_scene_error_detail(req: ImageReviewRefreshSceneRequest, error: Exception):
+    try:
+        provider = _runner._image_provider_name()
+    except Exception:
+        provider = "unknown"
+
+    return {
+        "code": "IMAGE_GENERATION_FAILED",
+        "scene_id": req.scene_id,
+        "provider": provider,
+        "message": str(error) or error.__class__.__name__,
+    }
+
+
 @app.get("/v1/samples/summary")
 def get_samples_summary():
     return _runner.get_samples_summary()
@@ -228,7 +242,10 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         print("[image-review] refresh-scene runtime error", repr(e))
-        raise
+        raise HTTPException(
+            status_code=502,
+            detail=_refresh_scene_error_detail(req, e),
+        ) from e
 
 
 from fastapi import Body

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -252,11 +252,13 @@ image api key is missing
 
 **发现日期**：2026-05-21（Step 6 前端真实生图可见验证时）
 
+**状态**：已修复（2026-05-22）。修复内容：`/v1/image-review/refresh-scene` 运行时异常会返回 `502` 和结构化 `detail`（`code` / `scene_id` / `provider` / `message`）；前端会优先展示结构化错误，网络中断时也会显示更明确的后端连接失败文案；已补 `scripts/verify_bug002_refresh_scene_error_detail.py` 覆盖接口错误契约。
+
 **触发条件**：
 
 `/v1/image-review/refresh-scene` 内部真实生图失败并抛出未捕获异常，例如缺少 API key、外部接口异常、超时等。
 
-**当前现象**：
+**修复前现象**：
 
 后端日志里有明确异常，例如：
 
@@ -272,7 +274,7 @@ Failed to fetch
 
 这会让用户不知道是鉴权、网络、限流还是服务端异常。
 
-**建议修复**：
+**已采用修复**：
 
 - 在 `app/main.py` 的 `refresh_image_review_scene` 接口层捕获可预期异常，返回结构化 JSON 错误，例如：
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -69,6 +69,13 @@ type ImageReviewSelectResponse = {
   storyboard?: Record<string, unknown>
 }
 
+type ApiErrorDetail = {
+  code?: string
+  scene_id?: string
+  provider?: string
+  message?: string
+}
+
 type ReviewWaitingState =
   | 'idle'
   | 'deferred_pending'
@@ -777,6 +784,26 @@ function markPlaceholderState(
       : item,
   )
 }
+
+function formatApiErrorDetail(sceneId: string, status: number, errorBody: unknown): string {
+  const body = errorBody as Record<string, unknown> | null
+  const detailValue = body && typeof body === 'object' ? body.detail : undefined
+
+  if (typeof detailValue === 'string') {
+    return `${sceneId} 候选图生成失败：HTTP ${status} · ${detailValue}`
+  }
+
+  if (detailValue && typeof detailValue === 'object') {
+    const detail = detailValue as ApiErrorDetail
+    const code = detail.code ? ` · ${detail.code}` : ''
+    const provider = detail.provider ? ` · provider=${detail.provider}` : ''
+    const message = detail.message ? ` · ${detail.message}` : ''
+    const detailSceneId = detail.scene_id || sceneId
+    return `${detailSceneId} 候选图生成失败：HTTP ${status}${code}${provider}${message}`
+  }
+
+  return `${sceneId} 候选图生成失败：HTTP ${status} · ${JSON.stringify(errorBody)}`
+}
 async function fetchSamplesSummary() {
   const response = await fetch(`${apiBaseUrl}/v1/samples/summary`)
   if (!response.ok) {
@@ -1081,29 +1108,33 @@ async function refreshImageReviewScene(sceneId: string) {
         : workflowForm.value.videoProvider,
   }
 
-  const response = await fetch(`${apiBaseUrl}/v1/image-review/refresh-scene`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  })
+  let response: Response
+  try {
+    response = await fetch(`${apiBaseUrl}/v1/image-review/refresh-scene`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown network error'
+    throw new Error(`${sceneId} 候选图生成失败：无法连接后端或请求被中断 · ${message}`)
+  }
 
   if (!response.ok) {
-    let detail = ''
+    let message = ''
     try {
       const errorBody = await response.json()
-      detail =
-        typeof errorBody?.detail === 'string'
-          ? errorBody.detail
-          : JSON.stringify(errorBody)
+      message = formatApiErrorDetail(sceneId, response.status, errorBody)
     } catch {
-      detail = await response.text().catch(() => '')
+      const detail = await response.text().catch(() => '')
+      message = `${sceneId} 候选图生成失败：HTTP ${response.status}${
+        detail ? ` · ${detail}` : ''
+      }`
     }
 
-    throw new Error(
-      `${sceneId} 候选图生成失败：HTTP ${response.status}${detail ? ` · ${detail}` : ''}`,
-    )
+    throw new Error(message)
   }
 
   const data: ImageReviewRefreshSceneResponse = await response.json()

--- a/scripts/verify_bug002_refresh_scene_error_detail.py
+++ b/scripts/verify_bug002_refresh_scene_error_detail.py
@@ -1,0 +1,65 @@
+"""Contract verification for refresh-scene error responses.
+
+Usage:
+    python scripts/verify_bug002_refresh_scene_error_detail.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import app.main as main_app
+from fastapi.testclient import TestClient
+
+
+def main() -> int:
+    original_refresh = main_app._runner.refresh_image_review_scene
+
+    def failing_refresh_scene(**kwargs):
+        raise RuntimeError("api image provider timeout")
+
+    main_app._runner.refresh_image_review_scene = failing_refresh_scene
+
+    try:
+        client = TestClient(main_app.app)
+        response = client.post(
+            "/v1/image-review/refresh-scene",
+            json={
+                "workflow_id": "wf_verify_bug002",
+                "session_id": "sess_verify_bug002",
+                "run_id": "run_verify_bug002",
+                "scene_id": "scene_02",
+                "storyboard": {"scenes": [{"scene_id": "scene_02"}]},
+                "workflow_input": {
+                    "topic": "小兔子的一天",
+                    "duration_sec": 60,
+                    "video_provider": "mock",
+                },
+                "image_review": {},
+                "character_manifest": {},
+                "image_prompts": {},
+                "video_provider": "mock",
+            },
+        )
+    finally:
+        main_app._runner.refresh_image_review_scene = original_refresh
+
+    assert response.status_code == 502, response.text
+    body = response.json()
+    detail = body.get("detail") or {}
+    assert detail.get("code") == "IMAGE_GENERATION_FAILED", body
+    assert detail.get("scene_id") == "scene_02", body
+    assert detail.get("provider"), body
+    assert "api image provider timeout" in detail.get("message", ""), body
+
+    print("[OK] refresh-scene runtime errors return structured JSON detail")
+    print("PASS: BUG-002 refresh-scene error detail contract verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Return structured `502` JSON error details from `/v1/image-review/refresh-scene` runtime failures
- Include `code`, `scene_id`, `provider`, and `message` in the backend error detail
- Update the frontend to display structured refresh-scene errors instead of a generic fetch failure
- Mark BUG-002 as fixed in the post-refactor TODO document
- Add an in-process verification script for the refresh-scene error contract

## Validation
- `python scripts/verify_bug002_refresh_scene_error_detail.py`
- `python -m py_compile app/main.py scripts/verify_bug002_refresh_scene_error_detail.py`
- `npm run build`
- `python scripts/verify_step19_image_review_refresh_scene.py`
- `make check`
- `git diff --check`