### PR TITLE
Feature/workflow status polling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import json
 import time
 from pathlib import Path
 
@@ -64,6 +65,39 @@ def _refresh_scene_error_detail(req: ImageReviewRefreshSceneRequest, error: Exce
     }
 
 
+def _workflow_dir(workflow_id: str) -> Path:
+    return ASSETS_DIR / "mock" / str(workflow_id)
+
+
+def _workflow_status_path(workflow_id: str) -> Path:
+    return _workflow_dir(workflow_id) / "status.json"
+
+
+def _workflow_outputs_path(workflow_id: str) -> Path:
+    return _workflow_dir(workflow_id) / "outputs.json"
+
+
+def _write_workflow_status(
+    workflow_id: str,
+    status: str,
+    *,
+    detail: dict | None = None,
+) -> dict:
+    payload = {
+        "workflow_id": workflow_id,
+        "status": status,
+        "updated_at": int(time.time()),
+    }
+    if detail:
+        payload.update(detail)
+
+    out_dir = _workflow_dir(workflow_id)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(_workflow_status_path(workflow_id), "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    return payload
+
+
 @app.get("/v1/samples/summary")
 def get_samples_summary():
     return _runner.get_samples_summary()
@@ -85,24 +119,47 @@ def get_real_kling_sample(sample_id: str):
 @app.post("/v1/workflow/run")
 def run_workflow(req: dict = Body(...)):
     workflow_id = req.get("workflow_id") or f"wf_{int(time.time()*1000)}"
+    _write_workflow_status(workflow_id, "processing")
 
     def on_complete(outputs: dict):
-        import os, json
-
-        out_dir = os.path.join("assets/mock", workflow_id)
-        os.makedirs(out_dir, exist_ok=True)
-        out_path = os.path.join(out_dir, "outputs.json")
-        with open(out_path, "w", encoding="utf-8") as f:
+        out_dir = _workflow_dir(workflow_id)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        with open(_workflow_outputs_path(workflow_id), "w", encoding="utf-8") as f:
             json.dump(outputs, f, ensure_ascii=False, indent=2)
+        _write_workflow_status(workflow_id, "completed")
         print(f"[AsyncRunner] workflow {workflow_id} completed.")
 
-    from app.services.runner import WorkflowRunner
+    def on_error(error: Exception):
+        _write_workflow_status(
+            workflow_id,
+            "failed",
+            detail={"message": str(error) or error.__class__.__name__},
+        )
 
     _runner._run_async(
-        req.dict() if hasattr(req, "dict") else dict(req), callback=on_complete
+        req.dict() if hasattr(req, "dict") else dict(req),
+        callback=on_complete,
+        error_callback=on_error,
     )
 
     return {"workflow_id": workflow_id, "status": "processing"}
+
+
+@app.get("/v1/workflow/status/{workflow_id}")
+def get_workflow_status(workflow_id: str):
+    status_path = _workflow_status_path(workflow_id)
+    if status_path.exists():
+        with open(status_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    if _workflow_outputs_path(workflow_id).exists():
+        return {
+            "workflow_id": workflow_id,
+            "status": "completed",
+            "updated_at": int(_workflow_outputs_path(workflow_id).stat().st_mtime),
+        }
+
+    raise HTTPException(status_code=404, detail=f"workflow not found: {workflow_id}")
 
 
 @app.post("/v1/image-review/select", response_model=ImageReviewSelectResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -119,7 +119,22 @@ def get_real_kling_sample(sample_id: str):
 @app.post("/v1/workflow/run")
 def run_workflow(req: dict = Body(...)):
     workflow_id = req.get("workflow_id") or f"wf_{int(time.time()*1000)}"
-    _write_workflow_status(workflow_id, "processing")
+    requested_steps = req.get("steps") or []
+    first_step = requested_steps[0] if requested_steps else {}
+    first_step_name = (
+        first_step.get("name") if isinstance(first_step, dict) else None
+    )
+    _write_workflow_status(
+        workflow_id,
+        "processing",
+        detail={
+            "current_step": first_step_name or "",
+            "current_step_index": 1 if first_step_name else 0,
+            "completed_steps": 0,
+            "total_steps": len(requested_steps),
+            "progress_percent": 0,
+        },
+    )
 
     def on_complete(outputs: dict):
         out_dir = _workflow_dir(workflow_id)
@@ -136,10 +151,14 @@ def run_workflow(req: dict = Body(...)):
             detail={"message": str(error) or error.__class__.__name__},
         )
 
+    def on_progress(progress: dict):
+        _write_workflow_status(workflow_id, "processing", detail=progress)
+
     _runner._run_async(
         req.dict() if hasattr(req, "dict") else dict(req),
         callback=on_complete,
         error_callback=on_error,
+        progress_callback=on_progress,
     )
 
     return {"workflow_id": workflow_id, "status": "processing"}

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -83,7 +83,12 @@ class WorkflowRunner:
                 subtitles=outputs.get("subtitles"),
             )
 
-    def _run_async(self, run_input: dict, callback: callable):
+    def _run_async(
+        self,
+        run_input: dict,
+        callback: callable,
+        error_callback: Optional[callable] = None,
+    ):
         import threading
         import traceback
         from app.schemas.workflow import WorkflowRunRequest
@@ -102,6 +107,8 @@ class WorkflowRunner:
             except Exception as error:
                 print("[AsyncRunner] task failed:", error)
                 traceback.print_exc()
+                if error_callback is not None:
+                    error_callback(error)
 
         threading.Thread(
             target=_task,

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -88,6 +88,7 @@ class WorkflowRunner:
         run_input: dict,
         callback: callable,
         error_callback: Optional[callable] = None,
+        progress_callback: Optional[callable] = None,
     ):
         import threading
         import traceback
@@ -96,7 +97,7 @@ class WorkflowRunner:
         def _task():
             try:
                 request = WorkflowRunRequest(**run_input)
-                result = self.run(request)
+                result = self.run(request, progress_callback=progress_callback)
                 if hasattr(result, "model_dump"):
                     payload = result.model_dump()
                 elif isinstance(result, dict):
@@ -730,7 +731,11 @@ class WorkflowRunner:
 
         raise RuntimeError(str(last_error) if last_error else "TTS request failed")
 
-    def run(self, req: WorkflowRunRequest) -> WorkflowRunResponse:
+    def run(
+        self,
+        req: WorkflowRunRequest,
+        progress_callback: Optional[callable] = None,
+    ) -> WorkflowRunResponse:
         run_id = f"run_{uuid4().hex[:12]}"
         ctx = StepContext(
             workflow_id=req.workflow_id,
@@ -808,11 +813,45 @@ class WorkflowRunner:
             },
         }
 
-        for step in req.steps:
+        total_steps = len(req.steps)
+
+        def emit_progress(
+            *,
+            current_step: str,
+            current_step_index: int,
+            completed_steps: int,
+        ) -> None:
+            if progress_callback is None:
+                return
+
+            try:
+                progress_callback(
+                    {
+                        "current_step": current_step,
+                        "current_step_index": current_step_index,
+                        "completed_steps": completed_steps,
+                        "total_steps": total_steps,
+                        "progress_percent": (
+                            round((completed_steps / total_steps) * 100)
+                            if total_steps
+                            else 0
+                        ),
+                    }
+                )
+            except Exception as error:
+                print(f"[WorkflowRunner] progress callback failed: {error}")
+
+        for step_index, step in enumerate(req.steps, start=1):
             name = step.name.strip()
             handler = self._handlers.get(name)
             if handler is None:
                 raise UnknownStepError(f"Unknown step: {name}")
+
+            emit_progress(
+                current_step=name,
+                current_step_index=step_index,
+                completed_steps=step_index - 1,
+            )
 
             if name == "image_assets":
                 output = self._image_review.build_deferred_image_assets_output(ctx)

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -179,6 +179,8 @@ multi-character visual profiles
 
 **发现日期**：2026-05-21（Step 6 前端真实生图可见验证时）
 
+**状态**：部分修复（2026-05-22）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。
+
 **触发条件**：
 
 使用真实 `api_image_generator` 生成多 scene 候选图，尤其是 60 秒或 120 秒 workflow 触发 6 到 12 个 scene 逐个刷新时。

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -179,7 +179,7 @@ multi-character visual profiles
 
 **发现日期**：2026-05-21（Step 6 前端真实生图可见验证时）
 
-**状态**：部分修复（2026-05-22）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。
+**状态**：部分修复（2026-05-22）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。第二段已给 image review 分场景刷新增加当前 scene 进度文案和进度条。
 
 **触发条件**：
 

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -179,7 +179,7 @@ multi-character visual profiles
 
 **发现日期**：2026-05-21（Step 6 前端真实生图可见验证时）
 
-**状态**：部分修复（2026-05-25）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。第二段已给 image review 分场景刷新增加当前 scene 进度文案和进度条。第三段已增加前端“停止生成”按钮，可中断当前 refresh-scene 请求并停止剩余 scene 刷新。第四段已修正 workflow 主流程等待态：未拿到 storyboard 前不再显示 0% 假进度，也不再提示用户先执行 Run。
+**状态**：部分修复（2026-05-25）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。第二段已给 image review 分场景刷新增加当前 scene 进度文案和进度条。第三段已增加前端“停止生成”按钮，可中断当前 refresh-scene 请求并停止剩余 scene 刷新。第四段已修正 workflow 主流程等待态：未拿到 storyboard 前不再显示 0% 假进度，也不再提示用户先执行 Run。第五段已增加主 workflow 已等待时长提示，并把状态轮询窗口从约 3 分钟延长到约 30 分钟，避免真实慢接口运行中页面过早回到空状态。第六段已增加后端 step 级进度状态，前端可显示当前步骤和已完成步骤数，避免长任务阶段只能看到泛泛的“运行中”。
 
 **触发条件**：
 

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -179,7 +179,7 @@ multi-character visual profiles
 
 **发现日期**：2026-05-21（Step 6 前端真实生图可见验证时）
 
-**状态**：部分修复（2026-05-22）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。第二段已给 image review 分场景刷新增加当前 scene 进度文案和进度条。第三段已增加前端“停止生成”按钮，可中断当前 refresh-scene 请求并停止剩余 scene 刷新。
+**状态**：部分修复（2026-05-25）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。第二段已给 image review 分场景刷新增加当前 scene 进度文案和进度条。第三段已增加前端“停止生成”按钮，可中断当前 refresh-scene 请求并停止剩余 scene 刷新。第四段已修正 workflow 主流程等待态：未拿到 storyboard 前不再显示 0% 假进度，也不再提示用户先执行 Run。
 
 **触发条件**：
 

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -179,7 +179,7 @@ multi-character visual profiles
 
 **发现日期**：2026-05-21（Step 6 前端真实生图可见验证时）
 
-**状态**：部分修复（2026-05-22）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。第二段已给 image review 分场景刷新增加当前 scene 进度文案和进度条。
+**状态**：部分修复（2026-05-22）。已完成第一段：新增 `GET /v1/workflow/status/{workflow_id}`，后端在异步 workflow 开始、完成、失败时写入 `status.json`；前端先轮询状态接口，只有 `completed` 后才请求一次 `outputs.json`，避免 Network 面板刷出大量 404。已补 `scripts/verify_perf001_workflow_status_contract.py` 覆盖 `processing / completed / failed` 状态契约。第二段已给 image review 分场景刷新增加当前 scene 进度文案和进度条。第三段已增加前端“停止生成”按钮，可中断当前 refresh-scene 请求并停止剩余 scene 刷新。
 
 **触发条件**：
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -31,6 +31,12 @@ type WorkflowRunPayload = {
   steps: Array<{ name: StepName }>
 }
 
+type WorkflowStatusResponse = {
+  workflow_id?: string
+  status?: string
+  message?: string
+}
+
 type ImageAssetRef = {
   scene_id?: string
   file_name?: string
@@ -1254,19 +1260,42 @@ async function waitForAsyncWorkflowOutputs(
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     await new Promise((resolve) => window.setTimeout(resolve, intervalMs))
 
-    const response = await fetch(
-      `${apiBaseUrl}/assets/mock/${encodeURIComponent(normalizedWorkflowId)}/outputs.json?ts=${Date.now()}`,
+    const statusResponse = await fetch(
+      `${apiBaseUrl}/v1/workflow/status/${encodeURIComponent(normalizedWorkflowId)}?ts=${Date.now()}`,
     )
 
-    if (response.status === 404) {
+    if (statusResponse.status === 404) {
       continue
     }
 
-    if (!response.ok) {
-      throw new Error(`Workflow outputs HTTP ${response.status}`)
+    if (!statusResponse.ok) {
+      throw new Error(`Workflow status HTTP ${statusResponse.status}`)
     }
 
-    return (await response.json()) as WorkflowRunResponse
+    const statusData = (await statusResponse.json()) as WorkflowStatusResponse
+    const status = String(statusData.status || '').trim().toLowerCase()
+
+    if (status === 'processing') {
+      continue
+    }
+
+    if (status === 'failed') {
+      throw new Error(statusData.message || 'Workflow failed')
+    }
+
+    if (status !== 'completed') {
+      throw new Error(`Unknown workflow status: ${statusData.status || 'empty'}`)
+    }
+
+    const outputsResponse = await fetch(
+      `${apiBaseUrl}/assets/mock/${encodeURIComponent(normalizedWorkflowId)}/outputs.json?ts=${Date.now()}`,
+    )
+
+    if (!outputsResponse.ok) {
+      throw new Error(`Workflow outputs HTTP ${outputsResponse.status}`)
+    }
+
+    return (await outputsResponse.json()) as WorkflowRunResponse
   }
 
   return null

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -462,6 +462,13 @@ const hasDebugContent = computed(() => {
   )
 })
 
+const reviewEmptyStateText = computed(() => {
+  if (loading.value) {
+    return 'Workflow 正在运行，故事和分镜生成完成后会自动在 Review 页展示选图和结果。'
+  }
+  return '请先在 Run 页签执行一次 workflow，然后回到 Review 查看选图和结果。'
+})
+
 
 const imageAssetsOutput = computed<Record<string, unknown>>(() => {
   const imageAssets = currentWorkflowResponse.value?.outputs?.image_assets
@@ -1790,7 +1797,7 @@ async function runWorkflow() {
         </template>
 
         <p v-else class="empty-state">
-          请先在 Run 页签执行一次 workflow，然后回到 Review 查看选图和结果。
+          {{ reviewEmptyStateText }}
         </p>
       </section>
       <section v-if="activeTab === 'assets'">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -35,6 +35,11 @@ type WorkflowStatusResponse = {
   workflow_id?: string
   status?: string
   message?: string
+  current_step?: string
+  current_step_index?: number
+  completed_steps?: number
+  total_steps?: number
+  progress_percent?: number
 }
 
 type ImageAssetRef = {
@@ -251,9 +256,21 @@ const DEFAULT_STEPS: StepName[] = [
   'final_video',
 ]
 
+function workflowStepLabel(stepName: string): string {
+  return (
+    STEP_OPTIONS.find((item) => item.value === stepName)?.label ||
+    stepName
+      .split('_')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ')
+  )
+}
+
 const loading = ref(false)
 const finalVideoRenderInFlight = ref(false)
 const errorMessage = ref('')
+const workflowRunElapsedSec = ref(0)
+const workflowStatusData = ref<WorkflowStatusResponse | null>(null)
 const resultText = ref('')
 
 const storyText = ref('')
@@ -462,9 +479,60 @@ const hasDebugContent = computed(() => {
   )
 })
 
+const workflowIsProcessing = computed(() => {
+  const response = currentWorkflowResponse.value
+  const status = String(response?.status || '').trim().toLowerCase()
+  return Boolean(loading.value || (status === 'processing' && !response?.outputs))
+})
+
+function formatElapsedTime(totalSec: number): string {
+  const normalizedSec = Math.max(0, Math.floor(totalSec))
+  const minutes = Math.floor(normalizedSec / 60)
+  const seconds = normalizedSec % 60
+  if (minutes <= 0) {
+    return `${seconds} 秒`
+  }
+  return `${minutes} 分 ${seconds} 秒`
+}
+
+const workflowRunStatusMessage = computed(() => {
+  if (!workflowIsProcessing.value) {
+    return ''
+  }
+
+  const elapsed = formatElapsedTime(workflowRunElapsedSec.value)
+  const statusData = workflowStatusData.value
+  const currentStep = String(statusData?.current_step || '').trim()
+  const currentStepLabel = currentStep ? workflowStepLabel(currentStep) : ''
+  const completedSteps =
+    typeof statusData?.completed_steps === 'number' ? statusData.completed_steps : null
+  const totalSteps =
+    typeof statusData?.total_steps === 'number' ? statusData.total_steps : null
+  const stepCopy =
+    currentStepLabel && totalSteps
+      ? `当前步骤：${currentStepLabel}（${completedSteps ?? 0}/${totalSteps}）。`
+      : currentStepLabel
+        ? `当前步骤：${currentStepLabel}。`
+        : ''
+
+  if (workflowRunElapsedSec.value < 60) {
+    return `Workflow 运行中，已等待 ${elapsed}。${stepCopy}`
+  }
+
+  return `Workflow 仍在运行，已等待 ${elapsed}。${stepCopy}真实接口较慢时可能需要几分钟，请保持页面打开。`
+})
+
+const workflowStatusProgress = computed(() => {
+  const progress = workflowStatusData.value?.progress_percent
+  if (typeof progress !== 'number' || !Number.isFinite(progress)) {
+    return null
+  }
+  return Math.max(0, Math.min(100, Math.round(progress)))
+})
+
 const reviewEmptyStateText = computed(() => {
-  if (loading.value) {
-    return 'Workflow 正在运行，故事和分镜生成完成后会自动在 Review 页展示选图和结果。'
+  if (workflowIsProcessing.value) {
+    return `${workflowRunStatusMessage.value} 故事和分镜生成完成后会自动在 Review 页展示选图和结果。`
   }
   return '请先在 Run 页签执行一次 workflow，然后回到 Review 查看选图和结果。'
 })
@@ -1333,7 +1401,7 @@ function scheduleImageReviewAutoRefreshIfNeeded() {
 
 async function waitForAsyncWorkflowOutputs(
   workflowId: string,
-  maxAttempts = 120,
+  maxAttempts = 1200,
   intervalMs = 1500,
 ): Promise<WorkflowRunResponse | null> {
   const normalizedWorkflowId = String(workflowId || '').trim()
@@ -1341,8 +1409,12 @@ async function waitForAsyncWorkflowOutputs(
     return null
   }
 
+  const startedAt = Date.now()
+
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    workflowRunElapsedSec.value = Math.floor((Date.now() - startedAt) / 1000)
     await new Promise((resolve) => window.setTimeout(resolve, intervalMs))
+    workflowRunElapsedSec.value = Math.floor((Date.now() - startedAt) / 1000)
 
     const statusResponse = await fetch(
       `${apiBaseUrl}/v1/workflow/status/${encodeURIComponent(normalizedWorkflowId)}?ts=${Date.now()}`,
@@ -1357,6 +1429,7 @@ async function waitForAsyncWorkflowOutputs(
     }
 
     const statusData = (await statusResponse.json()) as WorkflowStatusResponse
+    workflowStatusData.value = statusData
     const status = String(statusData.status || '').trim().toLowerCase()
 
     if (status === 'processing') {
@@ -1382,7 +1455,9 @@ async function waitForAsyncWorkflowOutputs(
     return (await outputsResponse.json()) as WorkflowRunResponse
   }
 
-  return null
+  throw new Error(
+    `Workflow 仍在处理中，前端已等待 ${formatElapsedTime(workflowRunElapsedSec.value)}。请稍后刷新状态或检查后端日志。`,
+  )
 }
 
 async function runWorkflow() {
@@ -1607,6 +1682,16 @@ async function runWorkflow() {
 
   // ✅ 点击 Run 立刻给 UI 反馈（跨 tab 都能感知）
   loading.value = true
+  workflowRunElapsedSec.value = 0
+  workflowStatusData.value = {
+    workflow_id: workflowId,
+    status: 'processing',
+    current_step: stepsSet.values().next().value || '',
+    current_step_index: 1,
+    completed_steps: 0,
+    total_steps: stepsSet.size,
+    progress_percent: 0,
+  }
   errorMessage.value = ''
   finalVideoText.value = ''
   finalVideoUrl.value = ''
@@ -1726,7 +1811,7 @@ async function runWorkflow() {
         />
       </section>
       <section v-if="activeTab === 'review'">
-        <template v-if="hasReviewContent || loading || refreshingImageReview || finalVideoRenderInFlight">
+        <template v-if="hasReviewContent || workflowIsProcessing || refreshingImageReview || finalVideoRenderInFlight">
           <section class="result-panel final-video-hero">
             <div class="render-mode-switch">
               <span class="label">Render Mode:</span>
@@ -1737,7 +1822,9 @@ async function runWorkflow() {
               :final-video-text="finalVideoText"
               :workflow-response="currentWorkflowResponse"
               :render-in-flight="finalVideoRenderInFlight"
-              :loading="loading || refreshingImageReview || finalVideoRenderInFlight"
+              :loading="workflowIsProcessing || refreshingImageReview || finalVideoRenderInFlight"
+              :workflow-status-message="workflowRunStatusMessage"
+              :workflow-status-progress="workflowStatusProgress"
               @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
               :show-render-button="workflowForm.renderMode === 'auto'"
             />

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -491,6 +491,44 @@ const reviewWaitingState = computed<ReviewWaitingState>(() => {
   return 'idle'
 })
 
+const reviewRefreshProgress = computed(() => {
+  if (!refreshingImageReview.value) {
+    return {
+      text: '',
+      percent: 0,
+    }
+  }
+
+  const queue = sceneRefreshQueue.value
+  const total = queue.length
+  if (total === 0) {
+    return {
+      text: '候选图生成中',
+      percent: 0,
+    }
+  }
+
+  const currentIndex = Math.max(queue.indexOf(sceneRefreshingId.value), 0)
+  const currentSceneId = sceneRefreshingId.value || queue[currentIndex] || ''
+  const currentPlaceholder = reviewPlaceholders.value.find(
+    (item) => item.scene_id === currentSceneId,
+  )
+  const currentSceneTitle = currentPlaceholder?.scene_title || currentSceneId
+  const completedCount = reviewPlaceholders.value.filter(
+    (item) => queue.includes(item.scene_id) && ['done', 'failed'].includes(item.state),
+  ).length
+
+  return {
+    text: `候选图生成中：${currentIndex + 1}/${total}${
+      currentSceneTitle ? ` · ${currentSceneTitle}` : ''
+    }`,
+    percent: Math.max(
+      5,
+      Math.min(100, Math.round((completedCount / total) * 100)),
+    ),
+  }
+})
+
 function assetRefPath(assetRef?: ImageAssetRef): string {
   if (!assetRef) {
     return ''
@@ -1690,6 +1728,8 @@ async function runWorkflow() {
               :api-base-url="apiBaseUrl"
               :loading="loading || refreshingImageReview"
               :selecting-scene-id="selectingSceneId || sceneRefreshingId"
+              :progress-text="reviewRefreshProgress.text"
+              :progress-percent="reviewRefreshProgress.percent"
               @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
             />
             <WorkflowResultsPanel

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -317,8 +317,10 @@ const refreshingImageReview = ref(false)
 const sceneRefreshQueue = ref<string[]>([])
 const sceneRefreshingId = ref('')
 const reviewPlaceholders = ref<ReviewPlaceholderItem[]>([])
+const imageReviewRefreshCancelled = ref(false)
 let reviewAutoRefreshFiredOnce = false
 let imageReviewAutoRefreshTimer: number | null = null
+let imageReviewRefreshAbortController: AbortController | null = null
 type ViewTab = 'run' | 'review' | 'assets' | 'debug'
 const activeTab = ref<ViewTab>('run')
 
@@ -1112,7 +1114,7 @@ function handleManualRender() {
   renderFinalVideoIfReady(currentWorkflowResponse.value)
 }
 
-async function refreshImageReviewScene(sceneId: string) {
+async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal) {
   if (!currentWorkflowResponse.value || !currentWorkflowPayload.value) {
     return
   }
@@ -1160,8 +1162,12 @@ async function refreshImageReviewScene(sceneId: string) {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),
+      signal,
     })
   } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error
+    }
     const message = error instanceof Error ? error.message : 'unknown network error'
     throw new Error(`${sceneId} 候选图生成失败：无法连接后端或请求被中断 · ${message}`)
   }
@@ -1201,6 +1207,21 @@ async function refreshImageReviewScene(sceneId: string) {
 
   applyWorkflowResponse(mergedResponse)
   markPlaceholderState(sceneId, 'done')
+}
+
+function cancelImageReviewRefresh() {
+  if (!refreshingImageReview.value) {
+    return
+  }
+
+  imageReviewRefreshCancelled.value = true
+  imageReviewRefreshAbortController?.abort()
+
+  if (sceneRefreshingId.value) {
+    markPlaceholderState(sceneRefreshingId.value, 'waiting')
+  }
+
+  errorMessage.value = '已取消剩余候选图生成。'
 }
 
 async function refreshImageReview() {
@@ -1243,24 +1264,42 @@ async function refreshImageReview() {
   }
 
   refreshingImageReview.value = true
+  imageReviewRefreshCancelled.value = false
   errorMessage.value = ''
 
   const failures: string[] = []
 
   try {
     for (const sceneId of sceneRefreshQueue.value) {
+      if (imageReviewRefreshCancelled.value) {
+        break
+      }
+
+      imageReviewRefreshAbortController = new AbortController()
       try {
-        await refreshImageReviewScene(sceneId)
+        await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal)
       } catch (error) {
+        if (
+          imageReviewRefreshCancelled.value ||
+          (error instanceof DOMException && error.name === 'AbortError')
+        ) {
+          markPlaceholderState(sceneId, 'waiting')
+          break
+        }
+
         const message = error instanceof Error ? error.message : '候选图分场景刷新失败'
         failures.push(message)
         markPlaceholderState(sceneId, 'failed', message)
+      } finally {
+        imageReviewRefreshAbortController = null
       }
     }
   } finally {
     sceneRefreshingId.value = ''
     sceneRefreshQueue.value = []
     refreshingImageReview.value = false
+    imageReviewRefreshCancelled.value = false
+    imageReviewRefreshAbortController = null
   }
 
   if (failures.length > 0) {
@@ -1730,7 +1769,9 @@ async function runWorkflow() {
               :selecting-scene-id="selectingSceneId || sceneRefreshingId"
               :progress-text="reviewRefreshProgress.text"
               :progress-percent="reviewRefreshProgress.percent"
+              :can-cancel="refreshingImageReview"
               @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
+              @cancel-refresh="cancelImageReviewRefresh"
             />
             <WorkflowResultsPanel
               :story-text="storyText"

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -48,6 +48,8 @@ const props = defineProps<{
   workflowResponse: UnknownRecord | null
   renderInFlight: boolean
   loading: boolean
+  workflowStatusMessage?: string
+  workflowStatusProgress?: number | null
 }>()
 
 function asObj(v: unknown): UnknownRecord | null {
@@ -71,6 +73,7 @@ const finalVideo = computed(() => asObj(outputs.value?.final_video))
 const indeterminate = computed(() => {
   if (props.finalVideoUrl) return false
   if (props.renderInFlight || finalStatus.value === 'rendering') return false
+  if (workflowInFlight.value && props.workflowStatusProgress != null) return false
   // runWorkflow 请求中，或 refresh 正在跑，但还没有任何 image_assets
   return props.loading  && imageAssetCount.value === 0
 })
@@ -100,6 +103,9 @@ const assetsReady = computed(() => {
 const progressPct = computed(() => {
   if (props.finalVideoUrl) return 100
   if (props.renderInFlight || finalStatus.value === 'rendering') return 90
+  if (workflowInFlight.value && props.workflowStatusProgress != null) {
+    return Math.max(0, Math.min(100, Math.round(props.workflowStatusProgress)))
+  }
   if (!sceneCount.value) return 0
 
   const ratio = Math.min(1, Math.max(0, imageAssetCount.value / sceneCount.value))
@@ -107,7 +113,7 @@ const progressPct = computed(() => {
 })
 
 const progressLabel = computed(() => {
-  if (workflowInFlight.value) return 'Workflow 运行中…'
+  if (workflowInFlight.value) return '处理中…'
   if (indeterminate.value) return '准备中…'
   if (props.finalVideoUrl) return '已生成'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '视频渲染中'
@@ -126,7 +132,7 @@ const placeholderTitle = computed(() => {
 
 const placeholderDesc = computed(() => {
   if (workflowInFlight.value) {
-    return 'Workflow 已提交，后端正在生成故事与分镜。完成后会自动进入候选图与视频准备阶段。'
+    return props.workflowStatusMessage || 'Workflow 已提交，后端正在生成故事与分镜。完成后会自动进入候选图与视频准备阶段。'
   }
   if (props.renderInFlight || finalStatus.value === 'rendering') {
     return '视频正在合成中，请稍候（音频/字幕/画面正在拼接）。'

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -23,8 +23,10 @@
             ></div>
           </div>
           <div class="ph-meta">
-            <span>{{ progressPct }}%</span>
-            <span class="ph-dot">·</span>
+            <template v-if="!indeterminate">
+              <span>{{ progressPct }}%</span>
+              <span class="ph-dot">·</span>
+            </template>
             <span>{{ progressLabel }}</span>
           </div>
         </div>
@@ -89,6 +91,7 @@ const audioItemCount = computed(() => {
 })
 
 const finalStatus = computed(() => asStr(finalVideo.value?.status).toLowerCase())
+const workflowInFlight = computed(() => props.loading && !outputs.value)
 
 const assetsReady = computed(() => {
   return sceneCount.value > 0 && imageAssetCount.value >= sceneCount.value
@@ -104,6 +107,7 @@ const progressPct = computed(() => {
 })
 
 const progressLabel = computed(() => {
+  if (workflowInFlight.value) return 'Workflow 运行中…'
   if (indeterminate.value) return '准备中…'
   if (props.finalVideoUrl) return '已生成'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '视频渲染中'
@@ -113,6 +117,7 @@ const progressLabel = computed(() => {
 })
 
 const placeholderTitle = computed(() => {
+  if (workflowInFlight.value) return '正在生成分镜'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '正在生成视频'
   if (!sceneCount.value) return '等待分镜'
   if (!assetsReady.value) return '等待候选图生成'
@@ -120,11 +125,14 @@ const placeholderTitle = computed(() => {
 })
 
 const placeholderDesc = computed(() => {
+  if (workflowInFlight.value) {
+    return 'Workflow 已提交，后端正在生成故事与分镜。完成后会自动进入候选图与视频准备阶段。'
+  }
   if (props.renderInFlight || finalStatus.value === 'rendering') {
     return '视频正在合成中，请稍候（音频/字幕/画面正在拼接）。'
   }
   if (!sceneCount.value) {
-    return '请先在 Run 执行一次，生成 storyboard。'
+    return '还没有可用的 storyboard。请在 Run 页签执行一次 workflow。'
   }
   if (!assetsReady.value) {
     return '系统正在准备每个场景的候选图，默认图生成后即可直接渲染，也可以手动改选。'

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -66,6 +66,8 @@ const props = defineProps<{
   showWaitingCard?: boolean
   refreshing?: boolean
   canRefresh?: boolean
+  progressText?: string
+  progressPercent?: number
 }>()
 
 const emit = defineEmits<{
@@ -250,6 +252,16 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
     class="result-panel"
   >
     <h2 class="section-title">Interactive Image Review</h2>
+
+    <div v-if="progressText" class="review-progress">
+      <div class="review-progress-copy">{{ progressText }}</div>
+      <div class="review-progress-track" aria-hidden="true">
+        <div
+          class="review-progress-fill"
+          :style="{ width: `${Math.max(0, Math.min(100, progressPercent || 0))}%` }"
+        ></div>
+      </div>
+    </div>
 
     <article v-if="showWaitingCard && renderEntries.length === 0" class="review-waiting-card">
       <div class="waiting-preview-frame">
@@ -747,6 +759,36 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   line-height: 1.4;
   color: #111827;
   text-align: center;
+}
+
+.review-progress {
+  margin: 0 0 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.review-progress-copy {
+  color: #334155;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.review-progress-track {
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e2e8f0;
+}
+
+.review-progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: #2563eb;
+  transition: width 180ms ease;
 }
 
 .summary-status {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -68,6 +68,7 @@ const props = defineProps<{
   canRefresh?: boolean
   progressText?: string
   progressPercent?: number
+  canCancel?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -79,6 +80,7 @@ const emit = defineEmits<{
     }
   ): void
   (e: 'refresh-review'): void
+  (e: 'cancel-refresh'): void
 }>()
 
 function toAssetHref(path?: string): string {
@@ -145,6 +147,10 @@ function onSelect(sceneId: string, assetRef: ImageAssetRef) {
 
 function onRefreshReview() {
   emit('refresh-review')
+}
+
+function onCancelRefresh() {
+  emit('cancel-refresh')
 }
 
 function placeholderStatusText(state: 'waiting' | 'refreshing' | 'done' | 'failed'): string {
@@ -254,7 +260,17 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
     <h2 class="section-title">Interactive Image Review</h2>
 
     <div v-if="progressText" class="review-progress">
-      <div class="review-progress-copy">{{ progressText }}</div>
+      <div class="review-progress-head">
+        <div class="review-progress-copy">{{ progressText }}</div>
+        <button
+          v-if="canCancel"
+          type="button"
+          class="cancel-refresh-button"
+          @click="onCancelRefresh"
+        >
+          停止生成
+        </button>
+      </div>
       <div class="review-progress-track" aria-hidden="true">
         <div
           class="review-progress-fill"
@@ -305,6 +321,14 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   ? '立即重试'
                   : '立即刷新结果'
             }}
+          </button>
+          <button
+            v-if="canCancel"
+            type="button"
+            class="cancel-refresh-button"
+            @click="onCancelRefresh"
+          >
+            停止生成
           </button>
         </div>
       </div>
@@ -768,12 +792,21 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   gap: 8px;
 }
 
+.review-progress-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .review-progress-copy {
+  flex: 1;
+  min-width: 0;
   color: #334155;
   font-size: 13px;
   font-weight: 700;
   line-height: 1.4;
-  text-align: center;
+  text-align: left;
 }
 
 .review-progress-track {
@@ -1340,6 +1373,29 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 .refresh-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.cancel-refresh-button {
+  appearance: none;
+  flex-shrink: 0;
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334155;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.cancel-refresh-button:hover {
+  border-color: #ef4444;
+  color: #b91c1c;
+  transform: translateY(-1px);
 }
 
 @keyframes reviewShimmer {

--- a/scripts/verify_perf001_workflow_status_contract.py
+++ b/scripts/verify_perf001_workflow_status_contract.py
@@ -1,0 +1,116 @@
+"""Contract verification for async workflow status polling.
+
+Usage:
+    python scripts/verify_perf001_workflow_status_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import app.main as main_app
+from fastapi.testclient import TestClient
+
+
+def make_payload(workflow_id: str) -> dict:
+    return {
+        "workflow_id": workflow_id,
+        "session_id": f"{workflow_id}_session",
+        "input": {
+            "topic": "小兔子的一天",
+            "duration_sec": 60,
+            "video_provider": "mock",
+        },
+        "steps": [{"name": "story"}],
+    }
+
+
+def main() -> int:
+    original_assets_dir = main_app.ASSETS_DIR
+    original_run_async = main_app._runner._run_async
+
+    try:
+        with TemporaryDirectory() as tmp_dir:
+            main_app.ASSETS_DIR = Path(tmp_dir)
+            client = TestClient(main_app.app)
+
+            captured = {}
+
+            def pending_run_async(run_input, callback, error_callback=None):
+                captured["run_input"] = run_input
+                captured["callback"] = callback
+                captured["error_callback"] = error_callback
+
+            main_app._runner._run_async = pending_run_async
+
+            response = client.post(
+                "/v1/workflow/run",
+                json=make_payload("wf_verify_status_processing"),
+            )
+            assert response.status_code == 200, response.text
+            assert response.json()["status"] == "processing"
+
+            status_response = client.get(
+                "/v1/workflow/status/wf_verify_status_processing"
+            )
+            assert status_response.status_code == 200, status_response.text
+            assert status_response.json()["status"] == "processing"
+
+            captured["callback"](
+                {
+                    "workflow_id": "wf_verify_status_processing",
+                    "status": "COMPLETED",
+                    "outputs": {"story": {"title": "小兔子的一天"}},
+                }
+            )
+
+            completed_response = client.get(
+                "/v1/workflow/status/wf_verify_status_processing"
+            )
+            assert completed_response.status_code == 200, completed_response.text
+            assert completed_response.json()["status"] == "completed"
+
+            outputs_path = (
+                Path(tmp_dir)
+                / "mock"
+                / "wf_verify_status_processing"
+                / "outputs.json"
+            )
+            with open(outputs_path, "r", encoding="utf-8") as f:
+                outputs_payload = json.load(f)
+            assert outputs_payload["outputs"]["story"]["title"] == "小兔子的一天"
+
+            def failing_run_async(run_input, callback, error_callback=None):
+                assert error_callback is not None
+                error_callback(RuntimeError("provider timeout"))
+
+            main_app._runner._run_async = failing_run_async
+            failed_run = client.post(
+                "/v1/workflow/run",
+                json=make_payload("wf_verify_status_failed"),
+            )
+            assert failed_run.status_code == 200, failed_run.text
+
+            failed_status = client.get("/v1/workflow/status/wf_verify_status_failed")
+            assert failed_status.status_code == 200, failed_status.text
+            failed_body = failed_status.json()
+            assert failed_body["status"] == "failed"
+            assert "provider timeout" in failed_body["message"]
+    finally:
+        main_app.ASSETS_DIR = original_assets_dir
+        main_app._runner._run_async = original_run_async
+
+    print("[OK] workflow status endpoint reports processing and completed")
+    print("[OK] workflow status endpoint reports async failures")
+    print("PASS: PERF-001 workflow status polling contract verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_perf001_workflow_status_contract.py
+++ b/scripts/verify_perf001_workflow_status_contract.py
@@ -42,10 +42,16 @@ def main() -> int:
 
             captured = {}
 
-            def pending_run_async(run_input, callback, error_callback=None):
+            def pending_run_async(
+                run_input,
+                callback,
+                error_callback=None,
+                progress_callback=None,
+            ):
                 captured["run_input"] = run_input
                 captured["callback"] = callback
                 captured["error_callback"] = error_callback
+                captured["progress_callback"] = progress_callback
 
             main_app._runner._run_async = pending_run_async
 
@@ -60,7 +66,26 @@ def main() -> int:
                 "/v1/workflow/status/wf_verify_status_processing"
             )
             assert status_response.status_code == 200, status_response.text
-            assert status_response.json()["status"] == "processing"
+            processing_body = status_response.json()
+            assert processing_body["status"] == "processing"
+            assert processing_body["current_step"] == "story"
+            assert processing_body["completed_steps"] == 0
+            assert processing_body["total_steps"] == 1
+
+            captured["progress_callback"](
+                {
+                    "current_step": "story",
+                    "current_step_index": 1,
+                    "completed_steps": 0,
+                    "total_steps": 1,
+                    "progress_percent": 0,
+                }
+            )
+            progress_response = client.get(
+                "/v1/workflow/status/wf_verify_status_processing"
+            )
+            assert progress_response.status_code == 200, progress_response.text
+            assert progress_response.json()["current_step"] == "story"
 
             captured["callback"](
                 {
@@ -86,7 +111,12 @@ def main() -> int:
                 outputs_payload = json.load(f)
             assert outputs_payload["outputs"]["story"]["title"] == "小兔子的一天"
 
-            def failing_run_async(run_input, callback, error_callback=None):
+            def failing_run_async(
+                run_input,
+                callback,
+                error_callback=None,
+                progress_callback=None,
+            ):
                 assert error_callback is not None
                 error_callback(RuntimeError("provider timeout"))
 


### PR DESCRIPTION
## Summary
- Add `/v1/workflow/status/{workflow_id}` for async workflow polling
- Persist workflow status as `processing / completed / failed`
- Report current workflow step progress, including current step, completed steps, total steps, and progress percent
- Update the frontend to poll workflow status before fetching `outputs.json`
- Avoid repeated `outputs.json` requests while the workflow is still processing
- Improve long-running workflow UI with elapsed time, step progress, image refresh progress, and cancel-remaining refresh controls
- Update the post-refactor TODO notes for the partially fixed PERF-001 items

## Validation
- `python scripts/verify_perf001_workflow_status_contract.py`
- `python -m py_compile app/main.py app/services/runner.py scripts/verify_perf001_workflow_status_contract.py`
- `npm run build`
- `make check`
- `git diff --check`

## Notes
- This PR improves observability and frontend feedback for long-running workflows.
- It does not yet optimize the actual slow provider calls.