### PR TITLE
feat(BUG-008): retry TTS at reduced speed when audio duration is short

### DIFF
--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -652,6 +652,7 @@ class WorkflowRunner:
         speaker: str,
         voice_style: str,
         output_path: Path,
+        speed: Optional[float] = None,
     ) -> Dict[str, Any]:
         import http.client
         import ssl
@@ -669,6 +670,8 @@ class WorkflowRunner:
             "input": text,
             "response_format": "mp3",
         }
+        if speed is not None:
+            payload["speed"] = round(max(0.25, min(4.0, float(speed))), 2)
 
         req = urllib_request.Request(
             url=f"{self._tts_api_base_url()}/audio/speech",

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -328,11 +328,57 @@ class RunnerAudioRenderSupport:
                         duration_sec = actual_duration_sec
                         duration_source = "ffprobe"
 
+                    # Duration retry: if actual audio is shorter than 70% of the
+                    # character-count estimate, re-generate at a slower speed so
+                    # the TTS fills the scene slot. Clamp speed to [0.75, 0.95].
+                    duration_retry_meta: Dict[str, Any] = {}
+                    if (
+                        actual_duration_sec is not None
+                        and actual_duration_sec < duration_estimate_sec * 0.70
+                        and duration_estimate_sec > 0
+                    ):
+                        ratio = actual_duration_sec / duration_estimate_sec
+                        # Target speed that would yield ~estimate duration
+                        retry_speed = max(0.75, min(0.95, ratio))
+                        try:
+                            retry_result = self._runner._generate_real_tts_audio(
+                                text=text,
+                                speaker=speaker,
+                                voice_style=voice_style,
+                                output_path=output_path,
+                                speed=retry_speed,
+                            )
+                            retry_duration = self._runner._probe_audio_duration_seconds(
+                                output_path
+                            )
+                            if retry_duration is not None and retry_duration > actual_duration_sec:
+                                duration_sec = retry_duration
+                                duration_source = "ffprobe_retry"
+                                duration_retry_meta = {
+                                    "duration_retry": True,
+                                    "retry_speed": retry_speed,
+                                    "original_duration_sec": actual_duration_sec,
+                                    "retry_duration_sec": retry_duration,
+                                    "retry_output_bytes": retry_result.get("output_bytes"),
+                                }
+                            else:
+                                # Retry didn't help — restore original file
+                                self._runner._generate_real_tts_audio(
+                                    text=text,
+                                    speaker=speaker,
+                                    voice_style=voice_style,
+                                    output_path=output_path,
+                                )
+                                duration_retry_meta = {"duration_retry": False, "retry_speed": retry_speed}
+                        except Exception:
+                            duration_retry_meta = {"duration_retry": False, "retry_error": True}
+
                     asset_metadata = {
                         "tts_model": tts_result.get("model"),
                         "tts_voice": tts_result.get("voice"),
                         "output_bytes": tts_result.get("output_bytes"),
                         "duration_source": duration_source,
+                        **duration_retry_meta,
                     }
                     real_generation_count += 1
                 except Exception as e:


### PR DESCRIPTION
## Summary
- When the actual audio duration detected by ffprobe is less than 70% of the duration estimated based on character count, calculate the required slowdown ratio (clamped within the range [0.75, 0.95]) and retry TTS at a slower speaking rate.
- Accept the retried audio only if its duration becomes longer; otherwise, revert to the original audio.
- Added an optional `speed` parameter to `_generate_real_tts_audio`, which is passed through to the payload of `/audio/speech`.
- Write retry metadata into `asset_metadata` for troubleshooting.

## Current Status of All Issues
| Issue | Status |
|-------|--------|
| Formula repetition at the end of stories | ✅ Fixed (merged to dev) |
| BUG-008 Audio duration adjustment | ✅ Fixed in this PR |
| BUG-009 Visual validator recognition failure | ✅ Fixed in the previous PR |
| Model limitations (tadpole rendering, appearance drift, feature cross-contamination) | Documented; cannot be fixed without model replacement |