### PR TITLE
feat: close image quality loop with vision-dominant scoring + retry

### DIFF
--- a/app/services/image_candidate_selector.py
+++ b/app/services/image_candidate_selector.py
@@ -27,6 +27,17 @@ COLOR_KEYWORDS = {
 }
 
 MIN_PASS_SCORE = 45.0
+
+# Vision-dominant scoring tunables. When the visual verifier returns a score:
+#  - metadata contribution is capped (no more drowning the signal in
+#    file_exists + image_readable + color overhead)
+#  - visual_score * VISION_SCORE_WEIGHT carries the main signal
+#  - any hard failure (missing/forbidden/anatomy) drops the score below
+#    MIN_PASS_SCORE by HARD_FAIL_MARGIN so should_retry fires
+VISION_MODE_METADATA_CAP = 25.0
+VISION_SCORE_WEIGHT = 0.7
+HARD_FAIL_MARGIN = 10.0
+
 VisualVerifier = Callable[..., Dict[str, Any]]
 
 
@@ -346,7 +357,11 @@ def _score_candidate(
     if quality_gates.get("multi_character_scene"):
         reasons.append("metadata_quality_gate_multi_character_scene")
 
+    metadata_score = score
+
     visual_review: Dict[str, Any] = {}
+    visual_score_value: Optional[float] = None
+    visual_hard_failures: List[str] = []
     if image is not None and visual_verifier is not None:
         try:
             visual_review = visual_verifier(
@@ -354,33 +369,51 @@ def _score_candidate(
                 prompt=prompt,
                 characters=characters,
             )
-            visual_score = float(visual_review.get("score") or 0.0)
-            visual_score = max(0.0, min(100.0, visual_score))
-            visual_delta = (visual_score - 50.0) * 0.9
-            score += visual_delta
-            reasons.append(f"visual_score:{visual_score:.1f}")
-            reasons.append(f"visual_delta:{visual_delta:.1f}")
+            raw_score = float(visual_review.get("score") or 0.0)
+            visual_score_value = max(0.0, min(100.0, raw_score))
 
             missing = visual_review.get("missing_required_characters") or []
             forbidden = visual_review.get("forbidden_trait_issues") or []
             anatomy = visual_review.get("anatomy_leakage_issues") or []
             if missing:
-                score -= 35.0
-                reasons.append("visual_missing_required_characters")
+                visual_hard_failures.append("missing_required_characters")
             if forbidden:
-                score -= 30.0
-                reasons.append("visual_forbidden_trait_issues")
+                visual_hard_failures.append("forbidden_trait_issues")
             if anatomy:
-                score -= 30.0
-                reasons.append("visual_anatomy_leakage_issues")
-            if visual_review.get("passed") is False:
-                reasons.append("visual_review_failed")
+                visual_hard_failures.append("anatomy_leakage_issues")
         except Exception as error:  # pragma: no cover - network/provider dependent
             visual_review = {
                 "enabled": True,
                 "error": type(error).__name__,
             }
             reasons.append(f"visual_review_error:{type(error).__name__}")
+
+    # Score modes:
+    # - vision_dominant: visual verifier ran successfully; the model's score
+    #   drives the result, metadata only contributes a small floor. Any hard
+    #   failure (missing/forbidden/anatomy) caps the score below the pass
+    #   threshold so the candidate is rejected and `should_retry` fires.
+    # - metadata_only: visual verifier disabled or errored; fall back to the
+    #   legacy metadata + color rule scoring.
+    if visual_score_value is not None:
+        score_mode = "vision_dominant"
+        capped_metadata = max(0.0, min(metadata_score, VISION_MODE_METADATA_CAP))
+        visual_contribution = visual_score_value * VISION_SCORE_WEIGHT
+        score = capped_metadata + visual_contribution
+        reasons.append("score_mode:vision_dominant")
+        reasons.append(f"visual_score:{visual_score_value:.1f}")
+        reasons.append(f"visual_contribution:{visual_contribution:.1f}")
+        reasons.append(f"capped_metadata_floor:{capped_metadata:.1f}")
+        for failure in visual_hard_failures:
+            reasons.append(f"visual_hard_fail:{failure}")
+        if visual_hard_failures:
+            score = min(score, MIN_PASS_SCORE - HARD_FAIL_MARGIN)
+        if visual_review.get("passed") is False:
+            reasons.append("visual_review_failed")
+            score = min(score, MIN_PASS_SCORE - 1.0)
+    else:
+        score_mode = "metadata_only"
+        reasons.append("score_mode:metadata_only")
 
     passed = score >= MIN_PASS_SCORE
 
@@ -389,6 +422,7 @@ def _score_candidate(
         "score": round(score, 2),
         "passed": passed,
         "reasons": reasons,
+        "score_mode": score_mode,
         "expected_colors": expected_colors,
         "matched_colors": matched_colors,
         "color_ratios": color_ratios,
@@ -397,6 +431,7 @@ def _score_candidate(
         "forbidden_color_ratios": forbidden_color_ratios,
         "quality_gates": quality_gates,
         "visual_review": visual_review,
+        "visual_hard_failures": visual_hard_failures,
     }
 
 

--- a/app/services/image_candidate_selector.py
+++ b/app/services/image_candidate_selector.py
@@ -505,11 +505,13 @@ def select_best_candidate(
                 "score": item.get("score"),
                 "passed": item.get("passed"),
                 "reasons": item.get("reasons") or [],
+                "score_mode": item.get("score_mode"),
                 "expected_colors": item.get("expected_colors") or [],
                 "matched_colors": item.get("matched_colors") or [],
                 "color_ratios": item.get("color_ratios") or {},
                 "quality_gates": item.get("quality_gates") or {},
                 "visual_review": item.get("visual_review") or {},
+                "visual_hard_failures": item.get("visual_hard_failures") or [],
             }
             for item in scored
         ],

--- a/app/services/image_quality_retry_policy.py
+++ b/app/services/image_quality_retry_policy.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+
+DEFAULT_MAX_RETRIES = 2
+MAX_ALLOWED_RETRIES = 5
+
+
+def quality_max_retries() -> int:
+    raw = (os.getenv("IMAGE_QUALITY_MAX_RETRIES") or "").strip()
+    if not raw:
+        return DEFAULT_MAX_RETRIES
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_RETRIES
+    return max(0, min(MAX_ALLOWED_RETRIES, value))
+
+
+def _clean_list(values: Any) -> List[str]:
+    if not isinstance(values, list):
+        return []
+    cleaned: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            cleaned.append(text)
+    return cleaned
+
+
+def derive_retry_prompt_amendment(
+    *,
+    base_prompt: str,
+    base_negative_prompt: str,
+    visual_review: Dict[str, Any],
+    attempt: int,
+) -> Dict[str, Any]:
+    """Build the next-attempt prompt + negative prompt from the failing visual_review.
+
+    Drives quality-retry: when the vision model flags missing characters,
+    forbidden traits, or anatomy leakage, the next generation gets stronger
+    positive constraints (e.g. "MUST show 小兔子 and 小乌龟 together") and
+    stronger negative constraints (e.g. "rabbit with turtle shell").
+    """
+
+    missing = _clean_list(visual_review.get("missing_required_characters"))
+    forbidden = _clean_list(visual_review.get("forbidden_trait_issues"))
+    anatomy = _clean_list(visual_review.get("anatomy_leakage_issues"))
+
+    positive_additions: List[str] = []
+    negative_additions: List[str] = []
+    amendment_reasons: List[str] = []
+
+    if missing:
+        names = ", ".join(missing)
+        positive_additions.append(
+            "CRITICAL: this scene MUST clearly show all of these characters "
+            f"together in the same frame: {names}. "
+            "Every listed character must be fully visible, no character may "
+            "be missing, hidden, or merged into another."
+        )
+        amendment_reasons.extend(f"missing:{name}" for name in missing)
+
+    for issue in forbidden:
+        negative_additions.append(issue)
+        amendment_reasons.append(f"forbidden:{issue}")
+
+    for issue in anatomy:
+        negative_additions.append(issue)
+        amendment_reasons.append(f"anatomy:{issue}")
+
+    if attempt >= 2 and (missing or forbidden or anatomy):
+        positive_additions.append(
+            "Keep each character's species anatomy strictly separate; "
+            "do not blend body parts, fur, shell, ears, or tails between characters."
+        )
+        amendment_reasons.append("species_anatomy_separation")
+
+    new_prompt = base_prompt
+    if positive_additions:
+        new_prompt = base_prompt + "\n\n" + "\n".join(positive_additions)
+
+    new_negative = base_negative_prompt
+    if negative_additions:
+        appended = ", ".join(negative_additions)
+        new_negative = (
+            f"{base_negative_prompt}, {appended}"
+            if base_negative_prompt
+            else appended
+        )
+
+    return {
+        "prompt": new_prompt,
+        "negative_prompt": new_negative,
+        "amendment_reasons": amendment_reasons,
+        "has_amendments": bool(positive_additions or negative_additions),
+    }
+
+
+def summarize_selection_for_history(
+    *,
+    attempt: int,
+    selection: Dict[str, Any],
+    amendment_reasons: List[str],
+) -> Dict[str, Any]:
+    selected = selection.get("selected_asset_ref") or {}
+    return {
+        "attempt": attempt,
+        "best_score": selection.get("best_score"),
+        "should_retry": bool(selection.get("should_retry")),
+        "selected_file_name": selected.get("file_name"),
+        "amendment_reasons": list(amendment_reasons or []),
+    }

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -6,6 +6,11 @@ from typing import Any, Dict, List
 from app.services.image_candidate_selector import select_best_candidate
 from app.services.image_provider_adapter import ApiImageGeneratorAdapter
 from app.services.image_provider_types import ImageGenerationTask
+from app.services.image_quality_retry_policy import (
+    derive_retry_prompt_amendment,
+    quality_max_retries,
+    summarize_selection_for_history,
+)
 
 
 class RunnerSingleSceneImageSupport:
@@ -207,71 +212,143 @@ class RunnerSingleSceneImageSupport:
             asset_meta["characters"]
         )
 
-        candidate_asset_refs: List[Dict[str, Any]] = []
         adapter = ApiImageGeneratorAdapter(runner)
 
-        for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
-            candidate_scene = runner._scene_candidate_variant(
-                scene=scene,
-                candidate_index=candidate_index,
-            )
-
-            candidate_prompt = base_prompt
-            if candidate_index == 1:
-                candidate_prompt = (
-                    f"{base_prompt}, alternate composition, different framing, "
-                    "slightly changed pose emphasis, secondary visual arrangement"
+        def _generate_candidate_pair(
+            active_prompt: str,
+            active_negative: str,
+        ) -> List[Dict[str, Any]]:
+            candidates: List[Dict[str, Any]] = []
+            for candidate_index, candidate_suffix in enumerate(
+                ["candidate_a", "candidate_b"]
+            ):
+                candidate_scene = runner._scene_candidate_variant(
+                    scene=scene,
+                    candidate_index=candidate_index,
                 )
 
-            file_name = f"{scene_id}__{candidate_suffix}.png"
-            output_path = run_dir / file_name
+                candidate_prompt = active_prompt
+                if candidate_index == 1:
+                    candidate_prompt = (
+                        f"{active_prompt}, alternate composition, different framing, "
+                        "slightly changed pose emphasis, secondary visual arrangement"
+                    )
 
-            task = ImageGenerationTask(
-                run_id=ctx.run_id,
-                item_id=scene_id,
-                scene_id=scene_id,
-                prompt=candidate_prompt,
-                candidate_suffix=candidate_suffix,
-                output_path=output_path,
-                relative_path=f"assets/mock/image/{ctx.run_id}/{file_name}",
-                public_url=f"/assets/mock/image/{ctx.run_id}/{file_name}",
-                prompt_metadata={
-                    "ctx": ctx,
-                    "scene": candidate_scene,
-                    "scene_index": scene_index + candidate_index,
-                    "negative_prompt": negative_prompt,
-                },
-            )
+                file_name = f"{scene_id}__{candidate_suffix}.png"
+                output_path = run_dir / file_name
 
-            image_bytes = adapter.generate(task)
-            if not isinstance(image_bytes, (bytes, bytearray)):
-                raise RuntimeError(
-                    f"api image provider returned invalid bytes for scene {scene_id} ({candidate_suffix})"
+                task = ImageGenerationTask(
+                    run_id=ctx.run_id,
+                    item_id=scene_id,
+                    scene_id=scene_id,
+                    prompt=candidate_prompt,
+                    candidate_suffix=candidate_suffix,
+                    output_path=output_path,
+                    relative_path=f"assets/mock/image/{ctx.run_id}/{file_name}",
+                    public_url=f"/assets/mock/image/{ctx.run_id}/{file_name}",
+                    prompt_metadata={
+                        "ctx": ctx,
+                        "scene": candidate_scene,
+                        "scene_index": scene_index + candidate_index,
+                        "negative_prompt": active_negative,
+                    },
                 )
 
-            output_path = Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_bytes(bytes(image_bytes))
+                image_bytes = adapter.generate(task)
+                if not isinstance(image_bytes, (bytes, bytearray)):
+                    raise RuntimeError(
+                        f"api image provider returned invalid bytes for scene {scene_id} ({candidate_suffix})"
+                    )
 
-            candidate_asset_refs.append(
-                {
-                    "scene_id": scene_id,
-                    "file_name": file_name,
-                    "relative_path": task.relative_path,
-                    "public_url": task.public_url,
-                    "mime_type": "image/png",
-                    "provider": "api_image_generator",
-                    "negative_prompt": negative_prompt,
-                }
-            )
+                output_path = Path(output_path)
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_bytes(bytes(image_bytes))
 
+                candidates.append(
+                    {
+                        "scene_id": scene_id,
+                        "file_name": file_name,
+                        "relative_path": task.relative_path,
+                        "public_url": task.public_url,
+                        "mime_type": "image/png",
+                        "provider": "api_image_generator",
+                        "negative_prompt": active_negative,
+                    }
+                )
+            return candidates
+
+        # === Attempt 1: original prompt ===
+        active_prompt = base_prompt
+        active_negative = negative_prompt
+        candidate_asset_refs = _generate_candidate_pair(active_prompt, active_negative)
         selection = select_best_candidate(
             candidate_asset_refs=candidate_asset_refs,
-            prompt=base_prompt,
+            prompt=active_prompt,
             characters=asset_meta["characters"],
         )
+        selection_history: List[Dict[str, Any]] = [
+            summarize_selection_for_history(
+                attempt=1, selection=selection, amendment_reasons=[]
+            )
+        ]
+        attempt = 1
+        max_retries = quality_max_retries()
+
+        # === Quality retry loop ===
+        # When the selector reports should_retry (best candidate's vision score
+        # plus hard-failure caps put it below MIN_PASS_SCORE), regenerate the
+        # candidate pair with prompt amendments derived from the failing
+        # visual_review (missing characters / forbidden traits / anatomy
+        # leakage). Only accept a retry if it scored strictly higher; stop on
+        # diminishing returns to avoid burning API budget for no gain.
+        while selection.get("should_retry") and attempt <= max_retries:
+            candidate_scores = selection.get("candidate_scores") or []
+            failing_visual_review = (
+                (candidate_scores[0].get("visual_review") if candidate_scores else {})
+                or {}
+            )
+            amendment = derive_retry_prompt_amendment(
+                base_prompt=base_prompt,
+                base_negative_prompt=negative_prompt,
+                visual_review=failing_visual_review,
+                attempt=attempt + 1,
+            )
+            if not amendment.get("has_amendments"):
+                # No structured failure signals to act on; retrying the same
+                # prompt with the same provider is unlikely to help.
+                break
+
+            attempt += 1
+            active_prompt = amendment["prompt"]
+            active_negative = amendment["negative_prompt"]
+
+            retry_candidates = _generate_candidate_pair(active_prompt, active_negative)
+            retry_selection = select_best_candidate(
+                candidate_asset_refs=retry_candidates,
+                prompt=active_prompt,
+                characters=asset_meta["characters"],
+            )
+            selection_history.append(
+                summarize_selection_for_history(
+                    attempt=attempt,
+                    selection=retry_selection,
+                    amendment_reasons=amendment.get("amendment_reasons") or [],
+                )
+            )
+
+            if float(retry_selection.get("best_score") or 0.0) > float(
+                selection.get("best_score") or 0.0
+            ):
+                selection = retry_selection
+                candidate_asset_refs = retry_candidates
+            else:
+                # Retry scored no better — stop to avoid runaway API cost.
+                break
+
         candidate_asset_refs = selection["candidate_asset_refs"]
         selected_asset_ref = selection["selected_asset_ref"]
+        quality_retry_attempts = max(0, attempt - 1)
+        quality_retry_exhausted = bool(selection.get("should_retry"))
 
         return {
             "scene_id": scene_id,
@@ -291,7 +368,11 @@ class RunnerSingleSceneImageSupport:
             "selection_reason": selection.get("selection_reason"),
             "candidate_scores": selection.get("candidate_scores") or [],
             "quality_gates": selection.get("quality_gates") or {},
-            "review_required": bool(selection.get("review_required")),
+            "review_required": bool(selection.get("review_required"))
+            or quality_retry_exhausted,
+            "quality_retry_attempts": quality_retry_attempts,
+            "quality_retry_exhausted": quality_retry_exhausted,
+            "selection_history": selection_history,
         }
 
     def run_single_scene_image_asset(

--- a/scripts/verify_image_quality_retry_loop.py
+++ b/scripts/verify_image_quality_retry_loop.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.services.image_candidate_selector import MIN_PASS_SCORE, select_best_candidate
+from app.services.image_quality_retry_policy import (
+    derive_retry_prompt_amendment,
+    quality_max_retries,
+    summarize_selection_for_history,
+)
+
+
+def _write_candidate(path: Path, color: tuple[int, int, int]) -> None:
+    try:
+        from PIL import Image
+
+        image = Image.new("RGB", (640, 640), color)
+        image.save(path)
+    except Exception:
+        path.write_bytes(b"candidate")
+
+
+def _both_failing_verifier(*, image_path: Path, prompt: str, characters: list[dict]) -> dict:
+    return {
+        "score": 20,
+        "passed": False,
+        "missing_required_characters": ["小乌龟"],
+        "forbidden_trait_issues": ["turtle with rabbit ears"],
+        "anatomy_leakage_issues": ["rabbit/turtle body part blending"],
+        "notes": "both candidates fail",
+    }
+
+
+def _all_passing_verifier(*, image_path: Path, prompt: str, characters: list[dict]) -> dict:
+    return {
+        "score": 82,
+        "passed": True,
+        "missing_required_characters": [],
+        "forbidden_trait_issues": [],
+        "anatomy_leakage_issues": [],
+        "notes": "both clean",
+    }
+
+
+def test_amendment_includes_required_characters() -> list[str]:
+    failures: list[str] = []
+    amendment = derive_retry_prompt_amendment(
+        base_prompt="forest scene with rabbit and turtle",
+        base_negative_prompt="low quality, blurry",
+        visual_review={
+            "missing_required_characters": ["小乌龟"],
+            "forbidden_trait_issues": [],
+            "anatomy_leakage_issues": [],
+        },
+        attempt=2,
+    )
+    if not amendment.get("has_amendments"):
+        failures.append("amendment should set has_amendments=true when characters are missing")
+    if "小乌龟" not in amendment.get("prompt", ""):
+        failures.append("missing character name should be injected into the next-attempt prompt")
+    if "CRITICAL" not in amendment.get("prompt", ""):
+        failures.append("missing-character constraint should be prefixed with CRITICAL")
+    if amendment.get("negative_prompt") != "low quality, blurry":
+        failures.append("negative_prompt should be unchanged when only missing-character signal present")
+    return failures
+
+
+def test_amendment_appends_negatives() -> list[str]:
+    failures: list[str] = []
+    amendment = derive_retry_prompt_amendment(
+        base_prompt="forest scene",
+        base_negative_prompt="low quality",
+        visual_review={
+            "missing_required_characters": [],
+            "forbidden_trait_issues": ["rabbit with turtle shell"],
+            "anatomy_leakage_issues": ["fused rabbit-turtle creature"],
+        },
+        attempt=2,
+    )
+    negative = amendment.get("negative_prompt", "")
+    if "rabbit with turtle shell" not in negative:
+        failures.append("forbidden trait should be appended to negative_prompt")
+    if "fused rabbit-turtle creature" not in negative:
+        failures.append("anatomy leakage should be appended to negative_prompt")
+    if not negative.startswith("low quality"):
+        failures.append("existing negative_prompt should be preserved as the prefix")
+    reasons = amendment.get("amendment_reasons") or []
+    if not any("forbidden:" in r for r in reasons):
+        failures.append("amendment_reasons should tag forbidden issues")
+    if not any("anatomy:" in r for r in reasons):
+        failures.append("amendment_reasons should tag anatomy issues")
+    return failures
+
+
+def test_amendment_no_changes_when_clean() -> list[str]:
+    failures: list[str] = []
+    amendment = derive_retry_prompt_amendment(
+        base_prompt="forest scene",
+        base_negative_prompt="low quality",
+        visual_review={
+            "missing_required_characters": [],
+            "forbidden_trait_issues": [],
+            "anatomy_leakage_issues": [],
+        },
+        attempt=2,
+    )
+    if amendment.get("has_amendments"):
+        failures.append("amendment should be empty when visual_review has no structured issues")
+    if amendment.get("prompt") != "forest scene":
+        failures.append("prompt should be unchanged when there is nothing to amend")
+    if amendment.get("negative_prompt") != "low quality":
+        failures.append("negative_prompt should be unchanged when there is nothing to amend")
+    return failures
+
+
+def test_max_retries_env_override() -> list[str]:
+    failures: list[str] = []
+    os.environ["IMAGE_QUALITY_MAX_RETRIES"] = "3"
+    if quality_max_retries() != 3:
+        failures.append(f"env override to 3 should yield 3, got {quality_max_retries()}")
+
+    os.environ["IMAGE_QUALITY_MAX_RETRIES"] = "99"
+    if quality_max_retries() != 5:
+        failures.append(f"env override should clamp to MAX_ALLOWED_RETRIES=5, got {quality_max_retries()}")
+
+    os.environ["IMAGE_QUALITY_MAX_RETRIES"] = "not-a-number"
+    if quality_max_retries() != 2:
+        failures.append(f"non-numeric env should fall back to default 2, got {quality_max_retries()}")
+
+    os.environ.pop("IMAGE_QUALITY_MAX_RETRIES", None)
+    if quality_max_retries() != 2:
+        failures.append(f"unset env should yield default 2, got {quality_max_retries()}")
+    return failures
+
+
+def test_selector_should_retry_on_both_failing() -> list[str]:
+    failures: list[str] = []
+    os.environ["IMAGE_REVIEW_VISION_ENABLED"] = "false"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        first = tmp_dir / "scene_01__candidate_a.png"
+        second = tmp_dir / "scene_01__candidate_b.png"
+        _write_candidate(first, (245, 245, 240))
+        _write_candidate(second, (245, 245, 240))
+
+        result = select_best_candidate(
+            candidate_asset_refs=[
+                {"file_name": first.name, "local_path": str(first)},
+                {"file_name": second.name, "local_path": str(second)},
+            ],
+            prompt="required scene characters: 小兔子 and 小乌龟",
+            characters=[
+                {"display_name": "小兔子", "species": "rabbit"},
+                {"display_name": "小乌龟", "species": "turtle"},
+            ],
+            visual_verifier=_both_failing_verifier,
+        )
+
+    best_score = float(result.get("best_score") or 0.0)
+    if not result.get("should_retry"):
+        failures.append(
+            f"both-failing candidates should set should_retry=true (best_score={best_score})"
+        )
+    if best_score >= MIN_PASS_SCORE:
+        failures.append(
+            f"best_score should be below MIN_PASS_SCORE={MIN_PASS_SCORE} when both candidates fail "
+            f"(got {best_score})"
+        )
+    scores = result.get("candidate_scores") or []
+    if scores and scores[0].get("score_mode") != "vision_dominant":
+        failures.append(
+            f"score_mode should be vision_dominant when verifier ran; got {scores[0].get('score_mode')}"
+        )
+    if scores and "missing_required_characters" not in (scores[0].get("visual_hard_failures") or []):
+        failures.append("visual_hard_failures should record missing_required_characters")
+    return failures
+
+
+def test_selector_no_retry_on_all_passing() -> list[str]:
+    failures: list[str] = []
+    os.environ["IMAGE_REVIEW_VISION_ENABLED"] = "false"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        first = tmp_dir / "scene_02__candidate_a.png"
+        second = tmp_dir / "scene_02__candidate_b.png"
+        _write_candidate(first, (245, 245, 240))
+        _write_candidate(second, (245, 245, 240))
+
+        result = select_best_candidate(
+            candidate_asset_refs=[
+                {"file_name": first.name, "local_path": str(first)},
+                {"file_name": second.name, "local_path": str(second)},
+            ],
+            prompt="required scene characters: 小兔子",
+            characters=[{"display_name": "小兔子", "species": "rabbit"}],
+            visual_verifier=_all_passing_verifier,
+        )
+    if result.get("should_retry"):
+        failures.append("all-passing candidates should NOT trigger should_retry")
+    return failures
+
+
+def test_selector_metadata_only_when_verifier_absent() -> list[str]:
+    failures: list[str] = []
+    os.environ["IMAGE_REVIEW_VISION_ENABLED"] = "false"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        first = tmp_dir / "scene_03__candidate_a.png"
+        second = tmp_dir / "scene_03__candidate_b.png"
+        _write_candidate(first, (245, 245, 240))
+        _write_candidate(second, (245, 245, 240))
+        result = select_best_candidate(
+            candidate_asset_refs=[
+                {"file_name": first.name, "local_path": str(first)},
+                {"file_name": second.name, "local_path": str(second)},
+            ],
+            prompt="forest",
+            characters=[{"display_name": "小兔子", "species": "rabbit"}],
+            visual_verifier=None,
+        )
+    scores = result.get("candidate_scores") or []
+    if scores and scores[0].get("score_mode") != "metadata_only":
+        failures.append(
+            f"score_mode should be metadata_only when no verifier; got {scores[0].get('score_mode')}"
+        )
+    return failures
+
+
+def test_summarize_selection_shape() -> list[str]:
+    failures: list[str] = []
+    summary = summarize_selection_for_history(
+        attempt=2,
+        selection={
+            "best_score": 88.5,
+            "should_retry": False,
+            "selected_asset_ref": {"file_name": "scene_01__candidate_b.png"},
+        },
+        amendment_reasons=["missing:小乌龟"],
+    )
+    if summary.get("attempt") != 2:
+        failures.append("history entry should preserve attempt index")
+    if summary.get("selected_file_name") != "scene_01__candidate_b.png":
+        failures.append("history entry should expose selected_file_name")
+    if summary.get("best_score") != 88.5:
+        failures.append("history entry should preserve best_score")
+    if summary.get("should_retry") is not False:
+        failures.append("history entry should preserve should_retry")
+    if summary.get("amendment_reasons") != ["missing:小乌龟"]:
+        failures.append("history entry should preserve amendment_reasons list")
+    return failures
+
+
+def main() -> int:
+    test_cases = [
+        ("amendment_includes_required_characters", test_amendment_includes_required_characters),
+        ("amendment_appends_negatives", test_amendment_appends_negatives),
+        ("amendment_no_changes_when_clean", test_amendment_no_changes_when_clean),
+        ("max_retries_env_override", test_max_retries_env_override),
+        ("selector_should_retry_on_both_failing", test_selector_should_retry_on_both_failing),
+        ("selector_no_retry_on_all_passing", test_selector_no_retry_on_all_passing),
+        ("selector_metadata_only_when_verifier_absent", test_selector_metadata_only_when_verifier_absent),
+        ("summarize_selection_shape", test_summarize_selection_shape),
+    ]
+
+    all_failures: list[str] = []
+    for name, test_fn in test_cases:
+        failures = test_fn()
+        if failures:
+            all_failures.append(f"[{name}]")
+            for failure in failures:
+                all_failures.append(f"  - {failure}")
+            print(f"  {name}: FAIL ({len(failures)})")
+        else:
+            print(f"  {name}: ok")
+
+    if all_failures:
+        print("SUMMARY = FAIL")
+        for line in all_failures:
+            print(line)
+        return 1
+    print("SUMMARY = PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Even with `IMAGE_REVIEW_VISION_ENABLED=true`, the multi-character image
quality issues (BUG-004 / 005 / 006 / 007) were still showing up in real
runs: rabbits with turtle shells, turtles with rabbit ears, "灰太狼"
sprouting rabbit ears, missing characters in shared scenes, etc.

Two root causes:

1. The visual verifier's score was being added as a small delta
   (`(score - 50) * 0.9`) on top of ~75 points of base + color rule
   scoring, so a clearly bad image (vision=40, anatomy leakage flagged)
   still totaled above the pass threshold. The signal was being drowned
   in metadata overhead.
2. The single-scene refresh path (`/v1/image-review/refresh-scene`)
   read the selector's result but never read `should_retry`, so even
   when the vision model said "this is broken", the broken image was
   accepted.

This PR fixes both, plus a contract test that pins the new behaviour.

## What changed (3 commits)

### 1. `fix: make visual verifier the dominant scoring signal`
`app/services/image_candidate_selector.py`

- Two scoring modes:
  - **vision_dominant** (when verifier returns a score): metadata
    contribution capped at 25, visual score takes 70% weight (max 70),
    any hard failure (`missing_required_characters` /
    `forbidden_trait_issues` / `anatomy_leakage_issues`) caps the total
    below `MIN_PASS_SCORE` so `should_retry` fires.
  - **metadata_only** (verifier disabled or errored): legacy metadata +
    color rule scoring preserved.
- Public `candidate_scores` now exposes `score_mode` and
  `visual_hard_failures` for downstream consumers.

### 2. `feat: quality-retry loop in refresh-scene with prompt amendment`
`app/services/image_quality_retry_policy.py` (new) +
`app/services/runner_single_scene_image_support.py`

- New `derive_retry_prompt_amendment(...)`: turns the failing
  `visual_review` into a stronger next-attempt prompt + negative prompt:
  - missing characters → CRITICAL positive constraint listing every
    required character by name
  - forbidden traits / anatomy leakage → appended to `negative_prompt`
    verbatim
  - attempts ≥ 2 add a generic species-anatomy-separation hint
- New env knob: `IMAGE_QUALITY_MAX_RETRIES` (default 2, hard max 5).
- `run_single_scene_api_image_asset` now actually retries: candidate
  generation is extracted into an inner helper, the outer loop only
  accepts a retry that strictly outscores the previous best, stops
  early when no structured failure signal is left to amend on, and
  returns new fields: `quality_retry_attempts`,
  `quality_retry_exhausted`, `selection_history`. When retries are
  exhausted `review_required=true` so the UI routes the scene into
  manual review.

### 3. `test: contract test for vision-dominant scoring and retry policy`
`scripts/verify_image_quality_retry_loop.py` (new, 8 cases)

Covers retry-policy amendments (3 paths), env override / clamp /
fallback / default for `IMAGE_QUALITY_MAX_RETRIES`, selector
`should_retry` decision on both-failing vs all-passing, `score_mode`
selection, `summarize_selection_for_history` shape.

## Test plan

- [ ] `PYTHONPATH=. python3 scripts/verify_image_quality_retry_loop.py` → `SUMMARY = PASS`
- [ ] `PYTHONPATH=. python3 scripts/verify_bug007_visual_scoring_contract.py` → `SUMMARY = PASS` (no regression)
- [ ] `PYTHONPATH=. python3 scripts/verify_bug007_image_quality_gates.py` → `SUMMARY = PASS` (no regression)
- [ ] `make check` clean
- [ ] `make api` + real workflow with topic 兔子和乌龟赛跑:
  - confirm response carries `quality_retry_attempts >= 1` for scenes the vision model flagged
  - confirm `selection_history` shows attempt 1 with `should_retry=true` and attempt 2 with higher `best_score`
  - confirm if all retries are exhausted, scene card surfaces `review_required=true`

## Follow-ups (out of scope)

- Apply the same retry loop to the batch path in
  `image_provider_queue.py` (currently only retries once and accepts
  weaker results).
- Wire the new `quality_retry_attempts` / `selection_history` fields
  into the frontend Review UI so users can see "auto-retried N times,
  visual score X".
- Per-run retry budget (`IMAGE_QUALITY_RETRY_BUDGET_PER_RUN`) to cap
  total cost across all scenes.
