### PR TITLE
fix: improve multi-character prompts and story timing

### DIFF
--- a/app/services/character_visual_profile.py
+++ b/app/services/character_visual_profile.py
@@ -112,6 +112,7 @@ def _known_risk_rules(subject: str) -> Dict[str, List[str]]:
             "must_keep": [
                 "small white storybook rabbit",
                 "long upright rabbit ears with soft pink inner ears",
+                "only the rabbit has long upright ears",
                 "round fluffy rabbit tail",
                 "soft white fur",
                 "small red scarf",
@@ -119,6 +120,7 @@ def _known_risk_rules(subject: str) -> Dict[str, List[str]]:
             "must_avoid": [
                 "turtle shell",
                 "hard round shell",
+                "shell on rabbit body",
                 "turtle body",
                 "short turtle legs",
                 "green turtle skin",
@@ -142,13 +144,17 @@ def _known_risk_rules(subject: str) -> Dict[str, List[str]]:
                 "small green storybook turtle",
                 "round green turtle shell",
                 "olive green turtle body",
+                "earless rounded turtle head",
+                "no external ears on the turtle",
                 "short turtle legs",
                 "gentle round eyes",
                 "small blue neck scarf",
             ],
             "must_avoid": [
                 "rabbit ears",
+                "bunny ears",
                 "long upright ears",
+                "external ears",
                 "fluffy rabbit tail",
                 "rabbit body",
                 "white rabbit fur",
@@ -157,6 +163,7 @@ def _known_risk_rules(subject: str) -> Dict[str, List[str]]:
             "required_presence_rules": [
                 "the turtle must be clearly visible as a separate character",
                 "do not merge the turtle with rabbit ears or rabbit body",
+                "draw the turtle as an earless turtle, never as a rabbit-like animal",
             ],
         }
 

--- a/app/services/character_visual_profile.py
+++ b/app/services/character_visual_profile.py
@@ -107,6 +107,59 @@ def _known_risk_rules(subject: str) -> Dict[str, List[str]]:
             ],
         }
 
+    if "兔" in value or "rabbit" in value.lower() or "bunny" in value.lower():
+        return {
+            "must_keep": [
+                "small white storybook rabbit",
+                "long upright rabbit ears with soft pink inner ears",
+                "round fluffy rabbit tail",
+                "soft white fur",
+                "small red scarf",
+            ],
+            "must_avoid": [
+                "turtle shell",
+                "hard round shell",
+                "turtle body",
+                "short turtle legs",
+                "green turtle skin",
+                "rabbit replaced by turtle",
+            ],
+            "required_presence_rules": [
+                "the rabbit must be clearly visible as a separate character",
+                "do not merge the rabbit with a turtle or shell body",
+            ],
+        }
+
+    if (
+        "乌龟" in value
+        or "海龟" in value
+        or "龟" in value
+        or "turtle" in value.lower()
+        or "tortoise" in value.lower()
+    ):
+        return {
+            "must_keep": [
+                "small green storybook turtle",
+                "round green turtle shell",
+                "olive green turtle body",
+                "short turtle legs",
+                "gentle round eyes",
+                "small blue neck scarf",
+            ],
+            "must_avoid": [
+                "rabbit ears",
+                "long upright ears",
+                "fluffy rabbit tail",
+                "rabbit body",
+                "white rabbit fur",
+                "turtle replaced by rabbit",
+            ],
+            "required_presence_rules": [
+                "the turtle must be clearly visible as a separate character",
+                "do not merge the turtle with rabbit ears or rabbit body",
+            ],
+        }
+
     return {
         "must_keep": [],
         "must_avoid": [],
@@ -125,7 +178,7 @@ def _generic_visual_identity(subject: str) -> str:
 
 def _generic_must_keep(subject: str) -> List[str]:
     return [
-        f"same main subject: {subject}",
+        f"same character identity: {subject}",
         "same body shape",
         "same color palette",
         "same facial features",

--- a/app/services/character_visual_profile_llm.py
+++ b/app/services/character_visual_profile_llm.py
@@ -471,6 +471,74 @@ def _deterministic_profile_payload(subject: str) -> Dict[str, Any]:
             "confidence": "fallback",
         }
 
+    if "兔" in value or "rabbit" in value.lower() or "bunny" in value.lower():
+        return {
+            "subject": value,
+            "visual_identity": (
+                "A small white storybook rabbit with long upright ears, soft pink inner ears, "
+                "a round fluffy tail, bright friendly eyes, and a small red scarf as its fixed "
+                "signature accessory."
+            ),
+            "must_keep": [
+                "small white storybook rabbit",
+                "long upright rabbit ears",
+                "soft pink inner ears",
+                "round fluffy rabbit tail",
+                "bright friendly eyes",
+                "small red scarf",
+            ],
+            "must_avoid": [
+                "turtle shell",
+                "hard round shell",
+                "turtle body",
+                "short turtle legs",
+                "green turtle skin",
+                "rabbit replaced by turtle",
+            ],
+            "required_presence_rules": [
+                "the rabbit must be clearly visible as a separate character",
+                "do not merge the rabbit with a turtle or shell body",
+            ],
+            "confidence": "fallback",
+        }
+
+    if (
+        "乌龟" in value
+        or "海龟" in value
+        or "龟" in value
+        or "turtle" in value.lower()
+        or "tortoise" in value.lower()
+    ):
+        return {
+            "subject": value,
+            "visual_identity": (
+                "A small green storybook turtle with a round green shell, olive green body, "
+                "short turtle legs, gentle round eyes, and a small blue neck scarf as its "
+                "fixed signature accessory."
+            ),
+            "must_keep": [
+                "small green storybook turtle",
+                "round green turtle shell",
+                "olive green turtle body",
+                "short turtle legs",
+                "gentle round eyes",
+                "small blue neck scarf",
+            ],
+            "must_avoid": [
+                "rabbit ears",
+                "long upright ears",
+                "fluffy rabbit tail",
+                "rabbit body",
+                "white rabbit fur",
+                "turtle replaced by rabbit",
+            ],
+            "required_presence_rules": [
+                "the turtle must be clearly visible as a separate character",
+                "do not merge the turtle with rabbit ears or rabbit body",
+            ],
+            "confidence": "fallback",
+        }
+
     return {
         "subject": value,
         "visual_identity": (
@@ -479,7 +547,7 @@ def _deterministic_profile_payload(subject: str) -> Dict[str, Any]:
             "and one small signature accessory that stays the same in every scene."
         ),
         "must_keep": [
-            f"same main subject: {value}",
+            f"same character identity: {value}",
             "same fixed color palette",
             "same body shape",
             "same facial features",
@@ -742,4 +810,3 @@ def build_llm_character_visual_profiles(
         "count": len(profiles),
         "profiles": profiles,
     }
-

--- a/app/services/character_visual_profile_llm.py
+++ b/app/services/character_visual_profile_llm.py
@@ -477,11 +477,12 @@ def _deterministic_profile_payload(subject: str) -> Dict[str, Any]:
             "visual_identity": (
                 "A small white storybook rabbit with long upright ears, soft pink inner ears, "
                 "a round fluffy tail, bright friendly eyes, and a small red scarf as its fixed "
-                "signature accessory."
+                "signature accessory. Only this rabbit has long upright ears."
             ),
             "must_keep": [
                 "small white storybook rabbit",
                 "long upright rabbit ears",
+                "only the rabbit has long upright ears",
                 "soft pink inner ears",
                 "round fluffy rabbit tail",
                 "bright friendly eyes",
@@ -490,6 +491,7 @@ def _deterministic_profile_payload(subject: str) -> Dict[str, Any]:
             "must_avoid": [
                 "turtle shell",
                 "hard round shell",
+                "shell on rabbit body",
                 "turtle body",
                 "short turtle legs",
                 "green turtle skin",
@@ -513,20 +515,24 @@ def _deterministic_profile_payload(subject: str) -> Dict[str, Any]:
             "subject": value,
             "visual_identity": (
                 "A small green storybook turtle with a round green shell, olive green body, "
-                "short turtle legs, gentle round eyes, and a small blue neck scarf as its "
-                "fixed signature accessory."
+                "an earless rounded turtle head with no external ears, short turtle legs, "
+                "gentle round eyes, and a small blue neck scarf as its fixed signature accessory."
             ),
             "must_keep": [
                 "small green storybook turtle",
                 "round green turtle shell",
                 "olive green turtle body",
+                "earless rounded turtle head",
+                "no external ears on the turtle",
                 "short turtle legs",
                 "gentle round eyes",
                 "small blue neck scarf",
             ],
             "must_avoid": [
                 "rabbit ears",
+                "bunny ears",
                 "long upright ears",
+                "external ears",
                 "fluffy rabbit tail",
                 "rabbit body",
                 "white rabbit fur",
@@ -535,6 +541,7 @@ def _deterministic_profile_payload(subject: str) -> Dict[str, Any]:
             "required_presence_rules": [
                 "the turtle must be clearly visible as a separate character",
                 "do not merge the turtle with rabbit ears or rabbit body",
+                "draw the turtle as an earless turtle, never as a rabbit-like animal",
             ],
             "confidence": "fallback",
         }

--- a/app/services/image_prompt_policy.py
+++ b/app/services/image_prompt_policy.py
@@ -109,7 +109,7 @@ def build_character_separation_block(outputs: Dict[str, Any]) -> str:
         "character separation: keep every character visually distinct",
         "do not transfer visual traits, body parts, clothing, shell, ears, tail, or accessories between characters",
         "each character must keep only its own defined appearance traits",
-        "supporting characters may appear, but they must not change the main subject identity",
+        "each required character must remain a separate readable character, not a background hint",
     ]
 
     for item in characters:
@@ -162,10 +162,10 @@ def build_scene_action_binding_block(
         parts.append(f"must match this story moment: {story}")
 
     parts.append(
-        "keep the main subject visually consistent while changing only pose, framing, background, and action"
+        "keep every required character visually consistent while changing only pose, framing, background, and action"
     )
     parts.append(
-        "do not let supporting characters or props become the main subject of this image"
+        "do not let props or background replace any required character in this image"
     )
 
     return "; ".join(parts)

--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -55,6 +55,7 @@ class ApiImageGeneratorAdapter:
             prompt=task.prompt,
             scene=task.prompt_metadata.get("scene") or {},
             scene_index=int(task.prompt_metadata.get("scene_index") or 1),
+            negative_prompt=str(task.prompt_metadata.get("negative_prompt") or ""),
         )
 
     def _generate_api_image_bytes(
@@ -63,6 +64,7 @@ class ApiImageGeneratorAdapter:
         prompt: str,
         scene: dict[str, Any],
         scene_index: int,
+        negative_prompt: str = "",
     ) -> bytes:
         if self._runner._force_image_rate_limit():
             raise RuntimeError("HTTP 429: IPM limit reached (forced for local testing)")
@@ -84,13 +86,17 @@ class ApiImageGeneratorAdapter:
         if not image_size:
             image_size = "1280x720"
 
-        negative_prompt = os.getenv(
+        default_negative_prompt = os.getenv(
             "SILICONFLOW_IMAGE_NEGATIVE_PROMPT",
             (
                 "low quality, blurry, distorted anatomy, broken composition, "
                 "extra limbs, duplicated subject, unreadable details"
             ),
         ).strip()
+        negative_prompt = self._merge_negative_prompt(
+            default_negative_prompt,
+            negative_prompt,
+        )
 
         num_inference_steps_raw = os.getenv("SILICONFLOW_IMAGE_STEPS", "20").strip()
         guidance_scale_raw = os.getenv("SILICONFLOW_IMAGE_GUIDANCE", "7.5").strip()
@@ -205,6 +211,19 @@ class ApiImageGeneratorAdapter:
         raise RuntimeError(
             f"Generated image download returned empty bytes for scene {scene_index}"
         )
+
+    def _merge_negative_prompt(self, *parts: str) -> str:
+        merged: list[str] = []
+        seen = set()
+
+        for part in parts:
+            for item in str(part or "").replace("；", ",").replace(";", ",").split(","):
+                value = item.strip()
+                if value and value not in seen:
+                    merged.append(value)
+                    seen.add(value)
+
+        return ", ".join(merged)
 
     def _request_generation_response_text(
         self,

--- a/app/services/runner_image_prompts_support.py
+++ b/app/services/runner_image_prompts_support.py
@@ -159,23 +159,36 @@ class RunnerImagePromptsSupport:
                 if not character_visual_profile:
                     character_visual_profile = policy_blocks.get("profile") or {}
 
-                prompt = ", ".join(
-                    part
-                    for part in [
-                        global_style_anchor,
-                        character_anchor,
-                        policy_blocks.get("visual_profile_block"),
-                        policy_blocks.get("character_visual_profiles_block"),
-                        character_block,
+                is_multi_character_scene = len(required_character_names) >= 2
+                prompt_parts = [
+                    global_style_anchor,
+                    character_anchor,
+                    policy_blocks.get("visual_profile_block"),
+                    policy_blocks.get("character_visual_profiles_block"),
+                    character_block,
+                    scene_required_presence_block,
+                    policy_blocks.get("character_separation_block"),
+                    shot_anchor,
+                    policy_blocks.get("scene_action_block"),
+                    story_anchor,
+                    policy_blocks.get("subject_negative_block"),
+                    negative_block,
+                ]
+                if is_multi_character_scene:
+                    prompt_parts = [
                         scene_required_presence_block,
+                        character_block,
+                        policy_blocks.get("character_visual_profiles_block"),
                         policy_blocks.get("character_separation_block"),
+                        global_style_anchor,
                         shot_anchor,
                         policy_blocks.get("scene_action_block"),
                         story_anchor,
-                        policy_blocks.get("subject_negative_block"),
                         negative_block,
                     ]
-                    if part
+
+                prompt = ", ".join(
+                    part for part in prompt_parts if part
                 )
 
                 prompts.append(
@@ -257,23 +270,36 @@ class RunnerImagePromptsSupport:
             if not character_visual_profile:
                 character_visual_profile = policy_blocks.get("profile") or {}
 
-            prompt = ", ".join(
-                part
-                for part in [
-                    global_style_anchor,
-                    character_anchor,
-                    policy_blocks.get("visual_profile_block"),
-                    policy_blocks.get("character_visual_profiles_block"),
-                    character_block,
+            is_multi_character_scene = len(required_character_names) >= 2
+            prompt_parts = [
+                global_style_anchor,
+                character_anchor,
+                policy_blocks.get("visual_profile_block"),
+                policy_blocks.get("character_visual_profiles_block"),
+                character_block,
+                scene_required_presence_block,
+                policy_blocks.get("character_separation_block"),
+                scene_anchor,
+                policy_blocks.get("scene_action_block"),
+                story_anchor,
+                policy_blocks.get("subject_negative_block"),
+                negative_block,
+            ]
+            if is_multi_character_scene:
+                prompt_parts = [
                     scene_required_presence_block,
+                    character_block,
+                    policy_blocks.get("character_visual_profiles_block"),
                     policy_blocks.get("character_separation_block"),
+                    global_style_anchor,
                     scene_anchor,
                     policy_blocks.get("scene_action_block"),
                     story_anchor,
-                    policy_blocks.get("subject_negative_block"),
                     negative_block,
                 ]
-                if part
+
+            prompt = ", ".join(
+                part for part in prompt_parts if part
             )
 
             prompts.append(

--- a/app/services/runner_image_prompts_support.py
+++ b/app/services/runner_image_prompts_support.py
@@ -111,6 +111,22 @@ class RunnerImagePromptsSupport:
                 text = str(shot.get("text") or "").strip()
 
                 scene_data = scene_map.get(scene_id) or {}
+                enriched_scene_characters = (
+                    runner._scene_characters.enriched_scene_characters_from_manifest(
+                        outputs,
+                        scene_data,
+                    )
+                )
+                required_character_ids = (
+                    runner._scene_characters.character_ids_from_bindings(
+                        enriched_scene_characters
+                    )
+                )
+                required_character_names = (
+                    runner._scene_characters.character_names_from_bindings(
+                        enriched_scene_characters
+                    )
+                )
                 character_block = runner._scene_characters.scene_character_prompt_block(
                     outputs, scene_data
                 )
@@ -168,6 +184,8 @@ class RunnerImagePromptsSupport:
                         "scene_id": scene_id,
                         "scene_title": scene_title,
                         "characters": scene_data.get("characters") or [],
+                        "required_character_ids": required_character_ids,
+                        "required_character_names": required_character_names,
                         "prompt": prompt,
                         "character_anchor": character_anchor_metadata,
                         "reference_images": character_anchor_metadata.get(
@@ -192,6 +210,20 @@ class RunnerImagePromptsSupport:
             shot_type = str(scene.get("shot_type", "medium")).strip()
             transition = str(scene.get("transition", "fade")).strip()
             scene_title = str(scene.get("scene_title", "")).strip()
+            enriched_scene_characters = (
+                runner._scene_characters.enriched_scene_characters_from_manifest(
+                    outputs,
+                    scene,
+                )
+            )
+            required_character_ids = runner._scene_characters.character_ids_from_bindings(
+                enriched_scene_characters
+            )
+            required_character_names = (
+                runner._scene_characters.character_names_from_bindings(
+                    enriched_scene_characters
+                )
+            )
 
             character_block = runner._scene_characters.scene_character_prompt_block(
                 outputs, scene
@@ -248,10 +280,9 @@ class RunnerImagePromptsSupport:
                 {
                     "scene_id": scene_id,
                     "scene_title": scene_title,
-                    "characters": runner._scene_characters.enriched_scene_characters_from_manifest(
-                        outputs,
-                        scene,
-                    ),
+                    "characters": enriched_scene_characters,
+                    "required_character_ids": required_character_ids,
+                    "required_character_names": required_character_names,
                     "prompt": prompt,
                     "character_anchor": character_anchor_metadata,
                     "reference_images": character_anchor_metadata.get(

--- a/app/services/runner_scene_characters.py
+++ b/app/services/runner_scene_characters.py
@@ -15,6 +15,82 @@ class RunnerSceneCharactersSupport:
     def __init__(self, runner: Any) -> None:
         self._runner = runner
 
+    def _character_label(self, item: Dict[str, Any]) -> str:
+        return (
+            str(item.get("display_name") or "").strip()
+            or str(item.get("species") or "").strip()
+            or str(item.get("character_id") or "").strip()
+        )
+
+    def _character_family(self, item: Dict[str, Any]) -> str:
+        text = " ".join(
+            [
+                str(item.get("display_name") or ""),
+                str(item.get("species") or ""),
+                str(item.get("visual_identity") or ""),
+            ]
+        ).lower()
+
+        if any(keyword in text for keyword in ["rabbit", "bunny", "兔"]):
+            return "rabbit"
+        if any(keyword in text for keyword in ["turtle", "tortoise", "乌龟", "海龟", "龟"]):
+            return "turtle"
+        return ""
+
+    def _family_forbidden_traits(self, family: str) -> List[str]:
+        if family == "rabbit":
+            return [
+                "no rabbit ears",
+                "no long upright rabbit ears",
+                "no fluffy rabbit tail",
+                "no rabbit body",
+            ]
+        if family == "turtle":
+            return [
+                "no turtle shell",
+                "no hard turtle shell",
+                "no turtle body",
+                "no short turtle legs",
+            ]
+        return []
+
+    def _cross_character_forbidden_traits(
+        self,
+        character: Dict[str, Any],
+        scene_characters: List[Dict[str, Any]],
+    ) -> List[str]:
+        character_family = self._character_family(character)
+        if not character_family:
+            return []
+
+        other_families: List[str] = []
+        for other in scene_characters:
+            if not isinstance(other, dict):
+                continue
+
+            other_label = self._character_label(other)
+            character_label = self._character_label(character)
+            if other_label and other_label == character_label:
+                continue
+
+            other_family = self._character_family(other)
+            if (
+                other_family
+                and other_family != character_family
+                and other_family not in other_families
+            ):
+                other_families.append(other_family)
+
+        constraints: List[str] = []
+        seen = set()
+        for family in other_families:
+            for trait in self._family_forbidden_traits(family):
+                if trait and trait not in seen:
+                    constraints.append(trait)
+                    seen.add(trait)
+
+        return constraints
+
     def enriched_scene_characters_from_manifest(
         self,
         outputs: Dict[str, Any],
@@ -188,6 +264,10 @@ class RunnerSceneCharactersSupport:
 
         parts: List[str] = []
         required_names: List[str] = []
+        enriched_scene_characters = self.enriched_scene_characters_from_manifest(
+            outputs,
+            scene,
+        )
 
         for binding in scene_characters:
             if not isinstance(binding, dict):
@@ -204,6 +284,10 @@ class RunnerSceneCharactersSupport:
 
             signature_traits = manifest_item.get("signature_traits") or []
             forbidden_traits = manifest_item.get("forbidden_traits") or []
+            cross_forbidden_traits = self._cross_character_forbidden_traits(
+                manifest_item,
+                enriched_scene_characters,
+            )
 
             name = display_name or species
             if name and name not in required_names:
@@ -214,6 +298,11 @@ class RunnerSceneCharactersSupport:
             )
             forbidden_text = ", ".join(
                 item.strip() for item in forbidden_traits if str(item).strip()
+            )
+            cross_forbidden_text = ", ".join(
+                item.strip()
+                for item in cross_forbidden_traits
+                if str(item).strip()
             )
 
             detail_parts = [
@@ -226,6 +315,9 @@ class RunnerSceneCharactersSupport:
                 "presence rule: when this character is required by the scene, it must appear as a real on-screen character in the frame",
                 f"must keep: {signature_text}" if signature_text else "",
                 f"must avoid: {forbidden_text}" if forbidden_text else "",
+                f"cross-character must avoid: {cross_forbidden_text}"
+                if cross_forbidden_text
+                else "",
             ]
             detail_text = "; ".join(part for part in detail_parts if part)
             if detail_text:
@@ -273,6 +365,23 @@ class RunnerSceneCharactersSupport:
                 if value:
                     negatives.append(value)
 
+        enriched_scene_characters = self.enriched_scene_characters_from_manifest(
+            outputs,
+            scene,
+        )
+        for character in enriched_scene_characters:
+            if not isinstance(character, dict):
+                continue
+
+            label = self._character_label(character)
+            for item in self._cross_character_forbidden_traits(
+                character,
+                enriched_scene_characters,
+            ):
+                value = str(item or "").strip()
+                if value:
+                    negatives.append(f"{label}: {value}" if label else value)
+
         generic_negatives = [
             "missing required scene character",
             "character omitted from scene",
@@ -283,6 +392,7 @@ class RunnerSceneCharactersSupport:
             "trait transfer between characters",
             "mixed body parts between characters",
             "merged characters",
+            "one character wearing another character's defining body traits",
         ]
         negatives.extend(generic_negatives)
 
@@ -309,5 +419,19 @@ class RunnerSceneCharactersSupport:
             if character_id and character_id not in seen:
                 results.append(character_id)
                 seen.add(character_id)
+
+        return results
+
+    def character_names_from_bindings(self, bindings: List[Dict[str, Any]]) -> List[str]:
+        results: List[str] = []
+        seen = set()
+
+        for item in bindings:
+            if not isinstance(item, dict):
+                continue
+            name = self._character_label(item)
+            if name and name not in seen:
+                results.append(name)
+                seen.add(name)
 
         return results

--- a/app/services/runner_scene_characters.py
+++ b/app/services/runner_scene_characters.py
@@ -232,19 +232,22 @@ class RunnerSceneCharactersSupport:
 
         parts = [
             f"required scene characters: {required_text}",
+            f"first priority: draw a multi-character scene with {required_text}, not a solo portrait",
             f"hard requirement: include all of {required_text} together in the same image",
             f"hard requirement: {required_text} must all be clearly visible at the same time in one coherent composition",
             "every listed scene character must be a real on-screen character in the frame, not omitted, not hidden, not cropped out, and not reduced to a tiny background decoration",
             "do not render only one character when multiple required scene characters are listed",
             "do not omit any listed scene character",
             "do not merge multiple characters into one body",
+            "do not create a hybrid creature that combines traits from multiple required characters",
             "do not replace one character with another character",
-            f"{primary_text} remains the main protagonist and visual focus",
+            "give every required character clear readable scale and enough visual space",
+            f"{primary_text} may lead the action, but must not hide, replace, or visually erase the other required characters",
         ]
 
         if secondary_text:
             parts.append(
-                f"{secondary_text} are required supporting characters and are not optional background hints"
+                f"{secondary_text} must be clearly visible near {primary_text} and are not optional background hints"
             )
 
         parts.append(

--- a/app/services/runner_scene_characters.py
+++ b/app/services/runner_scene_characters.py
@@ -41,7 +41,9 @@ class RunnerSceneCharactersSupport:
         if family == "rabbit":
             return [
                 "no rabbit ears",
+                "no bunny ears",
                 "no long upright rabbit ears",
+                "no external ears",
                 "no fluffy rabbit tail",
                 "no rabbit body",
             ]
@@ -49,6 +51,7 @@ class RunnerSceneCharactersSupport:
             return [
                 "no turtle shell",
                 "no hard turtle shell",
+                "no shell on body",
                 "no turtle body",
                 "no short turtle legs",
             ]
@@ -241,6 +244,9 @@ class RunnerSceneCharactersSupport:
             "do not merge multiple characters into one body",
             "do not create a hybrid creature that combines traits from multiple required characters",
             "do not replace one character with another character",
+            "anatomy separation: only rabbit characters may have long upright ears; only turtle characters may have shells",
+            "turtle anatomy rule: turtles must have an earless rounded reptile head with no external ears",
+            "rabbit anatomy rule: rabbits must not have a shell or turtle body",
             "give every required character clear readable scale and enough visual space",
             f"{primary_text} may lead the action, but must not hide, replace, or visually erase the other required characters",
         ]
@@ -316,6 +322,7 @@ class RunnerSceneCharactersSupport:
                 "appearance lock: keep the same body shape, proportions, facial features, dominant colors, outfit or shell or ears or tail, and the same signature accessory or detail in every scene",
                 "consistency rule: do not redesign this character between scenes; only change pose, camera angle, expression, background, and current action",
                 "presence rule: when this character is required by the scene, it must appear as a real on-screen character in the frame",
+                "strict anatomy rule: do not transfer this character's defining anatomy to any other character",
                 f"must keep: {signature_text}" if signature_text else "",
                 f"must avoid: {forbidden_text}" if forbidden_text else "",
                 f"cross-character must avoid: {cross_forbidden_text}"

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -16,15 +16,38 @@ class RunnerSingleSceneImageSupport:
         self,
         characters: List[Dict[str, Any]],
     ) -> str:
+        family_text = " ".join(
+            " ".join(
+                [
+                    str(character.get("display_name") or ""),
+                    str(character.get("species") or ""),
+                    str(character.get("visual_identity") or ""),
+                ]
+            )
+            for character in characters
+            if isinstance(character, dict)
+        ).lower()
+        has_rabbit = any(keyword in family_text for keyword in ["rabbit", "bunny", "兔"])
+        has_turtle = any(
+            keyword in family_text for keyword in ["turtle", "tortoise", "乌龟", "海龟", "龟"]
+        )
+
         negatives: List[str] = [
             "hybrid rabbit turtle creature",
             "rabbit with turtle shell",
+            "rabbit wearing turtle shell",
+            "shell on rabbit body",
             "turtle with rabbit ears",
+            "turtle with bunny ears",
+            "turtle with long upright ears",
+            "turtle with external ears",
             "mixed animal anatomy",
             "merged characters",
             "one body containing multiple characters",
             "missing required character",
             "solo portrait when multiple characters are required",
+            "malformed animal anatomy",
+            "unclear character species",
         ]
 
         for character in characters:
@@ -44,7 +67,27 @@ class RunnerSingleSceneImageSupport:
             if isinstance(forbidden_traits, list):
                 for item in forbidden_traits:
                     value = str(item or "").strip()
-                    if value:
+                    lowered = value.lower()
+                    conflicts_with_required_rabbit = has_rabbit and (
+                        "rabbit ear" in lowered
+                        or "bunny ear" in lowered
+                        or "upright ear" in lowered
+                        or "external ear" in lowered
+                        or "rabbit tail" in lowered
+                        or "rabbit body" in lowered
+                        or "rabbit fur" in lowered
+                    )
+                    conflicts_with_required_turtle = has_turtle and (
+                        "turtle shell" in lowered
+                        or "hard round shell" in lowered
+                        or "turtle body" in lowered
+                        or "turtle leg" in lowered
+                        or "turtle skin" in lowered
+                    )
+                    if value and not (
+                        conflicts_with_required_rabbit
+                        or conflicts_with_required_turtle
+                    ):
                         negatives.append(value)
 
         deduped: List[str] = []

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -12,6 +12,51 @@ class RunnerSingleSceneImageSupport:
     def __init__(self, runner: Any) -> None:
         self._runner = runner
 
+    def scene_negative_prompt_from_characters(
+        self,
+        characters: List[Dict[str, Any]],
+    ) -> str:
+        negatives: List[str] = [
+            "hybrid rabbit turtle creature",
+            "rabbit with turtle shell",
+            "turtle with rabbit ears",
+            "mixed animal anatomy",
+            "merged characters",
+            "one body containing multiple characters",
+            "missing required character",
+            "solo portrait when multiple characters are required",
+        ]
+
+        for character in characters:
+            if not isinstance(character, dict):
+                continue
+
+            forbidden_traits = character.get("forbidden_traits") or []
+            if isinstance(forbidden_traits, str):
+                forbidden_traits = [
+                    item.strip()
+                    for item in forbidden_traits.replace("；", ",")
+                    .replace(";", ",")
+                    .split(",")
+                    if item.strip()
+                ]
+
+            if isinstance(forbidden_traits, list):
+                for item in forbidden_traits:
+                    value = str(item or "").strip()
+                    if value:
+                        negatives.append(value)
+
+        deduped: List[str] = []
+        seen = set()
+        for item in negatives:
+            value = str(item or "").strip()
+            if value and value not in seen:
+                deduped.append(value)
+                seen.add(value)
+
+        return ", ".join(deduped)
+
     def run_single_scene_pillow_image_asset(
         self,
         *,
@@ -115,6 +160,9 @@ class RunnerSingleSceneImageSupport:
             prompt_item=prompt_item,
             fallback_scene_title=str(scene.get("scene_title") or "").strip(),
         )
+        negative_prompt = self.scene_negative_prompt_from_characters(
+            asset_meta["characters"]
+        )
 
         candidate_asset_refs: List[Dict[str, Any]] = []
         adapter = ApiImageGeneratorAdapter(runner)
@@ -148,6 +196,7 @@ class RunnerSingleSceneImageSupport:
                     "ctx": ctx,
                     "scene": candidate_scene,
                     "scene_index": scene_index + candidate_index,
+                    "negative_prompt": negative_prompt,
                 },
             )
 
@@ -169,6 +218,7 @@ class RunnerSingleSceneImageSupport:
                     "public_url": task.public_url,
                     "mime_type": "image/png",
                     "provider": "api_image_generator",
+                    "negative_prompt": negative_prompt,
                 }
             )
 
@@ -186,6 +236,7 @@ class RunnerSingleSceneImageSupport:
             "characters": asset_meta["characters"],
             "character_ids": asset_meta["character_ids"],
             "prompt": base_prompt,
+            "negative_prompt": negative_prompt,
             "selected_asset_ref": dict(selected_asset_ref),
             "file_name": selected_asset_ref["file_name"],
             "relative_path": selected_asset_ref["relative_path"],

--- a/app/services/runner_story_text.py
+++ b/app/services/runner_story_text.py
@@ -28,9 +28,9 @@ class RunnerStoryTextSupport:
             {
                 "duration_sec": 60,
                 "scene_count": 6,
-                "target_min_chars": 190,
-                "target_max_chars": 260,
-                "target_chars": 230,
+                "target_min_chars": 420,
+                "target_max_chars": 520,
+                "target_chars": 470,
             },
             {
                 "duration_sec": 120,

--- a/app/services/runner_story_text.py
+++ b/app/services/runner_story_text.py
@@ -28,9 +28,9 @@ class RunnerStoryTextSupport:
             {
                 "duration_sec": 60,
                 "scene_count": 6,
-                "target_min_chars": 420,
-                "target_max_chars": 520,
-                "target_chars": 470,
+                "target_min_chars": 250,
+                "target_max_chars": 310,
+                "target_chars": 280,
             },
             {
                 "duration_sec": 120,

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -530,6 +530,16 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - 自动筛选器需要检测/评估候选图是否包含所有 required characters；缺失关键角色时不能选中。
 - 补进程内验证：`兔子和乌龟赛跑` 的 storyboard / image_prompts / image_assets contract 中，每个相关 scene 都保留两个角色约束。
 
+**已采用修复（prompt contract 层）**：
+
+- `image_prompts` 每条 prompt 增加 `required_character_ids` / `required_character_names` metadata。
+- 多角色 scene prompt 保留 `scene cast lock` / `required scene characters` 强约束，明确要求所有角色同框且不可省略。
+- 补充 `verify_bug004_005_multi_character_prompt_contract.py`，覆盖非结构化主题“兔子和乌龟赛跑”的角色 manifest、storyboard、prompt 必需角色约束。
+
+**仍需后续跟进**：
+
+- 真实图片候选是否真的包含全部角色，需要 BUG-007 的自动筛选器接入 required character metadata 后继续验证。
+
 **优先级**：P0。建议下一步优先修。
 
 ---
@@ -566,6 +576,18 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - 每个 scene prompt 同时包含 `must_keep` 与 `must_avoid`。
 - 筛选器把“角色特征串扰”作为强扣分或失败条件。
 - 补验证脚本覆盖兔子/乌龟互斥特征写入 prompt。
+
+**已采用修复（prompt contract 层）**：
+
+- 多角色 scene 自动生成跨角色 negative constraints，例如：
+  - 兔子不能有 turtle shell / turtle body / short turtle legs。
+  - 乌龟不能有 rabbit ears / fluffy rabbit tail / rabbit body。
+- `scene_character_prompt_block` 写入 `cross-character must avoid`。
+- `scene_character_negative_block` 写入带角色名的串扰负面约束，避免不同角色身体特征互相污染。
+
+**仍需后续跟进**：
+
+- 真实候选图是否仍存在串扰，需要 BUG-007 的候选评分/筛选逻辑把这些 forbidden traits 作为硬扣分或失败条件。
 
 **优先级**：P0。建议和 BUG-004 同一轮修复。
 

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -535,6 +535,7 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - `image_prompts` 每条 prompt 增加 `required_character_ids` / `required_character_names` metadata。
 - 多角色 scene prompt 保留 `scene cast lock` / `required scene characters` 强约束，明确要求所有角色同框且不可省略。
 - 补充 `verify_bug004_005_multi_character_prompt_contract.py`，覆盖非结构化主题“兔子和乌龟赛跑”的角色 manifest、storyboard、prompt 必需角色约束。
+- 真实出图复测发现模型仍被“主角兔子”前置提示带偏后，已把多角色 required characters 约束前置到 prompt 开头，并增加 `not a solo portrait` 防单角色肖像约束。
 
 **仍需后续跟进**：
 
@@ -584,6 +585,8 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
   - 乌龟不能有 rabbit ears / fluffy rabbit tail / rabbit body。
 - `scene_character_prompt_block` 写入 `cross-character must avoid`。
 - `scene_character_negative_block` 写入带角色名的串扰负面约束，避免不同角色身体特征互相污染。
+- 为兔子 / 乌龟 deterministic visual profile 增加固定外观、固定配饰和互斥特征，避免 LLM profile 失败时回落到过于泛化的“same color palette”描述。
+- 真实复测仍出现兔子有壳、乌龟有耳朵后，已把 `hybrid rabbit turtle creature`、`rabbit with turtle shell`、`turtle with rabbit ears` 等约束写入 API 生图请求的 `negative_prompt` 字段。
 
 **仍需后续跟进**：
 
@@ -661,3 +664,32 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - 如果需要视觉级判断，后续接入视觉模型评审候选图。
 
 **优先级**：P1。建议在 BUG-004 / BUG-005 后修，否则筛选器缺少可靠评分目标。
+
+---
+
+## BUG-008: 60s 主题最终音频/视频只有约 40s
+
+**发现日期**：2026-05-25（真实前端验证时）
+
+**触发条件**：
+
+选择 `duration_sec=60`，开启旁白/音频并生成最终视频。
+
+**当前现象**：
+
+最终视频跟随真实 TTS 音频时长，只有约 40s；不是 final video 合成层被硬截断，而是故事/分镜旁白文本总量偏短，真实音频读完后视频自然结束。
+
+**原因定位**：
+
+60s story plan 的目标中文字符数只有 `190-260`，对真实 TTS 来说偏短，容易生成约 40s 左右的旁白。
+
+**已采用修复**：
+
+- 将 60s story plan 调整为 `420-520` 中文字符，目标约 `470` 字。
+- 补充 Step 8 验证，确保 60s template fallback story 达到新的最低文本长度。
+
+**仍需后续跟进**：
+
+- 真实 TTS 语速会随 provider/voice 波动，后续可以增加“音频总时长低于目标阈值时提示或重试扩写旁白”的闭环。
+
+**优先级**：P0。属于用户可见时长回归，建议和本轮一起提交。

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -491,3 +491,151 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 
 - Step 19 只做 `refresh_image_review_scene` 的等价搬移。
 - 这个问题属于现有 API 调用契约不一致，修复会改变 `/v1/image-review/refresh` 行为，适合单独提交。
+
+---
+
+## BUG-004: 多角色主题生成图缺少关键角色
+
+**发现日期**：2026-05-25（真实生图前端验证时）
+
+**触发条件**：
+
+主题包含多个核心角色，例如：
+
+```text
+写一个关于兔子和乌龟赛跑的故事
+```
+
+**当前现象**：
+
+生成出的图片里经常只有兔子，没有乌龟；即使故事和分镜中包含乌龟，候选图也可能没有把乌龟画出来。
+
+**用户可见影响**：
+
+- 故事主题和画面内容不一致。
+- 多角色故事无法成立，后续视频画面也会缺失关键角色。
+- 用户会认为系统没有理解主题。
+
+**可能原因**：
+
+- scene 的 `characters` / `character_ids` 没有稳定传入真实生图 prompt。
+- image prompt 对“每个 scene 必须出现哪些角色”的约束不够强。
+- prompt 对 supporting / secondary 角色的权重不足，模型倾向只画主角。
+- 自动选图器没有把“缺少角色”作为硬性失败条件。
+
+**建议修复**：
+
+- 在 image prompt 中增加 scene-level required character list，例如 `required_characters`。
+- 对每个 scene 明确写入“必须同时出现：兔子、乌龟”，而不是只在全局角色 profile 里描述。
+- 自动筛选器需要检测/评估候选图是否包含所有 required characters；缺失关键角色时不能选中。
+- 补进程内验证：`兔子和乌龟赛跑` 的 storyboard / image_prompts / image_assets contract 中，每个相关 scene 都保留两个角色约束。
+
+**优先级**：P0。建议下一步优先修。
+
+---
+
+## BUG-005: 多角色身份串扰，角色特征互相污染
+
+**发现日期**：2026-05-25（真实生图前端验证时）
+
+**触发条件**：
+
+主题或结构化角色中同时包含外形差异大的角色，例如兔子和乌龟。
+
+**当前现象**：
+
+- 乌龟会长兔耳朵。
+- 兔子会出现乌龟壳。
+- 不同角色的物种、服装、身体特征互相串。
+
+**用户可见影响**：
+
+画面中角色身份混乱，用户无法判断哪个角色是谁；多角色故事的视频连续性被破坏。
+
+**可能原因**：
+
+- 角色 identity lock 只描述了角色本身，但没有足够强的 negative constraints。
+- prompt 没有明确写“兔子不能有壳 / 乌龟不能有兔耳朵”等跨角色 forbidden traits。
+- 候选筛选器没有识别 identity leakage。
+
+**建议修复**：
+
+- 从 `character_manifest` 生成 cross-character negative constraints：
+  - 兔子：must_avoid turtle shell。
+  - 乌龟：must_avoid rabbit ears。
+- 每个 scene prompt 同时包含 `must_keep` 与 `must_avoid`。
+- 筛选器把“角色特征串扰”作为强扣分或失败条件。
+- 补验证脚本覆盖兔子/乌龟互斥特征写入 prompt。
+
+**优先级**：P0。建议和 BUG-004 同一轮修复。
+
+---
+
+## BUG-006: 角色跨图不一致，装饰、服装、外貌和颜色漂移
+
+**发现日期**：2026-05-25（真实生图前端验证时）
+
+**触发条件**：
+
+同一个 workflow 生成多个 scene / candidate 图。
+
+**当前现象**：
+
+同一角色在不同图片里的装饰、衣服、外貌甚至颜色不一致；例如同一只兔子在不同场景中颜色、服装、配饰变化明显。
+
+**用户可见影响**：
+
+多张图无法构成连续故事，最终视频像是多个不同角色拼接。
+
+**可能原因**：
+
+- 角色视觉 profile 不够具体，缺少稳定的 color palette / outfit / accessory 锁定字段。
+- 每张图 prompt 没有重复引用完整角色视觉锚点。
+- 真实生图 provider 没有参考图或 seed 锁定，纯文本 prompt 难以保持跨图一致。
+
+**建议修复**：
+
+- 为每个角色生成稳定视觉签名：
+  - 主色、辅色、衣服、配饰、体型、面部特征。
+- 每个 image prompt 都注入同一份角色视觉签名。
+- 如果 provider 支持参考图/seed，后续增加 reference image 或 seed 策略。
+- 在 `image_review` 中展示角色一致性风险，便于人工选择。
+
+**优先级**：P1。BUG-004 / BUG-005 修完后处理。
+
+---
+
+## BUG-007: 图片自动筛选器没有生效，总是默认选择第一张
+
+**发现日期**：2026-05-25（真实生图前端验证时）
+
+**触发条件**：
+
+每个 scene 生成多张候选图后进入自动筛选流程。
+
+**当前现象**：
+
+自动筛选器看起来没有真正按质量/角色匹配评分，总是默认选择第一张候选图。
+
+**用户可见影响**：
+
+- 如果第一张缺角色或角色串扰，系统仍会自动选中。
+- “候选图筛选”功能名存实亡，用户需要手动检查每一张。
+
+**可能原因**：
+
+- 当前筛选器可能只做占位逻辑或 fallback 到第一张。
+- 没有从候选图本身提取可评分信号。
+- 没有把 prompt contract（required characters / forbidden traits）接入评分。
+
+**建议修复**：
+
+- 先明确当前 selector 的真实逻辑，补一个验证证明它不是固定选第一张。
+- 如果当前只能基于 metadata，至少按以下规则排序：
+  - provider 成功状态。
+  - required characters 是否完整。
+  - 是否包含 identity leakage 风险。
+  - prompt/candidate metadata 是否完整。
+- 如果需要视觉级判断，后续接入视觉模型评审候选图。
+
+**优先级**：P1。建议在 BUG-004 / BUG-005 后修，否则筛选器缺少可靠评分目标。

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -558,6 +558,7 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - 乌龟会长兔耳朵。
 - 兔子会出现乌龟壳。
 - 不同角色的物种、服装、身体特征互相串。
+- 2026-05-25 真实复测：即使 prompt / negative prompt 已强化，仍出现“蓝色兔耳乌龟”“兔子背乌龟壳”“画面中出现额外小乌龟壳”等明显串扰。
 
 **用户可见影响**：
 
@@ -587,12 +588,16 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - `scene_character_negative_block` 写入带角色名的串扰负面约束，避免不同角色身体特征互相污染。
 - 为兔子 / 乌龟 deterministic visual profile 增加固定外观、固定配饰和互斥特征，避免 LLM profile 失败时回落到过于泛化的“same color palette”描述。
 - 真实复测仍出现兔子有壳、乌龟有耳朵后，已把 `hybrid rabbit turtle creature`、`rabbit with turtle shell`、`turtle with rabbit ears` 等约束写入 API 生图请求的 `negative_prompt` 字段。
+- 真实复测仍出现乌龟长耳朵后，继续强化正向结构约束：乌龟必须是 `earless rounded turtle head / no external ears`，只有兔子有长耳，只有乌龟有壳；同时避免在全局 `negative_prompt` 中写入裸的 `rabbit ears` / `turtle shell`，只禁止 `turtle with rabbit ears`、`rabbit with turtle shell` 这类串扰组合，避免把合法特征也负向掉。
 
 **仍需后续跟进**：
 
-- 真实候选图是否仍存在串扰，需要 BUG-007 的候选评分/筛选逻辑把这些 forbidden traits 作为硬扣分或失败条件。
+- 仅靠继续叠加 prompt / negative prompt 已经接近收益上限，真实 provider 仍可能把兔子和乌龟的身体特征混合。
+- 下一步应转为“视觉级失败检测 + 自动重试”：检测到乌龟长兔耳、兔子背龟壳、缺少必需角色、额外混合物种角色时，候选图直接判失败并重新生成。
+- 如果 provider 支持 reference image / seed / character consistency，应引入每个角色的参考图或稳定 seed；纯文本 prompt 很难保证多图、多角色一致。
+- BUG-007 的候选评分/筛选逻辑必须把这些 forbidden traits 作为硬扣分或失败条件，不能继续默认选择第一张。
 
-**优先级**：P0。建议和 BUG-004 同一轮修复。
+**优先级**：P0。prompt contract 已做基础修复，但真实画面仍未达产品可用标准；下一步优先做视觉检测/自动重试或参考图一致性方案。
 
 ---
 
@@ -606,7 +611,7 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 
 **当前现象**：
 
-同一角色在不同图片里的装饰、衣服、外貌甚至颜色不一致；例如同一只兔子在不同场景中颜色、服装、配饰变化明显。
+同一角色在不同图片里的装饰、衣服、外貌甚至颜色不一致；例如同一只兔子在不同场景中颜色、服装、配饰变化明显。2026-05-25 真实复测中，同一组兔子/乌龟仍会出现颜色、体型和物种特征漂移。
 
 **用户可见影响**：
 
@@ -625,8 +630,9 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - 每个 image prompt 都注入同一份角色视觉签名。
 - 如果 provider 支持参考图/seed，后续增加 reference image 或 seed 策略。
 - 在 `image_review` 中展示角色一致性风险，便于人工选择。
+- 仅靠当前文本 prompt 不能稳定保证跨图一致性，建议把 reference image / seed / 视觉评审重试作为后续主方案。
 
-**优先级**：P1。BUG-004 / BUG-005 修完后处理。
+**优先级**：P0。现在已影响最终视频观感，建议和 BUG-005 的视觉检测/自动重试一起做。
 
 ---
 
@@ -677,19 +683,19 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 
 **当前现象**：
 
-最终视频跟随真实 TTS 音频时长，只有约 40s；不是 final video 合成层被硬截断，而是故事/分镜旁白文本总量偏短，真实音频读完后视频自然结束。
+最终视频跟随真实 TTS 音频时长，曾只有约 40s；不是 final video 合成层被硬截断，而是故事/分镜旁白文本总量偏短，真实音频读完后视频自然结束。后续一次修复把 60s 文本目标调到 `420-520` 字，真实验证又生成约 1:25；再调到 `300-380` 字后真实验证仍约 1:14；最终调到 `250-310` 字后真实复测约 0:58，基本符合 60s 预期。
 
 **原因定位**：
 
-60s story plan 的目标中文字符数只有 `190-260`，对真实 TTS 来说偏短，容易生成约 40s 左右的旁白。
+60s story plan 的目标中文字符数原本只有 `190-260`，对真实 TTS 来说偏短，容易生成约 40s 左右的旁白；但 `420-520` 会把真实音频拉到约 80s+，`300-380` 仍会拉到 70s+，需要按真实 TTS 结果做中间校准。
 
 **已采用修复**：
 
-- 将 60s story plan 调整为 `420-520` 中文字符，目标约 `470` 字。
+- 将 60s story plan 调整为 `250-310` 中文字符，目标约 `280` 字，按真实 TTS 验证结果从过长配置继续回调到更接近 60s 的范围。
 - 补充 Step 8 验证，确保 60s template fallback story 达到新的最低文本长度。
 
 **仍需后续跟进**：
 
 - 真实 TTS 语速会随 provider/voice 波动，后续可以增加“音频总时长低于目标阈值时提示或重试扩写旁白”的闭环。
 
-**优先级**：P0。属于用户可见时长回归，建议和本轮一起提交。
+**优先级**：P1。当前 60s 真实复测已基本可接受，后续做音频时长闭环即可。

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -906,24 +906,23 @@ function markPlaceholderState(
   )
 }
 
-function formatApiErrorDetail(sceneId: string, status: number, errorBody: unknown): string {
+function formatImageReviewUserError(sceneId: string, status: number, errorBody: unknown): string {
   const body = errorBody as Record<string, unknown> | null
   const detailValue = body && typeof body === 'object' ? body.detail : undefined
+  const detail =
+    detailValue && typeof detailValue === 'object' ? (detailValue as ApiErrorDetail) : null
+  const detailSceneId = detail?.scene_id || sceneId
+  const code = String(detail?.code || '').toUpperCase()
 
-  if (typeof detailValue === 'string') {
-    return `${sceneId} 候选图生成失败：HTTP ${status} · ${detailValue}`
+  if (status >= 500 || code === 'IMAGE_GENERATION_FAILED') {
+    return `${detailSceneId} 候选图生成失败：图片服务暂时不可用，请稍后重试。`
   }
 
-  if (detailValue && typeof detailValue === 'object') {
-    const detail = detailValue as ApiErrorDetail
-    const code = detail.code ? ` · ${detail.code}` : ''
-    const provider = detail.provider ? ` · provider=${detail.provider}` : ''
-    const message = detail.message ? ` · ${detail.message}` : ''
-    const detailSceneId = detail.scene_id || sceneId
-    return `${detailSceneId} 候选图生成失败：HTTP ${status}${code}${provider}${message}`
+  if (status === 408 || status === 429) {
+    return `${detailSceneId} 候选图生成失败：图片服务响应较慢，请稍后重试。`
   }
 
-  return `${sceneId} 候选图生成失败：HTTP ${status} · ${JSON.stringify(errorBody)}`
+  return `${detailSceneId} 候选图生成失败：请稍后重试。`
 }
 async function fetchSamplesSummary() {
   const response = await fetch(`${apiBaseUrl}/v1/samples/summary`)
@@ -1243,20 +1242,23 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw error
     }
-    const message = error instanceof Error ? error.message : 'unknown network error'
-    throw new Error(`${sceneId} 候选图生成失败：无法连接后端或请求被中断 · ${message}`)
+    console.warn('[image-review] refresh-scene network error', sceneId, error)
+    throw new Error(`${sceneId} 候选图生成失败：网络连接不稳定，请稍后重试。`)
   }
 
   if (!response.ok) {
     let message = ''
     try {
       const errorBody = await response.json()
-      message = formatApiErrorDetail(sceneId, response.status, errorBody)
+      console.warn('[image-review] refresh-scene failed', sceneId, response.status, errorBody)
+      message = formatImageReviewUserError(sceneId, response.status, errorBody)
     } catch {
       const detail = await response.text().catch(() => '')
-      message = `${sceneId} 候选图生成失败：HTTP ${response.status}${
-        detail ? ` · ${detail}` : ''
-      }`
+      console.warn('[image-review] refresh-scene failed', sceneId, response.status, detail)
+      message =
+        response.status >= 500
+          ? `${sceneId} 候选图生成失败：图片服务暂时不可用，请稍后重试。`
+          : `${sceneId} 候选图生成失败：请稍后重试。`
     }
 
     throw new Error(message)
@@ -1343,6 +1345,7 @@ async function refreshImageReview() {
   errorMessage.value = ''
 
   const failures: string[] = []
+  const refreshTotal = sceneRefreshQueue.value.length
 
   try {
     for (const sceneId of sceneRefreshQueue.value) {
@@ -1378,7 +1381,7 @@ async function refreshImageReview() {
   }
 
   if (failures.length > 0) {
-    errorMessage.value = `部分候选图生成失败：${failures.join('；')}`
+    errorMessage.value = `部分候选图生成失败：${failures.length}/${refreshTotal} 个场景未完成。图片服务暂时不可用，请在 Review 中重试失败场景或稍后再试。`
     return
   }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1823,6 +1823,7 @@ async function runWorkflow() {
               :workflow-response="currentWorkflowResponse"
               :render-in-flight="finalVideoRenderInFlight"
               :loading="workflowIsProcessing || refreshingImageReview || finalVideoRenderInFlight"
+              :error-message="errorMessage"
               :workflow-status-message="workflowRunStatusMessage"
               :workflow-status-progress="workflowStatusProgress"
               @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -48,6 +48,7 @@ const props = defineProps<{
   workflowResponse: UnknownRecord | null
   renderInFlight: boolean
   loading: boolean
+  errorMessage?: string
   workflowStatusMessage?: string
   workflowStatusProgress?: number | null
 }>()
@@ -73,9 +74,11 @@ const finalVideo = computed(() => asObj(outputs.value?.final_video))
 const indeterminate = computed(() => {
   if (props.finalVideoUrl) return false
   if (props.renderInFlight || finalStatus.value === 'rendering') return false
-  if (workflowInFlight.value && props.workflowStatusProgress != null) return false
+  if (workflowInFlight.value && props.workflowStatusProgress != null) {
+    return props.workflowStatusProgress <= 0
+  }
   // runWorkflow 请求中，或 refresh 正在跑，但还没有任何 image_assets
-  return props.loading  && imageAssetCount.value === 0
+  return props.loading && imageAssetCount.value === 0
 })
 
 const sceneCount = computed(() => {
@@ -95,6 +98,10 @@ const audioItemCount = computed(() => {
 
 const finalStatus = computed(() => asStr(finalVideo.value?.status).toLowerCase())
 const workflowInFlight = computed(() => props.loading && !outputs.value)
+const blockingErrorMessage = computed(() => asStr(props.errorMessage).trim())
+const hasBlockingError = computed(() => {
+  return Boolean(blockingErrorMessage.value && !props.loading && !props.finalVideoUrl)
+})
 
 const assetsReady = computed(() => {
   return sceneCount.value > 0 && imageAssetCount.value >= sceneCount.value
@@ -113,6 +120,7 @@ const progressPct = computed(() => {
 })
 
 const progressLabel = computed(() => {
+  if (hasBlockingError.value) return `候选图生成失败（${imageAssetCount.value}/${sceneCount.value || '?'}）`
   if (workflowInFlight.value) return '处理中…'
   if (indeterminate.value) return '准备中…'
   if (props.finalVideoUrl) return '已生成'
@@ -123,6 +131,7 @@ const progressLabel = computed(() => {
 })
 
 const placeholderTitle = computed(() => {
+  if (hasBlockingError.value) return '候选图生成失败'
   if (workflowInFlight.value) return '正在生成分镜'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '正在生成视频'
   if (!sceneCount.value) return '等待分镜'
@@ -131,6 +140,9 @@ const placeholderTitle = computed(() => {
 })
 
 const placeholderDesc = computed(() => {
+  if (hasBlockingError.value) {
+    return `${blockingErrorMessage.value}。请在 Review 中重新生成失败场景，全部候选图生成后才能渲染视频。`
+  }
   if (workflowInFlight.value) {
     return props.workflowStatusMessage || 'Workflow 已提交，后端正在生成故事与分镜。完成后会自动进入候选图与视频准备阶段。'
   }

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -141,7 +141,7 @@ const placeholderTitle = computed(() => {
 
 const placeholderDesc = computed(() => {
   if (hasBlockingError.value) {
-    return `${blockingErrorMessage.value}。请在 Review 中重新生成失败场景，全部候选图生成后才能渲染视频。`
+    return blockingErrorMessage.value
   }
   if (workflowInFlight.value) {
     return props.workflowStatusMessage || 'Workflow 已提交，后端正在生成故事与分镜。完成后会自动进入候选图与视频准备阶段。'

--- a/scripts/verify_bug004_005_multi_character_prompt_contract.py
+++ b/scripts/verify_bug004_005_multi_character_prompt_contract.py
@@ -40,7 +40,8 @@ def build_request() -> WorkflowRunRequest:
 def main() -> int:
     os.environ["CHARACTER_PROFILE_PROVIDER"] = "template"
 
-    result = WorkflowRunner().run(build_request())
+    runner = WorkflowRunner()
+    result = runner.run(build_request())
     manifest = result.outputs.get("character_manifest") or {}
     storyboard = result.outputs.get("storyboard") or {}
     image_prompts = result.outputs.get("image_prompts") or {}
@@ -94,12 +95,22 @@ def main() -> int:
         print("has_scene_cast_lock =", "scene cast lock" in prompt)
         print("has_cross_character_avoid =", "cross-character must avoid" in prompt)
 
+        if not prompt.startswith("required scene characters:"):
+            failures.append(f"{scene_id}: prompt must start with required characters")
         if "scene cast lock" not in prompt:
             failures.append(f"{scene_id}: prompt missing scene cast lock")
         if "required scene characters" not in prompt:
             failures.append(f"{scene_id}: prompt missing required scene characters")
+        if "not a solo portrait" not in prompt:
+            failures.append(f"{scene_id}: prompt missing solo-portrait guardrail")
+        if "hybrid creature" not in prompt:
+            failures.append(f"{scene_id}: prompt missing hybrid guardrail")
         if "cross-character must avoid" not in prompt:
             failures.append(f"{scene_id}: prompt missing cross-character constraints")
+        if "small white storybook rabbit" not in prompt:
+            failures.append(f"{scene_id}: prompt missing concrete rabbit profile")
+        if "small green storybook turtle" not in prompt:
+            failures.append(f"{scene_id}: prompt missing concrete turtle profile")
         for expected in ["兔子", "乌龟", "no turtle shell", "no rabbit ears"]:
             if expected not in prompt:
                 failures.append(f"{scene_id}: prompt missing {expected}")
@@ -110,6 +121,22 @@ def main() -> int:
                 )
         if len(required_ids) < 2:
             failures.append(f"{scene_id}: required_character_ids missing characters")
+
+    if prompts:
+        negative_prompt = (
+            runner._single_scene_image_support.scene_negative_prompt_from_characters(
+                prompts[0].get("characters") or []
+            )
+        )
+        print("negative_prompt =", negative_prompt)
+        for expected in [
+            "hybrid rabbit turtle creature",
+            "rabbit with turtle shell",
+            "turtle with rabbit ears",
+            "missing required character",
+        ]:
+            if expected not in negative_prompt:
+                failures.append(f"negative_prompt missing {expected}")
 
     if failures:
         print("---")

--- a/scripts/verify_bug004_005_multi_character_prompt_contract.py
+++ b/scripts/verify_bug004_005_multi_character_prompt_contract.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.schemas.workflow import WorkflowRunRequest
+from app.services.runner import WorkflowRunner
+
+
+def build_request() -> WorkflowRunRequest:
+    return WorkflowRunRequest(
+        workflow_id="verify_bug004_005_multi_character_prompt_contract",
+        session_id="verify_bug004_005_multi_character_prompt_contract",
+        steps=[
+            {"name": "story"},
+            {"name": "storyboard"},
+            {"name": "image_prompts"},
+        ],
+        input={
+            "topic": "写一个关于兔子和乌龟赛跑的故事",
+            "duration_sec": 60,
+            "audience": "children",
+            "tone": "warm",
+            "visual_style": "storybook",
+            "character_style": "animal",
+            "language": "zh",
+            "audio_enabled": False,
+            "voiceover_enabled": False,
+            "subtitle_enabled": True,
+            "video_provider": "mock",
+            "output_mode": "full_video",
+        },
+    )
+
+
+def main() -> int:
+    os.environ["CHARACTER_PROFILE_PROVIDER"] = "template"
+
+    result = WorkflowRunner().run(build_request())
+    manifest = result.outputs.get("character_manifest") or {}
+    storyboard = result.outputs.get("storyboard") or {}
+    image_prompts = result.outputs.get("image_prompts") or {}
+
+    characters = manifest.get("characters") or []
+    scenes = storyboard.get("scenes") or []
+    prompts = image_prompts.get("prompts") or []
+    failures: list[str] = []
+
+    print("manifest_count =", len(characters))
+    print("scene_count =", len(scenes))
+    print("prompt_count =", len(prompts))
+
+    names = [
+        str(item.get("display_name") or item.get("species") or "").strip()
+        for item in characters
+        if str(item.get("display_name") or item.get("species") or "").strip()
+    ]
+    print("manifest_names =", names)
+
+    if len(characters) < 2:
+        failures.append("character_manifest must contain at least two characters")
+    for expected_name in ["兔子", "乌龟"]:
+        if not any(expected_name in name for name in names):
+            failures.append(f"character_manifest missing {expected_name}")
+
+    for index, scene in enumerate(scenes, start=1):
+        scene_id = str(scene.get("scene_id") or f"scene_{index:02d}")
+        scene_characters = scene.get("characters") or []
+        scene_names = [
+            str(item.get("display_name") or item.get("species") or "").strip()
+            for item in scene_characters
+            if isinstance(item, dict)
+        ]
+        print(f"{scene_id}_characters =", scene_names)
+
+        for expected_name in ["兔子", "乌龟"]:
+            if not any(expected_name in name for name in scene_names):
+                failures.append(f"{scene_id}: missing scene character {expected_name}")
+
+    for index, item in enumerate(prompts, start=1):
+        scene_id = str(item.get("scene_id") or f"prompt_{index:02d}")
+        prompt = str(item.get("prompt") or "")
+        required_names = item.get("required_character_names") or []
+        required_ids = item.get("required_character_ids") or []
+
+        print("---")
+        print("scene_id =", scene_id)
+        print("required_character_names =", required_names)
+        print("required_character_ids =", required_ids)
+        print("has_scene_cast_lock =", "scene cast lock" in prompt)
+        print("has_cross_character_avoid =", "cross-character must avoid" in prompt)
+
+        if "scene cast lock" not in prompt:
+            failures.append(f"{scene_id}: prompt missing scene cast lock")
+        if "required scene characters" not in prompt:
+            failures.append(f"{scene_id}: prompt missing required scene characters")
+        if "cross-character must avoid" not in prompt:
+            failures.append(f"{scene_id}: prompt missing cross-character constraints")
+        for expected in ["兔子", "乌龟", "no turtle shell", "no rabbit ears"]:
+            if expected not in prompt:
+                failures.append(f"{scene_id}: prompt missing {expected}")
+        for expected_name in ["兔子", "乌龟"]:
+            if not any(expected_name in str(name) for name in required_names):
+                failures.append(
+                    f"{scene_id}: required_character_names missing {expected_name}"
+                )
+        if len(required_ids) < 2:
+            failures.append(f"{scene_id}: required_character_ids missing characters")
+
+    if failures:
+        print("---")
+        print("SUMMARY = FAIL")
+        for failure in failures:
+            print("-", failure)
+        return 1
+
+    print("---")
+    print("SUMMARY = PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_bug004_005_multi_character_prompt_contract.py
+++ b/scripts/verify_bug004_005_multi_character_prompt_contract.py
@@ -133,10 +133,24 @@ def main() -> int:
             "hybrid rabbit turtle creature",
             "rabbit with turtle shell",
             "turtle with rabbit ears",
+            "turtle with long upright ears",
             "missing required character",
         ]:
             if expected not in negative_prompt:
                 failures.append(f"negative_prompt missing {expected}")
+        negative_terms = [
+            item.strip() for item in negative_prompt.split(",") if item.strip()
+        ]
+        for conflicting_bare_term in [
+            "rabbit ears",
+            "long upright ears",
+            "turtle shell",
+            "hard round shell",
+        ]:
+            if conflicting_bare_term in negative_terms:
+                failures.append(
+                    f"negative_prompt contains conflicting bare trait {conflicting_bare_term}"
+                )
 
     if failures:
         print("---")

--- a/scripts/verify_step11_image_prompts.py
+++ b/scripts/verify_step11_image_prompts.py
@@ -198,6 +198,15 @@ def main() -> int:
     assert "scene action binding" in first_scene_prompt
     assert "subject negative constraints" in first_scene_prompt
     assert "no turtle shell" in first_scene_prompt
+    assert "cross-character must avoid" in first_scene_prompt
+    assert scene_result["prompts"][0]["required_character_ids"] == [
+        "char_primary_01",
+        "char_secondary_01",
+    ]
+    assert scene_result["prompts"][0]["required_character_names"] == [
+        "小兔子",
+        "小乌龟",
+    ]
     first_character = scene_result["prompts"][0]["characters"][0]
     assert first_character["character_id"] == "char_primary_01"
     assert first_character["display_name"] == "小兔子"
@@ -214,6 +223,14 @@ def main() -> int:
     assert len(shot_result["prompts"]) == 2
     assert shot_result["prompts"][0]["shot_id"] == "shot_01"
     assert shot_result["prompts"][0]["characters"] == SCENES[0]["characters"]
+    assert shot_result["prompts"][0]["required_character_ids"] == [
+        "char_primary_01",
+        "char_secondary_01",
+    ]
+    assert shot_result["prompts"][0]["required_character_names"] == [
+        "小兔子",
+        "小乌龟",
+    ]
     assert "story context: 小兔子和小乌龟来到河边。" in shot_result["prompts"][0][
         "prompt"
     ]

--- a/scripts/verify_step11_image_prompts.py
+++ b/scripts/verify_step11_image_prompts.py
@@ -211,7 +211,7 @@ def main() -> int:
     assert first_character["character_id"] == "char_primary_01"
     assert first_character["display_name"] == "小兔子"
     assert "long upright ears" in first_character["signature_traits"]
-    assert "same main subject: 小兔子" in first_character["signature_traits"]
+    assert "same character identity: 小兔子" in first_character["signature_traits"]
     assert "no turtle shell" in first_character["forbidden_traits"]
     assert first_character["visual_identity"]
 

--- a/scripts/verify_step6_scene_characters.py
+++ b/scripts/verify_step6_scene_characters.py
@@ -83,9 +83,10 @@ def main() -> int:
 
     required_block = support.scene_character_required_presence_block(OUTPUTS, SCENE)
     assert "required scene characters: 小兔子 and 小乌龟" in required_block
+    assert "not a solo portrait" in required_block
     assert "include all of 小兔子 and 小乌龟 together" in required_block
-    assert "小兔子 remains the main protagonist" in required_block
-    assert "小乌龟 are required supporting characters" in required_block
+    assert "小兔子 may lead the action" in required_block
+    assert "小乌龟 must be clearly visible near 小兔子" in required_block
 
     prompt_block = support.scene_character_prompt_block(OUTPUTS, SCENE)
     assert "scene cast lock" in prompt_block

--- a/scripts/verify_step6_scene_characters.py
+++ b/scripts/verify_step6_scene_characters.py
@@ -92,18 +92,28 @@ def main() -> int:
     assert "name: 小兔子" in prompt_block
     assert "must keep: long upright ears, red scarf" in prompt_block
     assert "must avoid: no rabbit ears" in prompt_block
+    assert "cross-character must avoid" in prompt_block
+    assert "no turtle shell" in prompt_block
+    assert "no long upright rabbit ears" in prompt_block
 
     negative_block = support.scene_character_negative_block(OUTPUTS, SCENE)
     assert negative_block.startswith("subject negative constraints: ")
     assert "no turtle shell" in negative_block
+    assert "小兔子: no turtle shell" in negative_block
+    assert "小乌龟: no rabbit ears" in negative_block
     assert "missing required scene character" in negative_block
-    assert negative_block.count("no turtle shell") == 1
+    assert negative_block.count("no turtle shell") == 2
 
     character_ids = support.character_ids_from_bindings(
         SCENE["characters"]
         + [{"character_id": "char_primary_01"}, {"character_id": ""}, "bad-item"]
     )
     assert character_ids == ["char_primary_01", "char_secondary_01"], character_ids
+    character_names = support.character_names_from_bindings(
+        SCENE["characters"]
+        + [{"display_name": "小兔子"}, {"species": "bad"}, "bad-item"]
+    )
+    assert character_names == ["小兔子", "小乌龟", "bad"], character_names
 
     print("[OK] scene character bindings")
     print("[OK] scene character prompt contracts")

--- a/scripts/verify_step8_story_text.py
+++ b/scripts/verify_step8_story_text.py
@@ -50,9 +50,9 @@ def main() -> int:
     assert runner._duration_story_plan(60) == {
         "duration_sec": 60,
         "scene_count": 6,
-        "target_min_chars": 420,
-        "target_max_chars": 520,
-        "target_chars": 470,
+        "target_min_chars": 250,
+        "target_max_chars": 310,
+        "target_chars": 280,
     }
     assert runner._duration_story_plan(90)["scene_count"] == 12
 

--- a/scripts/verify_step8_story_text.py
+++ b/scripts/verify_step8_story_text.py
@@ -50,9 +50,9 @@ def main() -> int:
     assert runner._duration_story_plan(60) == {
         "duration_sec": 60,
         "scene_count": 6,
-        "target_min_chars": 190,
-        "target_max_chars": 260,
-        "target_chars": 230,
+        "target_min_chars": 420,
+        "target_max_chars": 520,
+        "target_chars": 470,
     }
     assert runner._duration_story_plan(90)["scene_count"] == 12
 
@@ -95,6 +95,25 @@ def main() -> int:
     assert len(paragraphs) == 7
     assert "小兔子" in paragraphs[0]
     assert "小乌龟" in paragraphs[0]
+
+    workflow_input_60 = WorkflowInput(
+        topic="小兔子和小乌龟一起过河",
+        duration_sec=60,
+        audio_enabled=True,
+        voiceover_enabled=True,
+    )
+    ctx_60 = runner._build_step_context(
+        workflow_id="verify-step8-60",
+        session_id="verify-session",
+        run_id="run_verify_step8_60",
+        workflow_input=workflow_input_60,
+    )
+    story_60 = runner._run_story(ctx_60, outputs)
+    story_plan_60 = runner._duration_story_plan(60)
+    assert (
+        runner._story_text_char_count(story_60["text"])
+        >= story_plan_60["target_min_chars"] - 10
+    )
 
     print("[OK] story duration plan helpers")
     print("[OK] story sanitization helpers")


### PR DESCRIPTION
## Summary

- Calibrate 60s story text target to better match real TTS/video duration.
- Strengthen rabbit/turtle multi-character prompt constraints and API negative prompts.
- Avoid conflicting bare negative terms like `rabbit ears` / `turtle shell` when those traits are valid for required characters.
- Hide raw image generation provider/HTTP/JSON errors from user-facing UI.
- Document remaining real-image quality issues and next steps for visual detection/retry or reference-image consistency.

## Validation

- `python scripts/verify_bug004_005_multi_character_prompt_contract.py`
- `python scripts/verify_step6_scene_characters.py`
- `python scripts/verify_step8_story_text.py`
- `python scripts/verify_step11_image_prompts.py`
- `make check`
- `npm run build`
- `git diff --check`

## Notes

Real 60s workflow validation now produced about 0:58, which is acceptable. Multi-character image quality is improved at the prompt-contract level but still not fully product-stable; follow-up work should use visual scoring/retry or reference images.