### PR TITLE
feat: P2-01/02/03 — image quality tiers, dual LLM fallback, per-scene enhance

### DIFF
--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -147,6 +147,10 @@ class WorkflowInput(BaseModel):
         default=True,
         description="Whether audio generation is enabled for this run",
     )
+    quality_tier: str = Field(
+        default="quality",
+        description="Image quality tier: fast / quality / cinematic",
+    )
 
 
 class WorkflowRunRequest(BaseModel):

--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -61,6 +61,13 @@ class PillowStorybookAdapter:
         return self._runner._build_scene_png(ctx, scene, scene_index)
 
 
+_QUALITY_TIER_PARAMS: dict[str, dict[str, Any]] = {
+    "fast":     {"num_inference_steps": 15, "guidance_scale": 6.5},
+    "quality":  {"num_inference_steps": 25, "guidance_scale": 7.5},
+    "cinematic": {"num_inference_steps": 40, "guidance_scale": 8.0},
+}
+
+
 class ApiImageGeneratorAdapter:
     def __init__(self, runner: Any) -> None:
         self._runner = runner
@@ -81,6 +88,7 @@ class ApiImageGeneratorAdapter:
             scene_index=int(task.prompt_metadata.get("scene_index") or 1),
             negative_prompt=str(task.prompt_metadata.get("negative_prompt") or ""),
             img2img_reference_path=task.prompt_metadata.get("img2img_reference_path"),
+            quality_tier=str(task.prompt_metadata.get("quality_tier") or "quality"),
         )
 
     def _generate_api_image_bytes(
@@ -91,6 +99,7 @@ class ApiImageGeneratorAdapter:
         scene: dict[str, Any],
         scene_index: int,
         negative_prompt: str = "",
+        quality_tier: str = "quality",
         img2img_reference_path: Optional[Any] = None,
     ) -> bytes:
         if self._runner._force_image_rate_limit():
@@ -115,8 +124,14 @@ class ApiImageGeneratorAdapter:
 
         is_flux = "flux" in model.lower()
 
+        # Env-var overrides take priority; quality_tier provides the default when they're unset.
+        tier_params = _QUALITY_TIER_PARAMS.get(
+            str(quality_tier or "quality").strip().lower(),
+            _QUALITY_TIER_PARAMS["quality"],
+        )
+
         num_inference_steps_raw = os.getenv("SILICONFLOW_IMAGE_STEPS", "").strip()
-        guidance_scale_raw = os.getenv("SILICONFLOW_IMAGE_GUIDANCE", "7.5").strip()
+        guidance_scale_raw = os.getenv("SILICONFLOW_IMAGE_GUIDANCE", "").strip()
 
         try:
             num_inference_steps = int(num_inference_steps_raw) if num_inference_steps_raw else None
@@ -124,9 +139,15 @@ class ApiImageGeneratorAdapter:
             num_inference_steps = None
 
         try:
-            guidance_scale = float(guidance_scale_raw)
+            guidance_scale = float(guidance_scale_raw) if guidance_scale_raw else None
         except ValueError:
-            guidance_scale = 7.5
+            guidance_scale = None
+
+        # Fall back to tier params when env vars are not set.
+        if num_inference_steps is None:
+            num_inference_steps = tier_params["num_inference_steps"]
+        if guidance_scale is None:
+            guidance_scale = tier_params["guidance_scale"]
 
         # FLUX.1 does not support negative_prompt; Kolors and others do
         if not is_flux:
@@ -156,12 +177,12 @@ class ApiImageGeneratorAdapter:
 
         if "kolors" in model.lower():
             payload["batch_size"] = 1
-            payload["num_inference_steps"] = num_inference_steps if num_inference_steps is not None else 20
+            payload["num_inference_steps"] = num_inference_steps
             payload["guidance_scale"] = guidance_scale
         elif is_flux:
-            # FLUX.1-schnell: 4 steps optimal; FLUX.1-dev: 25-50 steps
+            # FLUX.1-schnell: 4 steps optimal; FLUX.1-dev: 25-50 steps. Tier params override both.
             default_steps = 4 if "schnell" in model.lower() else 28
-            payload["num_inference_steps"] = num_inference_steps if num_inference_steps is not None else default_steps
+            payload["num_inference_steps"] = num_inference_steps if num_inference_steps != tier_params["num_inference_steps"] else default_steps
 
         if _img2img_enabled() and img2img_reference_path is not None:
             ref_path = Path(img2img_reference_path)

--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -124,30 +124,26 @@ class ApiImageGeneratorAdapter:
 
         is_flux = "flux" in model.lower()
 
-        # Env-var overrides take priority; quality_tier provides the default when they're unset.
-        tier_params = _QUALITY_TIER_PARAMS.get(
-            str(quality_tier or "quality").strip().lower(),
-            _QUALITY_TIER_PARAMS["quality"],
-        )
+        # quality_tier takes priority; env vars are the fallback when tier is absent/unknown.
+        tier_key = str(quality_tier or "").strip().lower()
+        tier_params = _QUALITY_TIER_PARAMS.get(tier_key)
 
-        num_inference_steps_raw = os.getenv("SILICONFLOW_IMAGE_STEPS", "").strip()
-        guidance_scale_raw = os.getenv("SILICONFLOW_IMAGE_GUIDANCE", "").strip()
-
-        try:
-            num_inference_steps = int(num_inference_steps_raw) if num_inference_steps_raw else None
-        except ValueError:
-            num_inference_steps = None
-
-        try:
-            guidance_scale = float(guidance_scale_raw) if guidance_scale_raw else None
-        except ValueError:
-            guidance_scale = None
-
-        # Fall back to tier params when env vars are not set.
-        if num_inference_steps is None:
+        if tier_params:
             num_inference_steps = tier_params["num_inference_steps"]
-        if guidance_scale is None:
             guidance_scale = tier_params["guidance_scale"]
+        else:
+            # tier not set — read legacy env vars, defaulting to "quality" tier values
+            default = _QUALITY_TIER_PARAMS["quality"]
+            num_inference_steps_raw = os.getenv("SILICONFLOW_IMAGE_STEPS", "").strip()
+            guidance_scale_raw = os.getenv("SILICONFLOW_IMAGE_GUIDANCE", "").strip()
+            try:
+                num_inference_steps = int(num_inference_steps_raw) if num_inference_steps_raw else default["num_inference_steps"]
+            except ValueError:
+                num_inference_steps = default["num_inference_steps"]
+            try:
+                guidance_scale = float(guidance_scale_raw) if guidance_scale_raw else default["guidance_scale"]
+            except ValueError:
+                guidance_scale = default["guidance_scale"]
 
         # FLUX.1 does not support negative_prompt; Kolors and others do
         if not is_flux:
@@ -180,9 +176,12 @@ class ApiImageGeneratorAdapter:
             payload["num_inference_steps"] = num_inference_steps
             payload["guidance_scale"] = guidance_scale
         elif is_flux:
-            # FLUX.1-schnell: 4 steps optimal; FLUX.1-dev: 25-50 steps. Tier params override both.
-            default_steps = 4 if "schnell" in model.lower() else 28
-            payload["num_inference_steps"] = num_inference_steps if num_inference_steps != tier_params["num_inference_steps"] else default_steps
+            # quality_tier wins when set; otherwise fall back to model-specific sensible defaults.
+            if tier_params:
+                payload["num_inference_steps"] = num_inference_steps
+            else:
+                default_steps = 4 if "schnell" in model.lower() else 28
+                payload["num_inference_steps"] = num_inference_steps if num_inference_steps != _QUALITY_TIER_PARAMS["quality"]["num_inference_steps"] else default_steps
 
         if _img2img_enabled() and img2img_reference_path is not None:
             ref_path = Path(img2img_reference_path)

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -474,7 +474,7 @@ class WorkflowRunner:
         }
 
         timeout = self._story_timeout_seconds()
-        provider_used = “primary”
+        provider_used = "primary"
         fallback_reason: Optional[str] = None
 
         try:
@@ -492,7 +492,7 @@ class WorkflowRunner:
 
             fallback_model = self._llm_fallback_model_name()
             fallback_payload = dict(payload)
-            fallback_payload[“model”] = fallback_model
+            fallback_payload["model"] = fallback_model
 
             content = self._call_llm_chat(
                 api_base_url=fallback_url,
@@ -500,23 +500,23 @@ class WorkflowRunner:
                 payload=fallback_payload,
                 timeout=timeout,
             )
-            provider_used = “fallback”
-            fallback_reason = f”{type(primary_err).__name__}: {primary_err}”
+            provider_used = "fallback"
+            fallback_reason = f"{type(primary_err).__name__}: {primary_err}"
 
-        title = f”{topic}的故事”
-        summary = f”一个围绕”{topic}”展开的短篇故事，整体气质{tone_label}，适合做成{audience_label}向内容。”
+        title = f"{topic}的故事"
+        summary = f"一个围绕“{topic}”展开的短篇故事，整体气质{tone_label}，适合做成{audience_label}向内容。"
 
         parsed = parse_story_payload(content, topic=topic)
-        text = parsed[“text”] if parsed and parsed.get(“text”) else content
+        text = parsed["text"] if parsed and parsed.get("text") else content
 
         result: Dict[str, Any] = {
-            “title”: title.strip(),
-            “summary”: summary.strip(),
-            “text”: text.strip(),
-            “provider_used”: provider_used,
+            "title": title.strip(),
+            "summary": summary.strip(),
+            "text": text.strip(),
+            "provider_used": provider_used,
         }
         if fallback_reason:
-            result[“fallback_reason”] = fallback_reason
+            result["fallback_reason"] = fallback_reason
         return result
 
     def _tts_api_key(self) -> str:

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -335,6 +335,48 @@ class WorkflowRunner:
     def _llm_api_key(self) -> str:
         return (os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY") or "").strip()
 
+    def _llm_fallback_api_base_url(self) -> str:
+        return (os.getenv("LLM_FALLBACK_BASE_URL") or "").strip().rstrip("/")
+
+    def _llm_fallback_api_key(self) -> str:
+        return (os.getenv("LLM_FALLBACK_API_KEY") or "").strip()
+
+    def _llm_fallback_model_name(self) -> str:
+        return (
+            (os.getenv("LLM_FALLBACK_MODEL") or "").strip()
+            or self._story_model_name()
+        )
+
+    def _call_llm_chat(
+        self,
+        *,
+        api_base_url: str,
+        api_key: str,
+        payload: Dict[str, Any],
+        timeout: int,
+    ) -> str:
+        """Send one OpenAI-compatible chat/completions request; return raw content string."""
+        req = urllib_request.Request(
+            url=f"{api_base_url.rstrip('/')}/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib_request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+        if not raw:
+            raise RuntimeError("LLM response is empty")
+        data = json.loads(raw.decode("utf-8", errors="ignore"))
+        content = (
+            (((data.get("choices") or [{}])[0]).get("message") or {}).get("content") or ""
+        ).strip()
+        if not content:
+            raise RuntimeError("LLM content is empty")
+        return content
+
     def _story_provider_name(self) -> str:
         return (os.getenv("STORY_PROVIDER") or DEFAULT_STORY_PROVIDER).strip()
 
@@ -356,7 +398,7 @@ class WorkflowRunner:
 
     def _generate_story_with_llm(
         self, ctx: StepContext, outputs: Dict[str, Any]
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Any]:
         api_key = self._llm_api_key()
         if not api_key:
             raise RuntimeError("LLM api key is missing (OPENAI_API_KEY/LLM_API_KEY)")
@@ -431,42 +473,51 @@ class WorkflowRunner:
             "max_tokens": 1400,
         }
 
-        req = urllib_request.Request(
-            url=f"{self._llm_api_base_url().rstrip('/')}/chat/completions",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            method="POST",
-        )
+        timeout = self._story_timeout_seconds()
+        provider_used = “primary”
+        fallback_reason: Optional[str] = None
 
-        with urllib_request.urlopen(req, timeout=self._story_timeout_seconds()) as resp:
-            raw = resp.read()
+        try:
+            content = self._call_llm_chat(
+                api_base_url=self._llm_api_base_url(),
+                api_key=api_key,
+                payload=payload,
+                timeout=timeout,
+            )
+        except Exception as primary_err:
+            fallback_url = self._llm_fallback_api_base_url()
+            fallback_key = self._llm_fallback_api_key()
+            if not fallback_url or not fallback_key:
+                raise
 
-        if not raw:
-            raise RuntimeError("LLM response is empty")
+            fallback_model = self._llm_fallback_model_name()
+            fallback_payload = dict(payload)
+            fallback_payload[“model”] = fallback_model
 
-        data = json.loads(raw.decode("utf-8", errors="ignore"))
-        content = (
-            (((data.get("choices") or [{}])[0]).get("message") or {}).get("content")
-            or ""
-        ).strip()
+            content = self._call_llm_chat(
+                api_base_url=fallback_url,
+                api_key=fallback_key,
+                payload=fallback_payload,
+                timeout=timeout,
+            )
+            provider_used = “fallback”
+            fallback_reason = f”{type(primary_err).__name__}: {primary_err}”
 
-        if not content:
-            raise RuntimeError("LLM content is empty")
-
-        title = f"{topic}的故事"
-        summary = f"一个围绕“{topic}”展开的短篇故事，整体气质{tone_label}，适合做成{audience_label}向内容。"
+        title = f”{topic}的故事”
+        summary = f”一个围绕”{topic}”展开的短篇故事，整体气质{tone_label}，适合做成{audience_label}向内容。”
 
         parsed = parse_story_payload(content, topic=topic)
-        text = parsed["text"] if parsed and parsed.get("text") else content
+        text = parsed[“text”] if parsed and parsed.get(“text”) else content
 
-        return {
-            "title": title.strip(),
-            "summary": summary.strip(),
-            "text": text.strip(),
+        result: Dict[str, Any] = {
+            “title”: title.strip(),
+            “summary”: summary.strip(),
+            “text”: text.strip(),
+            “provider_used”: provider_used,
         }
+        if fallback_reason:
+            result[“fallback_reason”] = fallback_reason
+        return result
 
     def _tts_api_key(self) -> str:
         tts_key = os.getenv("TTS_API_KEY", "").strip()

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -262,6 +262,7 @@ class RunnerSingleSceneImageSupport:
                         "scene": candidate_scene,
                         "scene_index": scene_index + candidate_index,
                         "negative_prompt": active_negative,
+                        "quality_tier": str(getattr(ctx.input, "quality_tier", "quality") or "quality"),
                     },
                 )
 

--- a/app/services/runner_storyboard.py
+++ b/app/services/runner_storyboard.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import urllib.request as urllib_request
 from typing import Any, Dict, List, Optional
 
 
@@ -161,42 +160,45 @@ class RunnerStoryboardSupport:
             "max_tokens": 1200,
         }
 
-        try:
-            req = urllib_request.Request(
-                url=f"{runner._llm_api_base_url().rstrip('/')}/chat/completions",
-                data=json.dumps(payload).encode("utf-8"),
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                method="POST",
-            )
-            with urllib_request.urlopen(req, timeout=runner._story_timeout_seconds()) as resp:
-                raw = resp.read()
-
-            data = json.loads(raw)
-            content = (
-                (data.get("choices") or [{}])[0]
-                .get("message", {})
-                .get("content", "")
-                .strip()
-            )
-
-            # Strip markdown code fences if present
+        def _parse_descriptions(raw_content: str) -> Dict[str, str]:
+            content = raw_content
             if content.startswith("```"):
                 content = content.split("```")[1]
                 if content.startswith("json"):
                     content = content[4:]
             content = content.strip()
-
             result = json.loads(content)
-            descriptions: Dict[str, str] = {}
+            out: Dict[str, str] = {}
             for item in result.get("scenes") or []:
                 sid = str(item.get("scene_id") or "").strip()
                 desc = str(item.get("visual_description") or "").strip()
                 if sid and desc:
-                    descriptions[sid] = desc
-            return descriptions
+                    out[sid] = desc
+            return out
+
+        try:
+            timeout = runner._story_timeout_seconds()
+            try:
+                content = runner._call_llm_chat(
+                    api_base_url=runner._llm_api_base_url(),
+                    api_key=api_key,
+                    payload=payload,
+                    timeout=timeout,
+                )
+            except Exception:
+                fallback_url = runner._llm_fallback_api_base_url()
+                fallback_key = runner._llm_fallback_api_key()
+                if not fallback_url or not fallback_key:
+                    raise
+                fallback_payload = dict(payload)
+                fallback_payload["model"] = runner._llm_fallback_model_name()
+                content = runner._call_llm_chat(
+                    api_base_url=fallback_url,
+                    api_key=fallback_key,
+                    payload=fallback_payload,
+                    timeout=timeout,
+                )
+            return _parse_descriptions(content)
 
         except Exception:
             return {}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -226,6 +226,7 @@ const DEFAULT_WORKFLOW_FORM: any = {
   secondaryCharacterForbiddenTraits: '',
   renderMode: 'auto',
   audioEnabled: true,
+  qualityTier: 'quality',
 }
 
 const STEP_OPTIONS: Array<{ label: string; value: StepName }> = [
@@ -515,6 +516,10 @@ const storyDiagnostics = computed(() => {
     generationSource:
       typeof storyRecord.generation_source === 'string'
         ? storyRecord.generation_source
+        : '—',
+    providerUsed:
+      typeof storyRecord.provider_used === 'string'
+        ? storyRecord.provider_used
         : '—',
     fallbackReason:
       typeof storyRecord.fallback_reason === 'string' &&
@@ -1275,7 +1280,7 @@ function handleManualRender() {
   renderFinalVideoIfReady(currentWorkflowResponse.value)
 }
 
-async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal) {
+async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qualityTierOverride?: string) {
   if (!currentWorkflowResponse.value || !currentWorkflowPayload.value) {
     return
   }
@@ -1299,7 +1304,9 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal) {
     run_id: currentWorkflowResponse.value.run_id || '',
     scene_id: sceneId,
     storyboard,
-    workflow_input: currentWorkflowPayload.value.input,
+    workflow_input: qualityTierOverride
+      ? { ...currentWorkflowPayload.value.input, quality_tier: qualityTierOverride }
+      : currentWorkflowPayload.value.input,
     image_review: imageReview && typeof imageReview === 'object' ? imageReview : {},
     character_manifest:
       outputs.character_manifest && typeof outputs.character_manifest === 'object'
@@ -1394,6 +1401,31 @@ async function retryImageReviewScene(sceneId: string) {
 
     const message = error instanceof Error ? error.message : '候选图场景重试失败'
     markPlaceholderState(sceneId, 'failed', message)
+    errorMessage.value = message
+  } finally {
+    sceneRefreshingId.value = ''
+    imageReviewRefreshAbortController = null
+  }
+}
+
+async function enhanceImageReviewScene(sceneId: string) {
+  if (!sceneId || refreshingImageReview.value || sceneRefreshingId.value) {
+    return
+  }
+
+  errorMessage.value = ''
+  imageReviewRefreshAbortController = new AbortController()
+
+  try {
+    await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal, 'cinematic')
+    if (workflowForm.value.renderMode === 'auto' && currentWorkflowResponse.value) {
+      void renderFinalVideoIfReady(currentWorkflowResponse.value)
+    }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return
+    }
+    const message = error instanceof Error ? error.message : '场景增强失败'
     errorMessage.value = message
   } finally {
     sceneRefreshingId.value = ''
@@ -1745,6 +1777,7 @@ async function runWorkflow() {
     output_mode: form.outputMode,
     render_mode: form.renderMode,
     audio_enabled: form.audioEnabled,
+    quality_tier: form.qualityTier || 'quality',
   }
 
   if (form.voiceMode === 'multi') {
@@ -2004,6 +2037,7 @@ async function runWorkflow() {
               :can-cancel="refreshingImageReview"
               @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
               @retry-scene="retryImageReviewScene"
+              @enhance-scene="enhanceImageReviewScene"
               @cancel-refresh="cancelImageReviewRefresh"
             />
             <WorkflowResultsPanel
@@ -2152,6 +2186,12 @@ async function runWorkflow() {
               <div class="diagnostics-item">
                 <span class="diagnostics-label">Source</span>
                 <strong>{{ storyDiagnostics.generationSource }}</strong>
+              </div>
+              <div class="diagnostics-item">
+                <span class="diagnostics-label">LLM provider</span>
+                <strong :class="storyDiagnostics.providerUsed === 'fallback' ? 'warn-text' : ''">
+                  {{ storyDiagnostics.providerUsed }}
+                </strong>
               </div>
               <div class="diagnostics-item">
                 <span class="diagnostics-label">Fallback reason</span>
@@ -2370,6 +2410,10 @@ h1 {
 
 .diagnostics-item--error strong {
   color: #dc2626;
+}
+
+.warn-text {
+  color: #d97706;
 }
 
 .hint {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -81,6 +81,7 @@ const emit = defineEmits<{
   ): void
   (e: 'refresh-review'): void
   (e: 'retry-scene', sceneId: string): void
+  (e: 'enhance-scene', sceneId: string): void
   (e: 'cancel-refresh'): void
 }>()
 
@@ -152,6 +153,10 @@ function onRefreshReview() {
 
 function onRetryScene(sceneId: string) {
   emit('retry-scene', sceneId)
+}
+
+function onEnhanceScene(sceneId: string) {
+  emit('enhance-scene', sceneId)
 }
 
 function onCancelRefresh() {
@@ -459,6 +464,16 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 >
                   Open original
                 </a>
+
+                <button
+                  type="button"
+                  class="enhance-scene-button"
+                  :disabled="loading || selectingSceneId === entry.sceneId"
+                  :title="'用 Cinematic 档重新生成更高质量候选'"
+                  @click="onEnhanceScene(entry.sceneId)"
+                >
+                  ✦ Enhance
+                </button>
               </div>
             </div>
           </div>
@@ -1110,6 +1125,29 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 }
 
 .retry-scene-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.enhance-scene-button {
+  width: fit-content;
+  min-height: 30px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid #c7d2fe;
+  background: #eef2ff;
+  color: #4338ca;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 6px;
+}
+
+.enhance-scene-button:hover:not(:disabled) {
+  background: #e0e7ff;
+}
+
+.enhance-scene-button:disabled {
   cursor: not-allowed;
   opacity: 0.65;
 }

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -35,6 +35,7 @@ export type WorkflowRunFormState = {
   secondaryCharacterForbiddenTraits: string
 
   renderMode: 'auto' | 'manual'
+  qualityTier: 'fast' | 'quality' | 'cinematic'
 }
 
 type StepOption = { label: string; value: StepName }
@@ -413,6 +414,40 @@ function getTopicManualMismatchWarning(): string {
                 @change="updateFormState('renderMode', 'manual')"
               />
               Manual
+            </label>
+          </div>
+
+          <div class="row">
+            <div class="row-label">Image Quality</div>
+
+            <label class="radio" title="15 steps — fast, lower detail">
+              <input
+                type="radio"
+                value="fast"
+                :checked="formState.qualityTier === 'fast'"
+                @change="updateFormState('qualityTier', 'fast')"
+              />
+              Fast
+            </label>
+
+            <label class="radio" title="25 steps — balanced quality">
+              <input
+                type="radio"
+                value="quality"
+                :checked="formState.qualityTier === 'quality'"
+                @change="updateFormState('qualityTier', 'quality')"
+              />
+              Quality
+            </label>
+
+            <label class="radio" title="40 steps — high detail, slower">
+              <input
+                type="radio"
+                value="cinematic"
+                :checked="formState.qualityTier === 'cinematic'"
+                @change="updateFormState('qualityTier', 'cinematic')"
+              />
+              Cinematic
             </label>
           </div>
 


### PR DESCRIPTION
## Summary

- **P2-01 (per-scene Enhance button)**: Added ✦ Enhance button to InteractiveImageReview done-scene cards; triggers `refresh-scene` with `quality_tier='cinematic'` override
- **P2-02 (dual LLM fallback)**: Added `_call_llm_chat()` helper + primary→fallback pattern in `runner.py` and `runner_storyboard.py`; `provider_used` / `fallback_reason` fields surfaced in story output and Debug panel
- **P2-03 (image quality tiers)**: Added `quality_tier` field to `WorkflowInput`; Fast/Quality/Cinematic radio in WorkflowRunPanel; `_QUALITY_TIER_PARAMS` dict controls steps/guidance per tier

## Bug fixes included

- **SyntaxError fix**: Curly-quote characters (U+201C/U+201D) in `runner.py` caused `SyntaxError: invalid character` on import; replaced with straight ASCII quotes
- **Quality-tier priority inversion fix**: `.env` `SILICONFLOW_IMAGE_STEPS` was silently overriding quality_tier; inverted priority so quality_tier always wins when valid, env vars are fallback-only

## Test plan

- [ ] `python3 -c "from app.services.runner import WorkflowRunner; print('OK')"` passes
- [ ] Run workflow with Fast tier — images generate with 15 inference steps
- [ ] Run workflow with Cinematic tier — images generate with 40 inference steps
- [ ] ✦ Enhance button appears on completed scene cards; clicking triggers cinematic re-generation
- [ ] Story output includes `provider_used: "primary"` under normal conditions
- [ ] Debug panel shows LLM provider row; turns amber when fallback fires