### PR TITLE
feat: per-scene retry button on failed image review cards

### DIFF
--- a/docs/post_refactor_todo.md
+++ b/docs/post_refactor_todo.md
@@ -775,6 +775,7 @@ resolved_image_prompts = explicit_image_prompts or stored_image_prompts
 
 - `should_retry` 增加对 `http 500` / `http 502` / `http 503` / `http 504` 和 `Request failed: Unknown error` 的识别。
 - 补充 `verify_bug010_image_provider_retry_contract.py`，覆盖 SiliconFlow `HTTP 500`、接口层 `HTTP 502`、下载 `HTTP 504` 应被重试，`HTTP 400` 不应被当作临时错误重试。
+- 前端失败 scene 卡片增加“重试该场景”入口，只重新调用当前 scene 的 `refresh-scene`，避免用户必须重新跑整批候选图。
 
 **仍需后续跟进**：
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1287,6 +1287,34 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal) {
   markPlaceholderState(sceneId, 'done')
 }
 
+async function retryImageReviewScene(sceneId: string) {
+  if (!sceneId || refreshingImageReview.value || sceneRefreshingId.value) {
+    return
+  }
+
+  errorMessage.value = ''
+  imageReviewRefreshAbortController = new AbortController()
+
+  try {
+    await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal)
+    if (workflowForm.value.renderMode === 'auto' && currentWorkflowResponse.value) {
+      void renderFinalVideoIfReady(currentWorkflowResponse.value)
+    }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      markPlaceholderState(sceneId, 'waiting')
+      return
+    }
+
+    const message = error instanceof Error ? error.message : '候选图场景重试失败'
+    markPlaceholderState(sceneId, 'failed', message)
+    errorMessage.value = message
+  } finally {
+    sceneRefreshingId.value = ''
+    imageReviewRefreshAbortController = null
+  }
+}
+
 function cancelImageReviewRefresh() {
   if (!refreshingImageReview.value) {
     return
@@ -1870,6 +1898,7 @@ async function runWorkflow() {
               :progress-percent="reviewRefreshProgress.percent"
               :can-cancel="refreshingImageReview"
               @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
+              @retry-scene="retryImageReviewScene"
               @cancel-refresh="cancelImageReviewRefresh"
             />
             <WorkflowResultsPanel

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -80,6 +80,7 @@ const emit = defineEmits<{
     }
   ): void
   (e: 'refresh-review'): void
+  (e: 'retry-scene', sceneId: string): void
   (e: 'cancel-refresh'): void
 }>()
 
@@ -147,6 +148,10 @@ function onSelect(sceneId: string, assetRef: ImageAssetRef) {
 
 function onRefreshReview() {
   emit('refresh-review')
+}
+
+function onRetryScene(sceneId: string) {
+  emit('retry-scene', sceneId)
 }
 
 function onCancelRefresh() {
@@ -672,6 +677,16 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 >
                   {{ entry.errorMessage }}
                 </div>
+
+                <button
+                  v-if="entry.state === 'failed'"
+                  type="button"
+                  class="retry-scene-button"
+                  :disabled="loading || refreshing || selectingSceneId === entry.sceneId"
+                  @click="onRetryScene(entry.sceneId)"
+                >
+                  重试该场景
+                </button>
               </div>
             </div>
           </div>
@@ -1075,6 +1090,28 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   font-size: 12px;
   line-height: 1.45;
   overflow-wrap: anywhere;
+}
+
+.retry-scene-button {
+  width: fit-content;
+  min-height: 34px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid #fecaca;
+  background: #fff1f2;
+  color: #b91c1c;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.retry-scene-button:hover:not(:disabled) {
+  background: #ffe4e6;
+}
+
+.retry-scene-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .candidate-header {


### PR DESCRIPTION
## Summary
- Add a "重试该场景" button on failed image review cards so users can re-trigger `refresh-scene` for just one scene instead of rerunning the entire batch.
- Wire a new `retry-scene` event from `InteractiveImageReview.vue` through `App.vue` into the existing `refreshImageReviewScene` flow, with abort signal + auto final-video rerender support.
- Frontend tail of BUG-010 in `docs/post_refactor_todo.md`.

## Test plan
- [ ] `make api` and `cd frontend && npm run dev`.
- [ ] Run a workflow with a topic that triggers real image generation; force one scene to fail (e.g. break `IMAGE_API_KEY` mid-run or wait for a real 5xx).
- [ ] Confirm a red "重试该场景" button appears on the failed scene card.
- [ ] Click it; observe a single `POST /v1/image-review/refresh-scene` for that scene only, not a full batch refresh.
- [ ] Verify cancel / abort still works while the retry is in-flight.