### PR TITLE
feat(BUG-006): seed consistency + opt-in img2img for cross-scene character drift

### DIFF
--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import os
 import time
 import urllib.error
 import urllib.request
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional
 
 from app.services.image_provider_retry import run_with_retry
 from app.services.image_provider_types import (
@@ -14,6 +17,26 @@ from app.services.image_provider_types import (
     ImageGenerationTask,
     RetryConfig,
 )
+
+
+def _derive_run_seed(run_id: str) -> int:
+    """Deterministic seed in [0, 9999999999] derived from run_id."""
+    digest = hashlib.sha256(run_id.encode("utf-8")).digest()
+    return int.from_bytes(digest[:5], "big") % 10_000_000_000
+
+
+def _img2img_enabled() -> bool:
+    return (os.getenv("SILICONFLOW_IMG2IMG_ENABLED") or "").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
+
+
+def _img2img_strength() -> float:
+    raw = (os.getenv("SILICONFLOW_IMG2IMG_STRENGTH") or "0.75").strip()
+    try:
+        return max(0.1, min(1.0, float(raw)))
+    except ValueError:
+        return 0.75
 
 
 class PillowStorybookAdapter:
@@ -53,18 +76,22 @@ class ApiImageGeneratorAdapter:
     def generate(self, task: ImageGenerationTask) -> bytes:
         return self._generate_api_image_bytes(
             prompt=task.prompt,
+            run_id=task.run_id,
             scene=task.prompt_metadata.get("scene") or {},
             scene_index=int(task.prompt_metadata.get("scene_index") or 1),
             negative_prompt=str(task.prompt_metadata.get("negative_prompt") or ""),
+            img2img_reference_path=task.prompt_metadata.get("img2img_reference_path"),
         )
 
     def _generate_api_image_bytes(
         self,
         *,
         prompt: str,
+        run_id: str = "",
         scene: dict[str, Any],
         scene_index: int,
         negative_prompt: str = "",
+        img2img_reference_path: Optional[Any] = None,
     ) -> bytes:
         if self._runner._force_image_rate_limit():
             raise RuntimeError("HTTP 429: IPM limit reached (forced for local testing)")
@@ -117,9 +144,8 @@ class ApiImageGeneratorAdapter:
             "image_size": image_size,
         }
 
-        # Reference images are intentionally not sent here yet.
-        # Current api_image_generator is treated as text-to-image only until
-        # a provider with explicit reference-image support is integrated.
+        if run_id:
+            payload["seed"] = _derive_run_seed(run_id)
 
         if negative_prompt:
             payload["negative_prompt"] = negative_prompt
@@ -128,6 +154,13 @@ class ApiImageGeneratorAdapter:
             payload["batch_size"] = 1
             payload["num_inference_steps"] = num_inference_steps
             payload["guidance_scale"] = guidance_scale
+
+        if _img2img_enabled() and img2img_reference_path is not None:
+            ref_path = Path(img2img_reference_path)
+            if ref_path.is_file():
+                ref_b64 = base64.b64encode(ref_path.read_bytes()).decode("ascii")
+                payload["image"] = f"data:image/png;base64,{ref_b64}"
+                payload["strength"] = _img2img_strength()
 
         request_url = f"{base_url.rstrip('/')}/images/generations"
         request_body = json.dumps(payload).encode("utf-8")

--- a/app/services/image_provider_queue.py
+++ b/app/services/image_provider_queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from app.services.image_provider_adapter import (
     ApiImageGeneratorAdapter,
@@ -100,6 +101,7 @@ class ImageProviderQueue:
         )
         anchor_reference_images = character_anchor.get("reference_images") or []
         assets: List[Dict[str, Any]] = []
+        first_item_img_path: Optional[Path] = None
 
         if shot_items:
             for index, shot in enumerate(shot_items, start=1):
@@ -142,6 +144,7 @@ class ImageProviderQueue:
                     shot_type=shot_type,
                     transition=transition,
                     anchor_reference_images=anchor_reference_images,
+                    img2img_reference_path=first_item_img_path,
                 )
 
                 selection = select_best_candidate(
@@ -168,6 +171,7 @@ class ImageProviderQueue:
                         shot_type=shot_type,
                         transition=transition,
                         anchor_reference_images=anchor_reference_images,
+                        img2img_reference_path=first_item_img_path,
                     )
                     retry_selection = select_best_candidate(
                         candidate_asset_refs=retry_candidate_asset_refs,
@@ -178,6 +182,13 @@ class ImageProviderQueue:
                         selection = retry_selection
                         candidate_asset_refs = retry_selection["candidate_asset_refs"]
                         selected_asset_ref = retry_selection["selected_asset_ref"]
+
+                if index == 1 and first_item_img_path is None:
+                    ref_file = str(selected_asset_ref.get("file_name") or "")
+                    if ref_file:
+                        candidate_path = run_dir / ref_file
+                        if candidate_path.is_file():
+                            first_item_img_path = candidate_path
 
                 assets.append(
                     {
@@ -211,6 +222,7 @@ class ImageProviderQueue:
                     }
                 )
         else:
+            first_item_img_path = None
             for index, scene in enumerate(scenes, start=1):
                 scene_id = str(scene.get("scene_id") or f"scene_{index:02d}")
                 prompt_item = prompt_by_scene_id.get(scene_id) or {}
@@ -237,6 +249,7 @@ class ImageProviderQueue:
                     base_prompt=base_prompt,
                     prompt_item=prompt_item,
                     anchor_reference_images=anchor_reference_images,
+                    img2img_reference_path=first_item_img_path,
                 )
 
                 selection = select_best_candidate(
@@ -258,6 +271,7 @@ class ImageProviderQueue:
                         base_prompt=base_prompt,
                         prompt_item=prompt_item,
                         anchor_reference_images=anchor_reference_images,
+                        img2img_reference_path=first_item_img_path,
                     )
                     retry_selection = select_best_candidate(
                         candidate_asset_refs=retry_candidate_asset_refs,
@@ -268,6 +282,13 @@ class ImageProviderQueue:
                         selection = retry_selection
                         candidate_asset_refs = retry_selection["candidate_asset_refs"]
                         selected_asset_ref = retry_selection["selected_asset_ref"]
+
+                if index == 1 and first_item_img_path is None:
+                    ref_file = str(selected_asset_ref.get("file_name") or "")
+                    if ref_file:
+                        candidate_path = run_dir / ref_file
+                        if candidate_path.is_file():
+                            first_item_img_path = candidate_path
 
                 assets.append(
                     {
@@ -450,6 +471,7 @@ class ImageProviderQueue:
         shot_type: str,
         transition: str,
         anchor_reference_images: List[Dict[str, Any]],
+        img2img_reference_path: Optional[Path] = None,
     ) -> List[Dict[str, Any]]:
         candidate_asset_refs: List[Dict[str, Any]] = []
 
@@ -509,6 +531,7 @@ class ImageProviderQueue:
                     "scene_index": index + candidate_index,
                     "character_anchor": character_anchor,
                     "reference_images": reference_images,
+                    "img2img_reference_path": img2img_reference_path,
                 },
             )
 
@@ -554,6 +577,7 @@ class ImageProviderQueue:
         base_prompt: str,
         prompt_item: Dict[str, Any],
         anchor_reference_images: List[Dict[str, Any]],
+        img2img_reference_path: Optional[Path] = None,
     ) -> List[Dict[str, Any]]:
         candidate_asset_refs: List[Dict[str, Any]] = []
 
@@ -597,6 +621,7 @@ class ImageProviderQueue:
                     "scene_index": index + candidate_index,
                     "character_anchor": character_anchor,
                     "reference_images": reference_images,
+                    "img2img_reference_path": img2img_reference_path,
                 },
             )
 


### PR DESCRIPTION
## Problem

Character appearance drifts significantly between scenes because each
scene is generated independently with a random noise seed. The rabbit's
ears, colors, and proportions look different in every image.

## Solution

### 1. Deterministic seed (always on)
Every API call now sends `seed = SHA256(run_id) % 10_000_000_000`.
All scenes in the same run share the same noise baseline → consistent
character low-frequency structure (shape, color palette) across scenes
with no extra API calls and no user action required.

### 2. img2img sequential reference (opt-in, default off)
After scene 1 is generated and selected, its file path is captured.
For scenes 2+, the image is base64-encoded and sent as the `image`
field so the model uses scene 1's character appearance as a visual anchor.

**New env vars (set in .env):**
| Var | Default | Description |
|-----|---------|-------------|
| `SILICONFLOW_IMG2IMG_ENABLED` | off | Set to `1` to enable img2img |
| `SILICONFLOW_IMG2IMG_STRENGTH` | `0.75` | Denoising strength 0.1–1.0 |

## Test plan
- [ ] Generate a multi-scene story and confirm characters look more
      consistent across scenes compared to before
- [ ] With `SILICONFLOW_IMG2IMG_ENABLED=1`, verify scenes 2+ receive
      the reference image without errors
- [ ] Verify scene 1 generates normally (no reference, text2img as before)
- [ ] Verify pillow/mock provider is unaffected (seed/img2img only sent
      for `api_image_generator`)
