### PR TITLE
fix: add visual scoring for image candidate selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,5 +55,13 @@ SILICONFLOW_IMAGE_NEGATIVE_PROMPT=low quality, blurry, distorted anatomy, broken
 SILICONFLOW_IMAGE_STEPS=20
 SILICONFLOW_IMAGE_GUIDANCE=7.5
 
+# Optional visual reviewer for image candidate auto-selection.
+# Without this, the selector can only use metadata / color / contrast signals.
+IMAGE_REVIEW_VISION_ENABLED=false
+IMAGE_REVIEW_VISION_MODEL=Qwen/Qwen2.5-VL-72B-Instruct
+IMAGE_REVIEW_VISION_API_KEY=
+IMAGE_REVIEW_VISION_BASE_URL=https://api.siliconflow.cn/v1
+IMAGE_REVIEW_VISION_TIMEOUT_SECONDS=60
+
 # Test switches
 FORCE_IMAGE_RATE_LIMIT=false

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,12 @@ check:
 		app/services/runner_audio_render_support.py \
 		app/services/runner_character_labels.py \
 		app/services/runner_character_manifest.py \
+		app/services/image_candidate_selector.py \
+		app/services/image_provider_retry.py \
 		app/services/runner_image_asset_refs.py \
 		app/services/runner_image_prompts_support.py \
 		app/services/runner_image_review.py \
+		app/services/image_visual_verifier.py \
 		app/services/runner_render_plan.py \
 		app/services/runner_scene_blueprints.py \
 		app/services/runner_scene_characters.py \

--- a/app/services/image_candidate_selector.py
+++ b/app/services/image_candidate_selector.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from app.services.image_visual_verifier import build_env_visual_verifier
 
 try:
     from PIL import Image, ImageStat
@@ -25,6 +27,7 @@ COLOR_KEYWORDS = {
 }
 
 MIN_PASS_SCORE = 45.0
+VisualVerifier = Callable[..., Dict[str, Any]]
 
 
 def _normalize_text(value: Any) -> str:
@@ -50,7 +53,11 @@ def _required_character_labels(characters: List[Dict[str, Any]]) -> List[str]:
     return labels
 
 
-def _quality_gates(characters: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _quality_gates(
+    characters: List[Dict[str, Any]],
+    *,
+    visual_verifier_available: bool = False,
+) -> Dict[str, Any]:
     labels = _required_character_labels(characters)
     multi_character_scene = len(labels) >= 2
     risk_reasons: List[str] = []
@@ -59,16 +66,17 @@ def _quality_gates(characters: List[Dict[str, Any]]) -> Dict[str, Any]:
         risk_reasons.extend(
             [
                 "multi_character_scene",
-                "metadata_only_candidate_filter",
-                "visual_verifier_not_available",
+                "visual_verifier_available"
+                if visual_verifier_available
+                else "visual_verifier_not_available",
             ]
         )
 
     return {
         "required_character_labels": labels,
         "multi_character_scene": multi_character_scene,
-        "visual_verifier_available": False,
-        "advisory_only": True,
+        "visual_verifier_available": visual_verifier_available,
+        "advisory_only": not visual_verifier_available,
         "risk_reasons": risk_reasons,
     }
 
@@ -240,6 +248,7 @@ def _score_candidate(
     prompt: str,
     characters: List[Dict[str, Any]],
     quality_gates: Dict[str, Any],
+    visual_verifier: Optional[VisualVerifier] = None,
 ) -> Dict[str, Any]:
     path = _candidate_path(candidate)
     reasons: List[str] = []
@@ -337,6 +346,42 @@ def _score_candidate(
     if quality_gates.get("multi_character_scene"):
         reasons.append("metadata_quality_gate_multi_character_scene")
 
+    visual_review: Dict[str, Any] = {}
+    if image is not None and visual_verifier is not None:
+        try:
+            visual_review = visual_verifier(
+                image_path=path,
+                prompt=prompt,
+                characters=characters,
+            )
+            visual_score = float(visual_review.get("score") or 0.0)
+            visual_score = max(0.0, min(100.0, visual_score))
+            visual_delta = (visual_score - 50.0) * 0.9
+            score += visual_delta
+            reasons.append(f"visual_score:{visual_score:.1f}")
+            reasons.append(f"visual_delta:{visual_delta:.1f}")
+
+            missing = visual_review.get("missing_required_characters") or []
+            forbidden = visual_review.get("forbidden_trait_issues") or []
+            anatomy = visual_review.get("anatomy_leakage_issues") or []
+            if missing:
+                score -= 35.0
+                reasons.append("visual_missing_required_characters")
+            if forbidden:
+                score -= 30.0
+                reasons.append("visual_forbidden_trait_issues")
+            if anatomy:
+                score -= 30.0
+                reasons.append("visual_anatomy_leakage_issues")
+            if visual_review.get("passed") is False:
+                reasons.append("visual_review_failed")
+        except Exception as error:  # pragma: no cover - network/provider dependent
+            visual_review = {
+                "enabled": True,
+                "error": type(error).__name__,
+            }
+            reasons.append(f"visual_review_error:{type(error).__name__}")
+
     passed = score >= MIN_PASS_SCORE
 
     return {
@@ -351,6 +396,7 @@ def _score_candidate(
         "forbidden_matched_colors": forbidden_matched_colors,
         "forbidden_color_ratios": forbidden_color_ratios,
         "quality_gates": quality_gates,
+        "visual_review": visual_review,
     }
 
 
@@ -359,9 +405,19 @@ def select_best_candidate(
     candidate_asset_refs: List[Dict[str, Any]],
     prompt: str,
     characters: List[Dict[str, Any]],
+    visual_verifier: Optional[VisualVerifier] = None,
 ) -> Dict[str, Any]:
     scored: List[Dict[str, Any]] = []
-    quality_gates = _quality_gates(characters)
+    original_order_refs: List[Dict[str, Any]] = []
+    if visual_verifier is None:
+        env_verifier = build_env_visual_verifier()
+        if env_verifier is not None:
+            visual_verifier = env_verifier.evaluate
+
+    quality_gates = _quality_gates(
+        characters,
+        visual_verifier_available=visual_verifier is not None,
+    )
 
     for candidate in candidate_asset_refs or []:
         if not isinstance(candidate, dict):
@@ -371,12 +427,16 @@ def select_best_candidate(
             prompt=prompt,
             characters=characters,
             quality_gates=quality_gates,
+            visual_verifier=visual_verifier,
         )
         enriched_ref = dict(candidate)
         enriched_ref["auto_filter_score"] = score_item["score"]
         enriched_ref["auto_filter_passed"] = score_item["passed"]
         enriched_ref["auto_filter_reasons"] = score_item["reasons"]
+        if score_item.get("visual_review"):
+            enriched_ref["visual_review"] = score_item["visual_review"]
         score_item["asset_ref"] = enriched_ref
+        original_order_refs.append(enriched_ref)
         scored.append(score_item)
 
     if not scored:
@@ -414,10 +474,11 @@ def select_best_candidate(
                 "matched_colors": item.get("matched_colors") or [],
                 "color_ratios": item.get("color_ratios") or {},
                 "quality_gates": item.get("quality_gates") or {},
+                "visual_review": item.get("visual_review") or {},
             }
             for item in scored
         ],
-        "candidate_asset_refs": [dict(item.get("asset_ref") or {}) for item in scored],
+        "candidate_asset_refs": [dict(item) for item in original_order_refs],
         "best_score": best_score,
         "should_retry": best_score < MIN_PASS_SCORE,
         "quality_gates": quality_gates,

--- a/app/services/image_provider_retry.py
+++ b/app/services/image_provider_retry.py
@@ -40,6 +40,11 @@ def should_retry(error: Exception, config: RetryConfig) -> bool:
             "http error 502",
             "http error 503",
             "http error 504",
+            "http 500",
+            "http 502",
+            "http 503",
+            "http 504",
+            "request failed: unknown error",
         ]
         if any(marker in message for marker in network_markers):
             return True

--- a/app/services/image_visual_verifier.py
+++ b/app/services/image_visual_verifier.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import os
+import re
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_VISION_MODEL = "Qwen/Qwen2.5-VL-72B-Instruct"
+
+
+def visual_review_enabled() -> bool:
+    value = (os.getenv("IMAGE_REVIEW_VISION_ENABLED") or "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def vision_model_name() -> str:
+    return (
+        os.getenv("IMAGE_REVIEW_VISION_MODEL")
+        or os.getenv("OPENAI_VISION_MODEL")
+        or os.getenv("VISION_MODEL")
+        or DEFAULT_VISION_MODEL
+    ).strip()
+
+
+def _api_base_url() -> str:
+    return (
+        os.getenv("IMAGE_REVIEW_VISION_BASE_URL")
+        or os.getenv("OPENAI_BASE_URL")
+        or os.getenv("LLM_API_BASE_URL")
+        or "https://api.siliconflow.cn/v1"
+    ).strip()
+
+
+def _api_key() -> str:
+    return (
+        os.getenv("IMAGE_REVIEW_VISION_API_KEY")
+        or os.getenv("OPENAI_API_KEY")
+        or os.getenv("LLM_API_KEY")
+        or os.getenv("SILICONFLOW_API_KEY")
+        or os.getenv("IMAGE_API_KEY")
+        or ""
+    ).strip()
+
+
+def _timeout_seconds() -> int:
+    raw = (os.getenv("IMAGE_REVIEW_VISION_TIMEOUT_SECONDS") or "").strip()
+    if raw.isdigit():
+        return max(5, min(180, int(raw)))
+    return 60
+
+
+def _character_summary(characters: List[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    for item in characters or []:
+        if not isinstance(item, dict):
+            continue
+
+        name = str(item.get("display_name") or item.get("species") or "").strip()
+        species = str(item.get("species") or "").strip()
+        traits = item.get("signature_traits") or item.get("visual_traits") or []
+        forbidden = item.get("forbidden_traits") or []
+        if isinstance(traits, list):
+            traits_text = ", ".join(str(value).strip() for value in traits if str(value).strip())
+        else:
+            traits_text = str(traits or "").strip()
+        if isinstance(forbidden, list):
+            forbidden_text = ", ".join(
+                str(value).strip() for value in forbidden if str(value).strip()
+            )
+        else:
+            forbidden_text = str(forbidden or "").strip()
+
+        parts = [
+            f"name={name}" if name else "",
+            f"species={species}" if species else "",
+            f"must_keep={traits_text}" if traits_text else "",
+            f"must_avoid={forbidden_text}" if forbidden_text else "",
+        ]
+        line = "; ".join(part for part in parts if part)
+        if line:
+            lines.append(f"- {line}")
+    return "\n".join(lines)
+
+
+def _image_data_url(path: Path) -> str:
+    mime_type = mimetypes.guess_type(path.name)[0] or "image/png"
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def _extract_json_object(text: str) -> Dict[str, Any]:
+    raw = str(text or "").strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```(?:json)?\s*", "", raw, flags=re.IGNORECASE)
+        raw = re.sub(r"\s*```$", "", raw)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start < 0 or end <= start:
+            raise
+        data = json.loads(raw[start : end + 1])
+
+    return data if isinstance(data, dict) else {}
+
+
+class OpenAICompatibleImageVisualVerifier:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str,
+        model: str,
+        timeout_seconds: int,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+
+    def evaluate(
+        self,
+        *,
+        image_path: Path,
+        prompt: str,
+        characters: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        character_summary = _character_summary(characters)
+        instruction = (
+            "You are a strict visual reviewer for children's story image candidates.\n"
+            "Return ONLY compact JSON with these keys: score, passed, "
+            "missing_required_characters, forbidden_trait_issues, anatomy_leakage_issues, notes.\n"
+            "Score from 0 to 100. Penalize missing required characters, merged characters, "
+            "wrong species, and traits transferred between characters.\n"
+            f"Scene prompt:\n{prompt}\n\nRequired characters:\n{character_summary or '- none'}"
+        )
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": instruction},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": _image_data_url(image_path)},
+                        },
+                    ],
+                }
+            ],
+            "temperature": 0,
+            "max_tokens": 500,
+        }
+
+        request = urllib.request.Request(
+            url=f"{self.base_url}/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+
+        with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+            raw = response.read()
+
+        data = json.loads(raw.decode("utf-8", errors="ignore"))
+        content = (
+            (((data.get("choices") or [{}])[0]).get("message") or {}).get("content")
+            or ""
+        )
+        result = _extract_json_object(content)
+        result["provider"] = "openai_compatible_vision"
+        result["model"] = self.model
+        return result
+
+
+def build_env_visual_verifier() -> Optional[OpenAICompatibleImageVisualVerifier]:
+    if not visual_review_enabled():
+        return None
+
+    model = vision_model_name()
+    api_key = _api_key()
+    if not model or not api_key:
+        return None
+
+    return OpenAICompatibleImageVisualVerifier(
+        api_key=api_key,
+        base_url=_api_base_url(),
+        model=model,
+        timeout_seconds=_timeout_seconds(),
+    )

--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -677,11 +677,22 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - 移除 selector 对 `candidate_a` 的轻微加分，避免同分或接近同分时主动偏向第一张。
 - 补充 `verify_bug007_image_quality_gates.py` 覆盖多角色场景会写入 advisory-only quality gate，且不会把 auto 模式变成强制人工审核；同时覆盖当 `candidate_b` 评分更高时会选中第二张。
 
+**已采用修复（可选视觉评分层）**：
+
+- 新增 `image_visual_verifier.py`，支持 OpenAI-compatible vision chat completions，对候选图返回视觉分数、缺失角色、禁用特征、角色串扰等结构化结果。
+- `select_best_candidate` 支持可注入的 `visual_verifier`，也支持通过 `IMAGE_REVIEW_VISION_ENABLED=true`、`IMAGE_REVIEW_VISION_MODEL` / `OPENAI_VISION_MODEL` / `VISION_MODEL` 启用真实视觉模型。
+- 视觉 verifier 启用时，visual score 会强影响候选排序；缺少必需角色、出现 forbidden traits、角色 anatomy leakage 会强扣分。
+- 未启用视觉模型时，继续使用现有 metadata / 颜色 / 对比度筛选，不影响本地测试和 auto 模式。
+- 补充 `verify_bug007_visual_scoring_contract.py`，证明视觉评分能把更符合要求的第二张候选图选出来，并保留失败候选的视觉失败原因。
+- `candidate_asset_refs` 保留原始 A/B 顺序返回，避免前端把已选中项排到第一张后误导用户以为 selector 永远默认选第一张。
+
 **仍需后续跟进**：
 
 - 当前 selector 确实在运行，会写入 `selection_source=auto_filter`、`candidate_scores` 和 `selection_reason`，但它仍不是视觉语义筛选器。
-- 它无法识别“兔子背壳”“缺少乌龟”“乌龟长兔耳朵”等真实画面语义错误；这类能力必须接视觉模型评审、对象检测、参考图一致性或 provider 原生 character consistency。
-- 如果候选图在颜色/对比度等基础分数上差别不明显，selector 仍可能看起来像默认选择第一张；这不是合格的产品级图片筛选。
+- 视觉模型未配置时，它无法识别“兔子背壳”“缺少乌龟”“乌龟长兔耳朵”等真实画面语义错误。
+- 后续真实前端验证需要打开视觉模型配置，确认真实 provider 的视觉评分质量、成本、速度和失败重试策略。
+- 如果需要更稳的产品效果，还需要把低视觉评分候选自动重试，而不仅是排序降权。
+- 2026-05-25 真实前端复测显示：候选图已不再永远选择原始第一张，A/B 标签和展示顺序也已更清晰；但自动选图质量仍不稳定，存在“选中的候选图不是最符合故事画面/角色一致性”的情况。后续需要继续调视觉评审 prompt、评分阈值、失败重试策略，必要时把低分候选图直接自动重生，而不是只在现有候选里排序。
 
 **优先级**：P1。建议在 BUG-004 / BUG-005 后修，否则筛选器缺少可靠评分目标。
 
@@ -741,3 +752,33 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 - 补充 Step 8 验证覆盖 `有6秒` 清理和质量检测。
 
 **优先级**：P0。已修，后续真实 workflow 复测确认。
+
+---
+
+## BUG-010: 图片 provider HTTP 500/502 没有稳定进入重试
+
+**发现日期**：2026-05-25（真实前端验证候选图生成失败时）
+
+**触发条件**：
+
+真实 `api_image_generator` 调用 SiliconFlow 生成候选图时，外部服务返回 `HTTP 500` / `HTTP 502`，错误体包含 `Request failed: Unknown error`。
+
+**当前现象**：
+
+前端看到 `/v1/image-review/refresh-scene` 返回 `502`，候选图生成失败；Network 面板里能看到部分场景成功、部分场景失败。用户只能在 Review 里重试失败场景或稍后再试。
+
+**原因定位**：
+
+重试机制一直存在：生成请求和图片下载都有 `run_with_retry`，真实 API 生成请求最多 6 次指数退避重试。但 provider adapter 抛出的错误文案是 `SiliconFlow image generation failed with HTTP 500: ...`，旧的重试规则只匹配 `http error 500` / `http error 502`，没有匹配 `http 500` / `http 502`，导致部分外部服务临时错误可能没有按预期进入重试。
+
+**已采用修复**：
+
+- `should_retry` 增加对 `http 500` / `http 502` / `http 503` / `http 504` 和 `Request failed: Unknown error` 的识别。
+- 补充 `verify_bug010_image_provider_retry_contract.py`，覆盖 SiliconFlow `HTTP 500`、接口层 `HTTP 502`、下载 `HTTP 504` 应被重试，`HTTP 400` 不应被当作临时错误重试。
+
+**仍需后续跟进**：
+
+- 如果外部 provider 连续 6 次仍返回 500/502，当前设计会把该 scene 标记失败，前端提示用户在 Review 中重试失败场景。
+- 后续可以增加“失败场景稍后自动补偿重试 / 分批 retry queue”，但要控制成本、等待时间和用户可见状态，不能无限重试。
+
+**优先级**：P0。真实接口不稳定时直接影响候选图完成率。

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -202,6 +202,30 @@ function candidateStatusCopy(state: 'waiting' | 'refreshing' | 'done' | 'failed'
   return `等待生成候选图 ${index}`
 }
 
+function candidateLabel(candidate: ImageAssetRef, fallbackIndex: number): string {
+  const fallbackLabel = String.fromCharCode('A'.charCodeAt(0) + fallbackIndex)
+  const source = [
+    candidate.file_name,
+    candidate.relative_path,
+    candidate.public_url,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  const match = source.match(/candidate[_-]([a-z0-9]+)/)
+  if (!match) {
+    return fallbackLabel
+  }
+
+  const suffix = match[1]
+  if (suffix.length === 1 && /[a-z]/.test(suffix)) {
+    return suffix.toUpperCase()
+  }
+
+  return suffix
+}
+
 const renderEntries = computed<ReviewRenderEntry[]>(() => {
   const itemMap = new Map<string, ImageReviewSelectedAsset>()
 
@@ -485,7 +509,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 
                   <div class="preview-info-panel">
                     <div class="preview-info-head">
-                      <span class="preview-title">候选图 {{ index === 0 ? 'A' : 'B' }}</span>
+                      <span class="preview-title">候选图 {{ candidateLabel(candidate, index) }}</span>
                       <span
                         class="preview-state-tag"
                         :class="

--- a/scripts/verify_bug007_image_quality_gates.py
+++ b/scripts/verify_bug007_image_quality_gates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import tempfile
+import os
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -21,6 +22,8 @@ def _write_candidate(path: Path, color: tuple[int, int, int]) -> None:
 
 
 def main() -> int:
+    os.environ["IMAGE_REVIEW_VISION_ENABLED"] = "false"
+
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
         first = tmp_dir / "scene_01__candidate_a.png"

--- a/scripts/verify_bug007_visual_env_config.py
+++ b/scripts/verify_bug007_visual_env_config.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.services.image_visual_verifier import (
+    DEFAULT_VISION_MODEL,
+    build_env_visual_verifier,
+    vision_model_name,
+)
+
+
+TRACKED_ENV_KEYS = [
+    "IMAGE_REVIEW_VISION_ENABLED",
+    "IMAGE_REVIEW_VISION_MODEL",
+    "OPENAI_VISION_MODEL",
+    "VISION_MODEL",
+    "IMAGE_REVIEW_VISION_API_KEY",
+    "OPENAI_API_KEY",
+    "LLM_API_KEY",
+    "SILICONFLOW_API_KEY",
+    "IMAGE_API_KEY",
+    "IMAGE_REVIEW_VISION_BASE_URL",
+    "OPENAI_BASE_URL",
+    "LLM_API_BASE_URL",
+]
+
+
+def main() -> int:
+    original_env = {key: os.environ.get(key) for key in TRACKED_ENV_KEYS}
+
+    try:
+        for key in TRACKED_ENV_KEYS:
+            os.environ.pop(key, None)
+
+        os.environ["IMAGE_REVIEW_VISION_ENABLED"] = "true"
+        os.environ["SILICONFLOW_API_KEY"] = "test-key"
+        os.environ["OPENAI_BASE_URL"] = "https://api.siliconflow.cn/v1"
+
+        verifier = build_env_visual_verifier()
+        failures: list[str] = []
+
+        print("vision_model_name =", vision_model_name())
+        print("verifier_model =", getattr(verifier, "model", None))
+        print("verifier_base_url =", getattr(verifier, "base_url", None))
+
+        if vision_model_name() != DEFAULT_VISION_MODEL:
+            failures.append("vision_model_name should fall back to the default vision model")
+        if verifier is None:
+            failures.append("visual verifier should be created with fallback SiliconFlow key")
+        elif verifier.model != DEFAULT_VISION_MODEL:
+            failures.append("visual verifier should use the default vision model")
+
+        os.environ["IMAGE_REVIEW_VISION_MODEL"] = "custom-vision-model"
+        if vision_model_name() != "custom-vision-model":
+            failures.append("explicit IMAGE_REVIEW_VISION_MODEL should override the default")
+
+        if failures:
+            print("SUMMARY = FAIL")
+            for failure in failures:
+                print("-", failure)
+            return 1
+
+        print("SUMMARY = PASS")
+        return 0
+    finally:
+        for key in TRACKED_ENV_KEYS:
+            value = original_env.get(key)
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_bug007_visual_scoring_contract.py
+++ b/scripts/verify_bug007_visual_scoring_contract.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.services.image_candidate_selector import select_best_candidate
+
+
+def _write_candidate(path: Path, color: tuple[int, int, int]) -> None:
+    try:
+        from PIL import Image
+
+        image = Image.new("RGB", (640, 640), color)
+        image.save(path)
+    except Exception:
+        path.write_bytes(b"candidate")
+
+
+def main() -> int:
+    os.environ["IMAGE_REVIEW_VISION_ENABLED"] = "false"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        first = tmp_dir / "scene_01__candidate_a.png"
+        second = tmp_dir / "scene_01__candidate_b.png"
+        _write_candidate(first, (245, 245, 240))
+        _write_candidate(second, (245, 245, 240))
+
+        def fake_visual_verifier(*, image_path: Path, prompt: str, characters: list[dict]) -> dict:
+            if image_path.name.endswith("candidate_b.png"):
+                return {
+                    "score": 94,
+                    "passed": True,
+                    "missing_required_characters": [],
+                    "forbidden_trait_issues": [],
+                    "anatomy_leakage_issues": [],
+                    "notes": "both required characters are visible and anatomy is clean",
+                }
+            return {
+                "score": 12,
+                "passed": False,
+                "missing_required_characters": ["小乌龟"],
+                "forbidden_trait_issues": ["兔子背着乌龟壳"],
+                "anatomy_leakage_issues": ["rabbit/turtle trait leakage"],
+                "notes": "candidate lacks a clean turtle and mixes traits",
+            }
+
+        result = select_best_candidate(
+            candidate_asset_refs=[
+                {"file_name": first.name, "local_path": str(first)},
+                {"file_name": second.name, "local_path": str(second)},
+            ],
+            prompt="required scene characters: 小兔子 and 小乌龟",
+            characters=[
+                {
+                    "display_name": "小兔子",
+                    "species": "rabbit",
+                    "visual_traits": "small white rabbit, long upright ears",
+                    "forbidden_traits": ["no turtle shell"],
+                },
+                {
+                    "display_name": "小乌龟",
+                    "species": "turtle",
+                    "visual_traits": "small green turtle, round shell",
+                    "forbidden_traits": ["no rabbit ears"],
+                },
+            ],
+            visual_verifier=fake_visual_verifier,
+        )
+
+    selected = result.get("selected_asset_ref") or {}
+    candidate_refs = result.get("candidate_asset_refs") or []
+    quality_gates = result.get("quality_gates") or {}
+    scores = result.get("candidate_scores") or []
+    failures: list[str] = []
+
+    print("selected_file =", selected.get("file_name"))
+    print("candidate_order =", [item.get("file_name") for item in candidate_refs])
+    print("quality_gates =", quality_gates)
+    print("candidate_scores =", scores)
+
+    if selected.get("file_name") != "scene_01__candidate_b.png":
+        failures.append("visual scoring should select candidate_b")
+    if [item.get("file_name") for item in candidate_refs] != [
+        "scene_01__candidate_a.png",
+        "scene_01__candidate_b.png",
+    ]:
+        failures.append("candidate_asset_refs should preserve original A/B order")
+    if quality_gates.get("visual_verifier_available") is not True:
+        failures.append("quality gate should mark visual verifier as available")
+    if quality_gates.get("advisory_only") is not False:
+        failures.append("quality gate should not be advisory-only when visual verifier is used")
+    if not any("visual_score" in " ".join(item.get("reasons") or []) for item in scores):
+        failures.append("candidate scores should include visual scoring reasons")
+    first_score = next(
+        (item for item in scores if item.get("file_name") == "scene_01__candidate_a.png"),
+        {},
+    )
+    first_review = first_score.get("visual_review") or {}
+    if first_review.get("passed") is not False:
+        failures.append("failed candidate should retain visual_review.passed=false")
+    if not first_review.get("missing_required_characters"):
+        failures.append("failed candidate should retain missing_required_characters")
+
+    if failures:
+        print("SUMMARY = FAIL")
+        for failure in failures:
+            print("-", failure)
+        return 1
+
+    print("SUMMARY = PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_bug010_image_provider_retry_contract.py
+++ b/scripts/verify_bug010_image_provider_retry_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.services.image_provider_retry import should_retry
+from app.services.image_provider_types import RetryConfig
+
+
+def main() -> int:
+    config = RetryConfig(
+        max_attempts=6,
+        base_delay_seconds=0.0,
+        backoff_multiplier=1.0,
+        retry_on_rate_limit=True,
+        retry_on_network_error=True,
+    )
+
+    retryable_errors = [
+        RuntimeError(
+            "SiliconFlow image generation failed with HTTP 500: "
+            '{"code":50507,"message":"Request failed: Unknown error","data":null}'
+        ),
+        RuntimeError("HTTP 502: IMAGE_GENERATION_FAILED"),
+        RuntimeError("Generated image download failed with HTTP 504 for scene 1"),
+    ]
+    non_retryable_error = RuntimeError(
+        "SiliconFlow image generation failed with HTTP 400: bad request"
+    )
+
+    failures: list[str] = []
+
+    for error in retryable_errors:
+        if not should_retry(error, config):
+            failures.append(f"expected retryable: {error}")
+
+    if should_retry(non_retryable_error, config):
+        failures.append("HTTP 400 should not be retried as a transient provider error")
+
+    if failures:
+        print("SUMMARY = FAIL")
+        for failure in failures:
+            print("-", failure)
+        return 1
+
+    print("SUMMARY = PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add optional vision-based scoring for image candidate auto-selection
- preserve original A/B candidate labels and ordering in Review UI
- improve retry detection for transient image provider HTTP 500/502/503/504 failures
- document remaining image selection quality follow-ups

## Validation
- python scripts/verify_bug007_visual_env_config.py
- python scripts/verify_bug007_visual_scoring_contract.py
- python scripts/verify_bug007_image_quality_gates.py
- python scripts/verify_bug010_image_provider_retry_contract.py
- make check
- npm run build
- git diff --check

## Notes
Auto-selection no longer appears to always pick the first candidate, but visual quality is still not fully solved. Follow-up work is tracked in TODO for better visual review prompts, thresholds, and low-score regeneration.