### PR TITLE
fix: restore style anchor to position 1 in multi-character scene prompts

### DIFF
--- a/app/services/runner_image_prompts_support.py
+++ b/app/services/runner_image_prompts_support.py
@@ -176,11 +176,11 @@ class RunnerImagePromptsSupport:
                 ]
                 if is_multi_character_scene:
                     prompt_parts = [
+                        global_style_anchor,
                         scene_required_presence_block,
                         character_block,
                         policy_blocks.get("character_visual_profiles_block"),
                         policy_blocks.get("character_separation_block"),
-                        global_style_anchor,
                         shot_anchor,
                         policy_blocks.get("scene_action_block"),
                         story_anchor,
@@ -287,11 +287,11 @@ class RunnerImagePromptsSupport:
             ]
             if is_multi_character_scene:
                 prompt_parts = [
+                    global_style_anchor,
                     scene_required_presence_block,
                     character_block,
                     policy_blocks.get("character_visual_profiles_block"),
                     policy_blocks.get("character_separation_block"),
-                    global_style_anchor,
                     scene_anchor,
                     policy_blocks.get("scene_action_block"),
                     story_anchor,


### PR DESCRIPTION
## Problem

Kolors (Stable Diffusion based) gives higher attention weight to tokens
that appear earlier in the prompt. The multi-character prompt_parts override
was placing `global_style_anchor` at index 4, after:

1. scene_required_presence_block
2. character_block  (very verbose — ~5–7 sentences per character)
3. character_visual_profiles_block
4. character_separation_block

For 2+ characters this amounted to hundreds of tokens before any style
words appeared, making "storybook illustration, warm mood, soft pastel
palette..." effectively invisible to the model. Result: the warm painterly
storybook aesthetic disappeared from multi-character scenes.

## Fix

Move `global_style_anchor` to index 0 in both the shot-based and
scene-based multi-character `prompt_parts` lists. Single-character scenes
were already correct (style anchor was already first).

## Test plan
- [ ] Generate a 2-character scene (e.g. 小兔子 + 小乌龟) and confirm the
      output matches the original soft warm painterly storybook style
- [ ] Single-character scenes unaffected (no change to their prompt_parts)
- [ ] Run `scripts/acceptance_character_visual_profiles_multi.py` to verify
      multi-character profile block is still present in the prompt
