### PR TITLE
feat(theme): Pearl Dawn light theme + ThemeSwitcher selector

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2294,10 +2294,13 @@ async function runWorkflow() {
   align-items: start;
 }
 
-/* Right column (preview panel) stays visible while form scrolls */
+/* Right column (preview panel) stays visible while form scrolls.
+   align-self:start + height:auto so panel fits content instead of
+   stretching to viewport — avoids huge whitespace below short content. */
 .studio-home-grid > :nth-child(2) {
   position: sticky;
   top: 1rem;
+  align-self: start;
   max-height: calc(100vh - 2rem);
   display: flex;
   flex-direction: column;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2346,10 +2346,7 @@ async function runWorkflow() {
 .review-section-title {
   font-size: 0.875rem;
   font-weight: 700;
-  background: linear-gradient(90deg, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0.75) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
   flex: 1;
   letter-spacing: 0.02em;
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2423,7 +2423,7 @@ async function runWorkflow() {
 
 .copy-diag-btn {
   border: 1px solid rgba(245,158,11,0.18);
-  background: rgba(14,11,5,0.60);
+  background: var(--glass-bg);
   color: var(--text-secondary);
   border-radius: 8px;
   padding: 6px 14px;
@@ -2549,7 +2549,7 @@ async function runWorkflow() {
   max-width: 520px;
   border-radius: 10px;
   border: 1px solid rgba(245,158,11,0.10);
-  background: rgba(14,11,5,0.60);
+  background: var(--glass-bg);
   margin-top: 8px;
 }
 
@@ -2586,7 +2586,7 @@ async function runWorkflow() {
   padding: 10px;
   border: 1px solid rgba(245,158,11,0.10);
   border-radius: 10px;
-  background: rgba(10,8,3,0.50);
+  background: var(--glass-bg);
 }
 
 .review-scene-grid {
@@ -2597,7 +2597,7 @@ async function runWorkflow() {
 .review-scene-card {
   padding: 16px;
   border-radius: 14px;
-  background: rgba(14,11,5,0.60);
+  background: var(--glass-bg);
   border: 1px solid rgba(245,158,11,0.10);
 }
 
@@ -2624,7 +2624,7 @@ async function runWorkflow() {
   padding: 12px;
   border-radius: 12px;
   border: 1px solid rgba(245,158,11,0.18);
-  background: rgba(10,8,3,0.50);
+  background: var(--glass-bg);
   cursor: pointer;
   text-align: left;
 }
@@ -2652,7 +2652,7 @@ async function runWorkflow() {
   padding: 12px;
   border-radius: 10px;
   border: 1px solid rgba(245,158,11,0.10);
-  background: rgba(10,8,3,0.50);
+  background: var(--glass-bg);
   color: var(--text-primary);
   font-size: 13px;
   line-height: 1.6;
@@ -2671,7 +2671,7 @@ async function runWorkflow() {
   padding: 14px;
   border: 1px solid rgba(245,158,11,0.10);
   border-radius: 12px;
-  background: rgba(10,8,3,0.50);
+  background: var(--glass-bg);
 }
 
 .mock-audio-label {
@@ -2689,7 +2689,7 @@ async function runWorkflow() {
   border: 1px solid rgba(245,158,11,0.10);
   border-radius: 14px;
   padding: 16px;
-  background: rgba(14,11,5,0.60);
+  background: var(--glass-bg);
 }
 
 .mock-audio-scene-head {
@@ -2716,7 +2716,7 @@ async function runWorkflow() {
   gap: 12px;
   padding: 12px 14px;
   border-radius: 12px;
-  background: rgba(10,8,3,0.50);
+  background: var(--glass-bg);
   border: 1px solid rgba(245,158,11,0.10);
 }
 

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -221,12 +221,12 @@ const placeholderDesc = computed(() => {
   max-width: 1100px;
   margin: 0 auto;
   border-radius: 18px;
-  background: linear-gradient(160deg, rgba(20,15,5,0.85) 0%, rgba(12,9,3,0.80) 100%);
+  background: var(--glass-bg);
   backdrop-filter: blur(20px) saturate(140%);
   -webkit-backdrop-filter: blur(20px) saturate(140%);
   overflow: hidden;
-  border: 1px solid rgba(245,158,11,0.14);
-  box-shadow: 0 8px 40px rgba(0,0,0,0.50), inset 0 1px 0 rgba(251,191,36,0.06);
+  border: 1px solid var(--border-glass);
+  box-shadow: var(--shadow-glass);
 }
 
 .final-video {
@@ -402,7 +402,7 @@ const placeholderDesc = computed(() => {
 .final-json {
   max-width: 1100px;
   margin: 10px auto 0;
-  background: rgba(0,0,0,0.30);
+  background: var(--surface-overlay-strong);
   border: 1px solid rgba(245,158,11,0.10);
   border-radius: 12px;
   padding: 10px 12px;

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -896,7 +896,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 .asset-code-wrap {
   padding: 10px 12px;
   border-radius: 8px;
-  background: rgba(0,0,0,0.25);
+  background: var(--surface-overlay-strong);
 }
 
 .asset-code-wrap-compact {
@@ -922,25 +922,25 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 .review-scene-card {
   padding: 14px;
   border-radius: 16px;
-  background: linear-gradient(160deg, rgba(20,15,5,0.82) 0%, rgba(14,11,4,0.78) 100%);
-  border: 1px solid rgba(245,158,11,0.10);
-  box-shadow: 0 4px 16px rgba(0,0,0,0.35), inset 0 1px 0 rgba(251,191,36,0.06);
+  background: var(--glass-bg);
+  border: 1px solid var(--border-glass);
+  box-shadow: var(--shadow-glass);
   transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 .review-scene-card:hover {
-  border-color: rgba(245,158,11,0.22);
-  box-shadow: 0 4px 24px rgba(0,0,0,0.40), 0 0 0 1px rgba(245,158,11,0.08);
+  border-color: var(--border-arc);
+  box-shadow: var(--shadow-glass), 0 0 0 1px var(--border-glass);
 }
 
 .review-scene-card-placeholder {
-  background: linear-gradient(160deg, rgba(16,12,4,0.88) 0%, rgba(12,9,3,0.84) 100%);
-  border-color: rgba(245,158,11,0.12);
+  background: var(--glass-bg-light);
+  border-color: var(--border-glass);
 }
 
 .review-scene-card-refreshing {
-  border-color: rgba(245,158,11,0.32);
-  box-shadow: 0 4px 24px rgba(0,0,0,0.35), 0 0 20px rgba(245,158,11,0.10);
+  border-color: var(--border-arc);
+  box-shadow: var(--shadow-glass), var(--glow-arc);
 }
 
 .review-scene-card-failed {
@@ -982,7 +982,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   padding: 10px;
   border-radius: 14px;
   background: var(--glass-bg);
-  border: 1px solid rgba(245,158,11,0.08);
+  border: 1px solid var(--border-glass);
 }
 
 .preview-card-selected,
@@ -995,8 +995,8 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   aspect-ratio: 16 / 9;
   border-radius: 12px;
   overflow: hidden;
-  border: 1px solid rgba(255,255,255,0.10);
-  background: rgba(0,0,0,0.40);
+  border: 1px solid var(--border-glass);
+  background: var(--surface-overlay-strong);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1170,8 +1170,8 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 
 .asset-select-card {
   appearance: none;
-  border: 1px solid rgba(255,255,255,0.08);
-  background: rgba(255,255,255,0.03);
+  border: 1px solid var(--border-glass);
+  background: var(--surface-overlay-soft);
   border-radius: 14px;
   padding: 0;
   text-align: left;
@@ -1209,7 +1209,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   max-width: 100%;
   padding: 3px 7px;
   border-radius: 5px;
-  background: rgba(0,0,0,0.30);
+  background: var(--surface-overlay-strong);
   color: var(--text-muted);
   font-size: 0.6875rem;
   line-height: 1.35;
@@ -1399,6 +1399,49 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   animation: reviewShimmer 1.6s linear infinite;
   pointer-events: none;
 }
+
+/* ─── Pearl Dawn — stronger shimmer overlay (generation in progress) ─── */
+:root[data-theme="pearl"] .shimmer-active::after {
+  background: linear-gradient(
+    110deg,
+    rgba(255, 193, 80, 0) 12%,
+    rgba(255, 193, 80, 0.40) 45%,
+    rgba(255, 215, 130, 0.55) 50%,
+    rgba(255, 193, 80, 0.40) 55%,
+    rgba(255, 193, 80, 0) 88%
+  );
+  mix-blend-mode: normal;
+}
+
+/* ─── Pearl Dawn — replace deep brown landscape with cream-gold ─── */
+:root[data-theme="pearl"] .placeholder-card {
+  background: linear-gradient(160deg, #fdf9eb 0%, #faf3df 100%);
+}
+:root[data-theme="pearl"] .placeholder-canvas {
+  background: #fdf6df;
+  border: 1px solid rgba(200,154,85,0.20);
+}
+:root[data-theme="pearl"] .placeholder-sky {
+  background: linear-gradient(180deg, #fff5d8 0%, #fdebc2 100%);
+}
+:root[data-theme="pearl"] .placeholder-cloud,
+:root[data-theme="pearl"] .placeholder-cloud::before,
+:root[data-theme="pearl"] .placeholder-cloud::after {
+  background: rgba(255,255,255,0.85);
+}
+:root[data-theme="pearl"] .placeholder-hill-back  { background: #f0d89a; }
+:root[data-theme="pearl"] .placeholder-hill-front { background: #e6c478; }
+:root[data-theme="pearl"] .placeholder-water {
+  background: linear-gradient(180deg, #fbe6b3 0%, #f4d68c 100%);
+}
+:root[data-theme="pearl"] .placeholder-sun {
+  background: rgba(255,193,80,0.55);
+  box-shadow: 0 0 0 6px rgba(255,193,80,0.20), 0 0 22px rgba(255,193,80,0.32);
+}
+:root[data-theme="pearl"] .placeholder-tree,
+:root[data-theme="pearl"] .placeholder-tree::before { background: #c89a55; }
+:root[data-theme="pearl"] .placeholder-caption-bar { background: rgba(200,154,85,0.18); }
+
 
 .review-waiting-card {
   display: grid;

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -981,7 +981,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   align-items: stretch;
   padding: 10px;
   border-radius: 14px;
-  background: rgba(10,8,3,0.62);
+  background: var(--glass-bg);
   border: 1px solid rgba(245,158,11,0.08);
 }
 

--- a/frontend/src/components/SampleAssetsPanel.vue
+++ b/frontend/src/components/SampleAssetsPanel.vue
@@ -528,7 +528,7 @@ code {
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid rgba(245,158,11,0.10);
-  background: rgba(0,0,0,0.25);
+  background: var(--surface-overlay-strong);
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.6;

--- a/frontend/src/components/SampleAssetsPanel.vue
+++ b/frontend/src/components/SampleAssetsPanel.vue
@@ -344,7 +344,7 @@ function isVideoAsset(path?: string): boolean {
 .samples-metric {
   padding: 14px 16px;
   border-radius: 12px;
-  background: rgba(14,11,5,0.60);
+  background: var(--glass-bg);
   border: 1px solid rgba(245,158,11,0.10);
   text-align: left;
 }
@@ -377,7 +377,7 @@ function isVideoAsset(path?: string): boolean {
 .sample-detail-panel {
   padding: 16px;
   border-radius: 14px;
-  background: rgba(14,11,5,0.60);
+  background: var(--glass-bg);
   border: 1px solid rgba(245,158,11,0.10);
   box-shadow: 0 4px 16px rgba(0,0,0,0.30);
 }

--- a/frontend/src/components/WorkflowResultsPanel.vue
+++ b/frontend/src/components/WorkflowResultsPanel.vue
@@ -77,7 +77,7 @@ defineProps<{
   margin-top: 16px;
   padding: 18px 20px;
   border-radius: 14px;
-  background: rgba(14,11,5,0.65);
+  background: var(--glass-bg);
   backdrop-filter: blur(20px) saturate(150%);
   -webkit-backdrop-filter: blur(20px) saturate(150%);
   border: 1px solid rgba(245,158,11,0.12);

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -870,37 +870,37 @@ function getTopicManualMismatchWarning(): string {
 .input {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid rgba(245,158,11,0.20);
+  border: 1px solid var(--input-border);
   border-radius: 10px;
   padding: 10px 12px;
   margin-bottom: 14px;
   font-size: 0.875rem;
   color: var(--text-primary);
-  background: rgba(0,0,0,0.30);
+  background: var(--input-bg);
   font-family: inherit;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, background 0.2s, box-shadow 0.15s;
 }
 
 .textarea {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid rgba(245,158,11,0.20);
+  border: 1px solid var(--input-border);
   border-radius: 10px;
   padding: 10px 12px;
   font-size: 0.9375rem;
   line-height: 1.5;
   resize: vertical;
-  background: rgba(0,0,0,0.30);
+  background: var(--input-bg);
   color: var(--text-primary);
   font-family: inherit;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, background 0.2s, box-shadow 0.15s;
 }
 
 .input:focus,
 .textarea:focus {
   outline: none;
-  border-color: var(--arc-400);
-  box-shadow: 0 0 0 2px rgba(245,158,11,0.12);
+  border-color: var(--input-focus-border);
+  box-shadow: var(--input-focus-shadow);
 }
 
 /* Placeholder text color */
@@ -920,8 +920,8 @@ function getTopicManualMismatchWarning(): string {
   margin-top: 1rem;
   padding: 1rem;
   border-radius: 0.875rem;
-  background: rgba(0,0,0,0.20);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: var(--surface-overlay-mid);
+  border: 1px solid var(--border-glass);
 }
 
 .config-grid {
@@ -970,9 +970,9 @@ function getTopicManualMismatchWarning(): string {
   display: flex;
   align-items: center;
   gap: 8px;
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid var(--border-glass);
   border-radius: 10px;
-  background: rgba(0,0,0,0.20);
+  background: var(--surface-overlay-soft);
   padding: 9px 10px;
   font-size: 0.8125rem;
   color: var(--text-secondary);
@@ -991,22 +991,24 @@ function getTopicManualMismatchWarning(): string {
 
 .btn {
   margin-top: 1rem;
-  border: none;
+  border: 1px solid var(--cta-border, rgba(245,158,11,0.45));
   border-radius: 10px;
-  background: linear-gradient(90deg, var(--arc-400), var(--prism-500));
-  color: #fff;
+  background: var(--cta-bg, linear-gradient(135deg, var(--arc-400), var(--arc-300)));
+  color: var(--cta-fg, #fff);
   padding: 11px 18px;
   font-size: 0.9375rem;
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   cursor: pointer;
   font-family: inherit;
-  transition: opacity 0.15s, box-shadow 0.15s;
-  box-shadow: 0 4px 16px rgba(245,158,11,0.25);
+  transition: filter 0.18s, box-shadow 0.18s, transform 0.18s;
+  box-shadow: var(--cta-shadow, 0 4px 18px rgba(245,158,11,0.35));
 }
 
 .btn:hover:not(:disabled) {
-  opacity: 0.9;
-  box-shadow: 0 6px 20px rgba(245,158,11,0.38);
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow: var(--cta-shadow-hover, 0 6px 24px rgba(245,158,11,0.48));
 }
 
 .btn:disabled {
@@ -1018,12 +1020,8 @@ function getTopicManualMismatchWarning(): string {
   position: sticky;
   bottom: 16px;
   margin-top: 14px;
-  padding: 10px;
-  border-radius: 14px;
-  border: 1px solid rgba(245,158,11,0.15);
-  background: rgba(6,11,26,0.90);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  padding: 0;
+  background: transparent;
   z-index: 20;
 }
 
@@ -1047,10 +1045,10 @@ function getTopicManualMismatchWarning(): string {
 /* ===== Render & Audio block ===== */
 .render-audio-block {
   grid-column: 1 / -1;
-  border: 1px solid rgba(255,255,255,0.07);
+  border: 1px solid var(--border-glass);
   border-radius: 10px;
   padding: 12px;
-  background: rgba(0,0,0,0.15);
+  background: var(--surface-overlay-soft);
 }
 
 .render-audio-block .block-title {
@@ -1118,12 +1116,12 @@ function getTopicManualMismatchWarning(): string {
 
 .chipBtn {
   width: 100%;
-  border: 1px solid rgba(255,255,255,0.10);
+  border: 1px solid var(--border-glass);
   border-radius: 999px;
   padding: 6px 12px;
   font-size: 0.75rem;
   cursor: pointer;
-  background: rgba(0,0,0,0.20);
+  background: var(--surface-overlay-soft);
   color: var(--text-secondary);
   white-space: nowrap;
   text-align: center;
@@ -1132,16 +1130,16 @@ function getTopicManualMismatchWarning(): string {
 }
 
 .chipBtn:hover {
-  border-color: rgba(245,158,11,0.38);
+  border-color: var(--border-arc);
   color: var(--arc-300);
-  background: rgba(245,158,11,0.09);
+  background: var(--chip-hover-bg);
 }
 
 .chipBtn.active {
   border-color: var(--arc-400);
-  background: rgba(245,158,11,0.15);
+  background: var(--chip-active-bg);
   color: var(--arc-200);
-  box-shadow: 0 0 8px rgba(245,158,11,0.20);
+  box-shadow: var(--chip-active-shadow);
 }
 
 .chipBtn.subtle {
@@ -1150,10 +1148,10 @@ function getTopicManualMismatchWarning(): string {
 
 .advancedBox {
   margin-top: 6px;
-  border: 1px dashed rgba(255,255,255,0.10);
+  border: 1px dashed var(--border-glass);
   border-radius: 10px;
   padding: 10px;
-  background: rgba(0,0,0,0.15);
+  background: var(--surface-overlay-soft);
 }
 
 .advancedSummary {

--- a/frontend/src/components/studio/DiagnosticsPanel.vue
+++ b/frontend/src/components/studio/DiagnosticsPanel.vue
@@ -117,7 +117,7 @@ const generationSourceBadge = computed(() => {
 .diag-field__val {
   font-family: var(--font-mono, monospace);
   color: var(--text-secondary);
-  background: rgba(0,0,0,0.30);
+  background: var(--surface-overlay-strong);
   padding: 0.1rem 0.4rem;
   border-radius: 0.25rem;
   font-size: 0.7rem;
@@ -126,8 +126,8 @@ const generationSourceBadge = computed(() => {
 .diag-field__val--warn { color: #fbbf24; }
 
 .diag-json {
-  background: rgba(0,0,0,0.40);
-  border: 1px solid rgba(255,255,255,0.05);
+  background: var(--surface-overlay-strong);
+  border: 1px solid var(--border-glass);
   border-radius: 0.5rem;
   padding: 0.625rem;
   font-family: monospace;

--- a/frontend/src/components/studio/StudioCreatePanel.vue
+++ b/frontend/src/components/studio/StudioCreatePanel.vue
@@ -48,4 +48,14 @@ defineProps<{
   flex: 1;
   overflow-y: auto;
 }
+
+:global(:root[data-theme="pearl"]) .create-panel__header {
+  border-bottom-color: rgba(214,179,90,0.14);
+  background: linear-gradient(180deg, rgba(255,255,255,0.42), rgba(255,255,255,0));
+}
+
+:global(:root[data-theme="pearl"]) .create-panel__icon {
+  color: #c89a55;
+  filter: drop-shadow(0 0 8px rgba(214,179,90,0.18));
+}
 </style>

--- a/frontend/src/components/studio/StudioLayout.vue
+++ b/frontend/src/components/studio/StudioLayout.vue
@@ -150,14 +150,15 @@ defineEmits<{
 }>()
 
 // ── Theme system ────────────────────────────────
-type ThemeKey = 'gold' | 'blue' | 'purple'
+type ThemeKey = 'gold' | 'blue' | 'purple' | 'pearl'
 
 const THEMES: Record<ThemeKey, { label: string; short: string; a: string; b: string; c: string }> = {
   gold:   { label: '沉金暗调', short: '金',  a: '245,158,11', b: '249,115,22', c: '251,191,36' },
   blue:   { label: '极夜蓝调', short: '蓝',  a: '14,165,233', b: '99,102,241', c: '56,189,248' },
   purple: { label: '暗紫星芒', short: '紫',  a: '168,85,247', b: '244,63,94',  c: '192,132,252' },
+  pearl:  { label: '珍珠晨光', short: '珠',  a: '194,145,74', b: '79,143,192', c: '233,203,131' },
 }
-const THEME_ORDER: ThemeKey[] = ['gold', 'blue', 'purple']
+const THEME_ORDER: ThemeKey[] = ['gold', 'blue', 'purple', 'pearl']
 
 const currentTheme = ref<ThemeKey>(
   (localStorage.getItem('studio_theme') as ThemeKey | null) ?? 'gold'
@@ -335,11 +336,11 @@ watch(() => props.modelValue, () => {
   padding: 20px 0 16px;
   gap: 0;
 
-  background: rgba(7,5,2,0.88);
+  background: var(--sidebar-bg, rgba(7,5,2,0.88));
   backdrop-filter: blur(28px) saturate(150%);
   -webkit-backdrop-filter: blur(28px) saturate(150%);
   border-right: 1px solid var(--sidebar-border, rgba(245,158,11,0.10));
-  box-shadow: 4px 0 32px rgba(0,0,0,0.55), inset -1px 0 0 var(--sidebar-border, rgba(245,158,11,0.06));
+  box-shadow: var(--sidebar-shadow, 4px 0 32px rgba(0,0,0,0.55)), inset -1px 0 0 var(--sidebar-border, rgba(245,158,11,0.06));
 }
 
 /* ── Brand ── */
@@ -545,7 +546,7 @@ watch(() => props.modelValue, () => {
   top: 0;
   z-index: 40;
   padding: 0.45rem 1.75rem 0.35rem;
-  background: rgba(9,7,3,0.82);
+  background: var(--sidebar-bg, rgba(9,7,3,0.82));
   backdrop-filter: blur(24px) saturate(150%);
   -webkit-backdrop-filter: blur(24px) saturate(150%);
   border-bottom: 1px solid var(--sidebar-border, rgba(245,158,11,0.10));
@@ -713,6 +714,54 @@ watch(() => props.modelValue, () => {
   --pt-glow-a: rgba(192,132,252,0.95);
   --pt-glow-b: rgba(233,213,255,0.95);
   --pt-glow-c: rgba(233,213,255,1);
+}
+
+/* ═══════════════════════════════════════════════
+   珍珠晨光 · Pearl Dawn (light theme)
+═══════════════════════════════════════════════ */
+.s-root[data-theme="pearl"] {
+  --accent-a:           rgba(194,145,74,0.70);
+  --accent-c:           rgba(233,203,131,0.80);
+  --accent-a-solid:     #c2914a;
+  --brand-glow:         rgba(194,145,74,0.55);
+  --sidebar-bg:         rgba(255,253,247,0.86);
+  --sidebar-border:     rgba(194,145,74,0.16);
+  --sidebar-shadow:     4px 0 32px rgba(120,90,40,0.10);
+  --item-hover-bg:      rgba(194,145,74,0.10);
+  --item-hover-border:  rgba(194,145,74,0.28);
+  --item-active-bg:     rgba(194,145,74,0.18);
+  --item-active-border: rgba(194,145,74,0.50);
+  --item-glow:          rgba(194,145,74,0.22);
+  /* Soft pearl orbs */
+  --orb-a1: rgba(194,145,74,0.22);
+  --orb-a2: rgba(140,100,40,0.08);
+  --orb-b1: rgba(79,143,192,0.20);
+  --orb-b2: rgba(40,90,140,0.08);
+  --orb-c1: rgba(233,203,131,0.16);
+  --dot-color:  rgba(194,145,74,0.18);
+  --dc-color:   rgba(194,145,74,0.90);
+  --pt-a:       #c2914a;
+  --pt-b:       #e9cb83;
+  --pt-c:       #d6b06a;
+  --pt-glow-a:  rgba(194,145,74,0.85);
+  --pt-glow-b:  rgba(233,203,131,0.85);
+  --pt-glow-c:  rgba(194,145,74,1);
+}
+
+/* Sidebar nav items — text reversal for light theme */
+.s-root[data-theme="pearl"] .sb-icon          { color: rgba(50,44,34,0.50); }
+.s-root[data-theme="pearl"] .sb-item:hover:not(.is-active) .sb-icon { color: rgba(50,44,34,0.78); }
+.s-root[data-theme="pearl"] .sb-label         { color: rgba(50,44,34,0.45); }
+.s-root[data-theme="pearl"] .sb-item:hover:not(.is-active) .sb-label { color: rgba(50,44,34,0.78); }
+.s-root[data-theme="pearl"] .sb-item.is-active .sb-icon,
+.s-root[data-theme="pearl"] .sb-item.is-active .sb-label { color: var(--arc-300, #b8843e); }
+.s-root[data-theme="pearl"] .sb-dev-btn       { color: rgba(50,44,34,0.45); background: rgba(0,0,0,0.04); border-color: rgba(0,0,0,0.08); }
+.s-root[data-theme="pearl"] .sb-dev-btn:hover { color: rgba(50,44,34,0.75); background: rgba(0,0,0,0.08); }
+.s-root[data-theme="pearl"] .sb-theme-label   { color: rgba(50,44,34,0.50); }
+
+/* Lighten the dark inset highlight in light mode */
+.s-root[data-theme="pearl"] .sb-item.is-active {
+  box-shadow: 0 0 18px var(--item-glow), inset 0 1px 0 rgba(255,255,255,0.50);
 }
 
 /* ── Responsive ── */

--- a/frontend/src/components/studio/StudioLayout.vue
+++ b/frontend/src/components/studio/StudioLayout.vue
@@ -103,13 +103,15 @@
         </button>
       </nav>
 
-      <!-- Footer: theme switcher + slot + dev -->
+      <!-- Footer: header-actions slot + dev toggle -->
       <div class="sb-footer">
         <slot name="header-actions"/>
-        <ThemeSwitcher/>
         <button v-if="devMode" class="sb-dev-btn" title="Dev mode" @click="$emit('toggle-dev')">⚙</button>
       </div>
     </aside>
+
+    <!-- Floating theme switcher — fixed to viewport top-right -->
+    <ThemeSwitcher/>
 
     <!-- ═══════════════════════════════════
          CONTENT AREA
@@ -665,12 +667,12 @@ watch(() => props.modelValue, () => {
   --item-active-border: rgba(200,154,85,0.55);
   --item-glow:          rgba(200,154,85,0.22);
 
-  /* Aurora orbs — pastel soft */
-  --orb-a1: rgba(255,226,168,0.36);
-  --orb-a2: rgba(220,180,100,0.10);
-  --orb-b1: rgba(180,210,235,0.32);
-  --orb-b2: rgba(120,170,210,0.10);
-  --orb-c1: rgba(255,233,175,0.18);
+  /* Aurora orbs — brighter, more visible warm-cool blooms on pearl bg */
+  --orb-a1: rgba(255,210,130,0.55);
+  --orb-a2: rgba(220,170,80,0.18);
+  --orb-b1: rgba(150,190,225,0.50);
+  --orb-b2: rgba(90,150,200,0.18);
+  --orb-c1: rgba(255,225,160,0.30);
 
   --dot-color:  rgba(200,154,85,0.16);
   --dc-color:   rgba(200,154,85,0.85);
@@ -695,6 +697,60 @@ watch(() => props.modelValue, () => {
 /* Soft white highlight on active item */
 .s-root[data-theme="pearl"] .sb-item.is-active {
   box-shadow: 0 4px 18px var(--item-glow), inset 0 1px 0 rgba(255,255,255,0.85);
+}
+
+/* ═══════════════════════════════════════════════
+   Pearl Dawn — drifting flowing light layer
+   Below content but above page bg. Strong, visible bloom that
+   slowly rotates → "morning light streaming through the room".
+═══════════════════════════════════════════════ */
+.s-root[data-theme="pearl"]::before {
+  content: '';
+  position: fixed;
+  inset: -30%;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    conic-gradient(
+      from 0deg at 28% 32%,
+      transparent 0deg,
+      rgba(255, 198, 110, 0.50) 50deg,
+      rgba(255, 222, 165, 0.28) 110deg,
+      transparent 190deg,
+      rgba(160, 205, 235, 0.42) 270deg,
+      rgba(190, 220, 240, 0.20) 320deg,
+      transparent 360deg
+    );
+  filter: blur(60px);
+  animation: pearlFlow 26s linear infinite;
+  will-change: transform;
+  mix-blend-mode: normal;
+}
+
+.s-root[data-theme="pearl"]::after {
+  content: '';
+  position: fixed;
+  inset: -20%;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    conic-gradient(
+      from 180deg at 75% 68%,
+      transparent 0deg,
+      rgba(255, 210, 140, 0.38) 70deg,
+      transparent 170deg,
+      rgba(195, 220, 235, 0.32) 250deg,
+      rgba(255, 205, 145, 0.22) 320deg,
+      transparent 360deg
+    );
+  filter: blur(70px);
+  animation: pearlFlow 36s linear infinite reverse;
+  will-change: transform;
+}
+
+@keyframes pearlFlow {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
 }
 
 /* ── Responsive ── */

--- a/frontend/src/components/studio/StudioLayout.vue
+++ b/frontend/src/components/studio/StudioLayout.vue
@@ -471,23 +471,24 @@ watch(() => props.modelValue, () => {
   z-index: 1;
 }
 
-/* Progress bar — sticky top strip with glass background */
+/* Progress bar wrapper — transparent so it disappears when child is hidden.
+   Visual (bg/border/padding) lives in .studio-progress inside StudioProgress
+   component, which uses v-if="visible". */
 .s-progress {
   position: sticky;
   top: 0;
   z-index: 40;
-  padding: 0.45rem 1.75rem 0.35rem;
-  background: var(--sidebar-bg, rgba(9,7,3,0.82));
-  backdrop-filter: blur(24px) saturate(150%);
-  -webkit-backdrop-filter: blur(24px) saturate(150%);
-  border-bottom: 1px solid var(--sidebar-border, rgba(245,158,11,0.10));
+  background: transparent;
   flex-shrink: 0;
 }
 
 /* Main content */
 .s-main {
   flex: 1;
-  padding: 1.5rem 1.75rem;
+  /* Tighter left padding so cards sit closer to the sidebar.
+     Pearl theme's lighter bg makes any whitespace look bigger; this
+     also subtly tightens dark themes (1.75rem → 1.25rem). */
+  padding: 1.5rem 1.5rem 1.5rem 1.25rem;
   max-width: 1440px;
   width: 100%;
   box-sizing: border-box;
@@ -699,13 +700,10 @@ watch(() => props.modelValue, () => {
   box-shadow: 0 4px 18px var(--item-glow), inset 0 1px 0 rgba(255,255,255,0.85);
 }
 
-.s-root[data-theme="pearl"] .s-progress {
-  padding-top: 0.32rem;
-  padding-bottom: 0.22rem;
-  background:
-    linear-gradient(90deg, rgba(255,255,255,0.42), rgba(238,247,255,0.30));
-  border-bottom-color: rgba(214, 179, 90, 0.10);
-  box-shadow: 0 8px 22px rgba(90, 110, 130, 0.025);
+/* Pearl bg is light so any whitespace looks bigger than the same px
+   on the dark themes. Tighten s-main left padding visually. */
+.s-root[data-theme="pearl"] .s-main {
+  padding-left: 0.7rem;
 }
 
 /* ═══════════════════════════════════════════════

--- a/frontend/src/components/studio/StudioLayout.vue
+++ b/frontend/src/components/studio/StudioLayout.vue
@@ -667,12 +667,12 @@ watch(() => props.modelValue, () => {
   --item-active-border: rgba(200,154,85,0.55);
   --item-glow:          rgba(200,154,85,0.22);
 
-  /* Aurora orbs — brighter, more visible warm-cool blooms on pearl bg */
-  --orb-a1: rgba(255,210,130,0.55);
-  --orb-a2: rgba(220,170,80,0.18);
-  --orb-b1: rgba(150,190,225,0.50);
-  --orb-b2: rgba(90,150,200,0.18);
-  --orb-c1: rgba(255,225,160,0.30);
+  /* Aurora orbs — cool pearl-dominant, gold only as small warm accent */
+  --orb-a1: rgba(230,210,160,0.32);   /* champagne whisper */
+  --orb-a2: rgba(200,180,140,0.10);
+  --orb-b1: rgba(155,195,225,0.55);   /* ice blue (dominant) */
+  --orb-b2: rgba(100,160,210,0.20);
+  --orb-c1: rgba(220,230,238,0.30);   /* pearl white centre */
 
   --dot-color:  rgba(200,154,85,0.16);
   --dc-color:   rgba(200,154,85,0.85);
@@ -699,10 +699,19 @@ watch(() => props.modelValue, () => {
   box-shadow: 0 4px 18px var(--item-glow), inset 0 1px 0 rgba(255,255,255,0.85);
 }
 
+.s-root[data-theme="pearl"] .s-progress {
+  padding-top: 0.32rem;
+  padding-bottom: 0.22rem;
+  background:
+    linear-gradient(90deg, rgba(255,255,255,0.42), rgba(238,247,255,0.30));
+  border-bottom-color: rgba(214, 179, 90, 0.10);
+  box-shadow: 0 8px 22px rgba(90, 110, 130, 0.025);
+}
+
 /* ═══════════════════════════════════════════════
    Pearl Dawn — drifting flowing light layer
-   Below content but above page bg. Strong, visible bloom that
-   slowly rotates → "morning light streaming through the room".
+   Cool-dominant: ice blue + pearl white major notes, gold minor accent.
+   No more "土黄 sweep" — see color ratio note in style.css.
 ═══════════════════════════════════════════════ */
 .s-root[data-theme="pearl"]::before {
   content: '';
@@ -714,17 +723,16 @@ watch(() => props.modelValue, () => {
     conic-gradient(
       from 0deg at 28% 32%,
       transparent 0deg,
-      rgba(255, 198, 110, 0.50) 50deg,
-      rgba(255, 222, 165, 0.28) 110deg,
+      rgba(160, 200, 230, 0.42) 50deg,
+      rgba(195, 220, 235, 0.24) 110deg,
       transparent 190deg,
-      rgba(160, 205, 235, 0.42) 270deg,
-      rgba(190, 220, 240, 0.20) 320deg,
+      rgba(232, 215, 175, 0.22) 270deg,
+      rgba(240, 230, 210, 0.10) 320deg,
       transparent 360deg
     );
-  filter: blur(60px);
-  animation: pearlFlow 26s linear infinite;
+  filter: blur(70px);
+  animation: pearlFlow 28s linear infinite;
   will-change: transform;
-  mix-blend-mode: normal;
 }
 
 .s-root[data-theme="pearl"]::after {
@@ -737,14 +745,14 @@ watch(() => props.modelValue, () => {
     conic-gradient(
       from 180deg at 75% 68%,
       transparent 0deg,
-      rgba(255, 210, 140, 0.38) 70deg,
+      rgba(180, 210, 230, 0.36) 70deg,
       transparent 170deg,
-      rgba(195, 220, 235, 0.32) 250deg,
-      rgba(255, 205, 145, 0.22) 320deg,
+      rgba(220, 228, 238, 0.30) 250deg,
+      rgba(232, 215, 175, 0.18) 320deg,
       transparent 360deg
     );
-  filter: blur(70px);
-  animation: pearlFlow 36s linear infinite reverse;
+  filter: blur(80px);
+  animation: pearlFlow 38s linear infinite reverse;
   will-change: transform;
 }
 

--- a/frontend/src/components/studio/StudioLayout.vue
+++ b/frontend/src/components/studio/StudioLayout.vue
@@ -106,13 +106,7 @@
       <!-- Footer: theme switcher + slot + dev -->
       <div class="sb-footer">
         <slot name="header-actions"/>
-        <!-- Theme cycle button -->
-        <button class="sb-theme-btn" @click="cycleTheme" :title="`主题：${THEMES[currentTheme].label} → 点击切换`">
-          <span class="sb-theme-ring">
-            <span class="sb-theme-dot"/>
-          </span>
-          <span class="sb-theme-label">{{ THEMES[currentTheme].short }}</span>
-        </button>
+        <ThemeSwitcher/>
         <button v-if="devMode" class="sb-dev-btn" title="Dev mode" @click="$emit('toggle-dev')">⚙</button>
       </div>
     </aside>
@@ -137,6 +131,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { animate } from 'animejs'
+import ThemeSwitcher from './ThemeSwitcher.vue'
+import { useTheme } from '../../composables/useTheme'
 
 const props = defineProps<{
   modelValue: string
@@ -149,45 +145,26 @@ defineEmits<{
   (e: 'toggle-dev'): void
 }>()
 
-// ── Theme system ────────────────────────────────
-type ThemeKey = 'gold' | 'blue' | 'purple' | 'pearl'
+// ── Theme (shared composable) ────────────────────
+const { theme: currentTheme, themeMeta } = useTheme()
 
-const THEMES: Record<ThemeKey, { label: string; short: string; a: string; b: string; c: string }> = {
-  gold:   { label: '沉金暗调', short: '金',  a: '245,158,11', b: '249,115,22', c: '251,191,36' },
-  blue:   { label: '极夜蓝调', short: '蓝',  a: '14,165,233', b: '99,102,241', c: '56,189,248' },
-  purple: { label: '暗紫星芒', short: '紫',  a: '168,85,247', b: '244,63,94',  c: '192,132,252' },
-  pearl:  { label: '珍珠晨光', short: '珠',  a: '194,145,74', b: '79,143,192', c: '233,203,131' },
-}
-const THEME_ORDER: ThemeKey[] = ['gold', 'blue', 'purple', 'pearl']
-
-const currentTheme = ref<ThemeKey>(
-  (localStorage.getItem('studio_theme') as ThemeKey | null) ?? 'gold'
-)
-
-function applyTheme(t: ThemeKey) {
-  document.documentElement.setAttribute('data-theme', t)
-}
-
-function cycleTheme() {
-  const idx = THEME_ORDER.indexOf(currentTheme.value)
-  currentTheme.value = THEME_ORDER[(idx + 1) % THEME_ORDER.length]
-  localStorage.setItem('studio_theme', currentTheme.value)
-  applyTheme(currentTheme.value)
-}
-
-// Theme-aware accent color helper
+// Accent helpers for inline-styled SVG / dynamic styles
 function tc(opacity: number, variant: 'a' | 'b' | 'c' = 'a'): string {
-  return `rgba(${THEMES[currentTheme.value][variant]},${opacity})`
+  const arr = themeMeta.value.swatches
+  // Convert hex swatch to "r,g,b" for use in rgba()
+  const hex = variant === 'a' ? arr[0] : variant === 'b' ? arr[1] : arr[2]
+  const rgb = hexToRgb(hex)
+  return `rgba(${rgb},${opacity})`
 }
 
-const themeAccentA = computed(() => {
-  const { a } = THEMES[currentTheme.value]
-  return `rgb(${a})`
-})
-const themeAccentB = computed(() => {
-  const { b } = THEMES[currentTheme.value]
-  return `rgb(${b})`
-})
+function hexToRgb(hex: string): string {
+  const m = hex.replace('#', '').match(/.{2}/g)
+  if (!m || m.length < 3) return '255,255,255'
+  return `${parseInt(m[0], 16)},${parseInt(m[1], 16)},${parseInt(m[2], 16)}`
+}
+
+const themeAccentA = computed(() => themeMeta.value.swatches[0])
+const themeAccentB = computed(() => themeMeta.value.swatches[1])
 
 // ── Content animation ────────────────────────────
 const mainRef = ref<HTMLElement | null>(null)
@@ -208,9 +185,6 @@ function animateContentIn() {
 }
 
 onMounted(() => {
-  // Apply saved theme on load
-  applyTheme(currentTheme.value)
-
   animate('.sb-item', {
     opacity: [0, 1],
     translateX: [-10, 0],
@@ -466,51 +440,6 @@ watch(() => props.modelValue, () => {
   border-top: 1px solid var(--sidebar-border, rgba(245,158,11,0.08));
 }
 
-/* Theme cycle button */
-.sb-theme-btn {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  width: 56px;
-  padding: 8px 4px;
-  border-radius: 12px;
-  border: 1px solid var(--sidebar-border, rgba(245,158,11,0.14));
-  background: transparent;
-  cursor: pointer;
-  font-family: inherit;
-  transition: background 0.2s, border-color 0.2s;
-}
-.sb-theme-btn:hover {
-  background: var(--item-hover-bg, rgba(245,158,11,0.08));
-  border-color: var(--item-active-border, rgba(245,158,11,0.30));
-}
-
-.sb-theme-ring {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px; height: 22px;
-  border-radius: 50%;
-  border: 1.5px solid var(--accent-a, rgba(245,158,11,0.60));
-  box-shadow: 0 0 8px var(--accent-a, rgba(245,158,11,0.30));
-}
-
-.sb-theme-dot {
-  display: block;
-  width: 10px; height: 10px;
-  border-radius: 50%;
-  background: var(--accent-a-solid, #f59e0b);
-  box-shadow: 0 0 6px var(--accent-a, rgba(245,158,11,0.70));
-}
-
-.sb-theme-label {
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  color: rgba(255,255,255,0.40);
-}
-
 .sb-dev-btn {
   width: 36px; height: 36px;
   border-radius: 10px;
@@ -720,48 +649,52 @@ watch(() => props.modelValue, () => {
    珍珠晨光 · Pearl Dawn (light theme)
 ═══════════════════════════════════════════════ */
 .s-root[data-theme="pearl"] {
-  --accent-a:           rgba(194,145,74,0.70);
+  --accent-a:           rgba(200,154,85,0.72);
   --accent-c:           rgba(233,203,131,0.80);
-  --accent-a-solid:     #c2914a;
-  --brand-glow:         rgba(194,145,74,0.55);
-  --sidebar-bg:         rgba(255,253,247,0.86);
-  --sidebar-border:     rgba(194,145,74,0.16);
-  --sidebar-shadow:     4px 0 32px rgba(120,90,40,0.10);
-  --item-hover-bg:      rgba(194,145,74,0.10);
-  --item-hover-border:  rgba(194,145,74,0.28);
-  --item-active-bg:     rgba(194,145,74,0.18);
-  --item-active-border: rgba(194,145,74,0.50);
-  --item-glow:          rgba(194,145,74,0.22);
-  /* Soft pearl orbs */
-  --orb-a1: rgba(194,145,74,0.22);
-  --orb-a2: rgba(140,100,40,0.08);
-  --orb-b1: rgba(79,143,192,0.20);
-  --orb-b2: rgba(40,90,140,0.08);
-  --orb-c1: rgba(233,203,131,0.16);
-  --dot-color:  rgba(194,145,74,0.18);
-  --dc-color:   rgba(194,145,74,0.90);
-  --pt-a:       #c2914a;
+  --accent-a-solid:     #c89a55;
+  --brand-glow:         rgba(200,154,85,0.50);
+
+  /* Bright white pearl sidebar */
+  --sidebar-bg:         rgba(255,255,255,0.88);
+  --sidebar-border:     rgba(200,154,85,0.18);
+  --sidebar-shadow:     4px 0 28px rgba(100,90,60,0.10);
+
+  --item-hover-bg:      rgba(200,154,85,0.10);
+  --item-hover-border:  rgba(200,154,85,0.28);
+  --item-active-bg:     rgba(255,238,200,0.55);
+  --item-active-border: rgba(200,154,85,0.55);
+  --item-glow:          rgba(200,154,85,0.22);
+
+  /* Aurora orbs — pastel soft */
+  --orb-a1: rgba(255,226,168,0.36);
+  --orb-a2: rgba(220,180,100,0.10);
+  --orb-b1: rgba(180,210,235,0.32);
+  --orb-b2: rgba(120,170,210,0.10);
+  --orb-c1: rgba(255,233,175,0.18);
+
+  --dot-color:  rgba(200,154,85,0.16);
+  --dc-color:   rgba(200,154,85,0.85);
+  --pt-a:       #c89a55;
   --pt-b:       #e9cb83;
   --pt-c:       #d6b06a;
-  --pt-glow-a:  rgba(194,145,74,0.85);
-  --pt-glow-b:  rgba(233,203,131,0.85);
-  --pt-glow-c:  rgba(194,145,74,1);
+  --pt-glow-a:  rgba(200,154,85,0.80);
+  --pt-glow-b:  rgba(233,203,131,0.80);
+  --pt-glow-c:  rgba(200,154,85,0.95);
 }
 
-/* Sidebar nav items — text reversal for light theme */
-.s-root[data-theme="pearl"] .sb-icon          { color: rgba(50,44,34,0.50); }
-.s-root[data-theme="pearl"] .sb-item:hover:not(.is-active) .sb-icon { color: rgba(50,44,34,0.78); }
-.s-root[data-theme="pearl"] .sb-label         { color: rgba(50,44,34,0.45); }
-.s-root[data-theme="pearl"] .sb-item:hover:not(.is-active) .sb-label { color: rgba(50,44,34,0.78); }
+/* Sidebar nav items — dark icons/labels on white pearl */
+.s-root[data-theme="pearl"] .sb-icon                                { color: rgba(60,66,76,0.55); }
+.s-root[data-theme="pearl"] .sb-item:hover:not(.is-active) .sb-icon { color: rgba(60,66,76,0.85); }
+.s-root[data-theme="pearl"] .sb-label                               { color: rgba(60,66,76,0.55); }
+.s-root[data-theme="pearl"] .sb-item:hover:not(.is-active) .sb-label{ color: rgba(60,66,76,0.85); }
 .s-root[data-theme="pearl"] .sb-item.is-active .sb-icon,
-.s-root[data-theme="pearl"] .sb-item.is-active .sb-label { color: var(--arc-300, #b8843e); }
-.s-root[data-theme="pearl"] .sb-dev-btn       { color: rgba(50,44,34,0.45); background: rgba(0,0,0,0.04); border-color: rgba(0,0,0,0.08); }
-.s-root[data-theme="pearl"] .sb-dev-btn:hover { color: rgba(50,44,34,0.75); background: rgba(0,0,0,0.08); }
-.s-root[data-theme="pearl"] .sb-theme-label   { color: rgba(50,44,34,0.50); }
+.s-root[data-theme="pearl"] .sb-item.is-active .sb-label            { color: #8b6722; }
+.s-root[data-theme="pearl"] .sb-dev-btn                             { color: rgba(60,66,76,0.55); background: rgba(0,0,0,0.04); border-color: rgba(0,0,0,0.08); }
+.s-root[data-theme="pearl"] .sb-dev-btn:hover                       { color: rgba(60,66,76,0.85); background: rgba(0,0,0,0.07); }
 
-/* Lighten the dark inset highlight in light mode */
+/* Soft white highlight on active item */
 .s-root[data-theme="pearl"] .sb-item.is-active {
-  box-shadow: 0 0 18px var(--item-glow), inset 0 1px 0 rgba(255,255,255,0.50);
+  box-shadow: 0 4px 18px var(--item-glow), inset 0 1px 0 rgba(255,255,255,0.85);
 }
 
 /* ── Responsive ── */

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -702,7 +702,7 @@ const progressSteps = computed(() => {
   flex-shrink: 0;
   padding: 0.875rem 1.25rem 1rem;
   border-top: 1px solid rgba(245,158,11,0.08);
-  background: rgba(0,0,0,0.15);
+  background: var(--surface-overlay-soft);
 }
 
 .pp-history-header {
@@ -779,7 +779,7 @@ const progressSteps = computed(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0,0,0,0.30);
+  background: var(--surface-overlay-strong);
   opacity: 0;
   transition: opacity 0.18s;
 }

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -46,35 +46,21 @@
             </button>
           </div>
         </div>
-      </template>
-
-      <!-- ════ B: Render in flight ════ -->
-      <div v-else-if="renderInFlight" class="pp-state">
-        <svg class="pp-state-svg pp-spin" viewBox="0 0 60 60" fill="none">
-          <circle cx="30" cy="30" r="24" stroke="currentColor" stroke-opacity="0.15" stroke-width="4"/>
-          <path d="M30 6 A24 24 0 0 1 54 30" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
-        </svg>
-        <div class="pp-state-title">视频合成中…</div>
-        <div class="pp-state-desc">画面、音频与字幕正在拼接渲染</div>
-      </div>
-
-      <!-- ════ C: Workflow processing ════ -->
-      <div v-else-if="isProcessing" class="pp-state pp-state--proc">
-        <div class="pp-steps">
-          <div
-            v-for="step in progressSteps"
-            :key="step.id"
-            :class="['pp-step', `pp-step--${step.state}`]"
-          >
-            <span class="pp-step-dot"/>
-            <span class="pp-step-label">{{ step.label }}</span>
-            <span v-if="step.state === 'active'" class="pp-step-pulse"/>
+        <div v-else class="pp-trail">
+          <div class="pp-trail-icon" aria-hidden="true">
+            <span class="pp-trail-book"></span>
+            <span class="pp-trail-play"></span>
+            <span class="pp-trail-star pp-trail-star--a"></span>
+            <span class="pp-trail-star pp-trail-star--b"></span>
+          </div>
+          <div class="pp-trail-copy">
+            <div class="pp-trail-title">创作记录将在这里沉淀</div>
+            <p class="pp-trail-desc">继续生成后，分镜、画面、配音与字幕将在这里形成完整创作记录。</p>
           </div>
         </div>
-        <div v-if="statusLabel" class="pp-status-label">{{ statusLabel }}</div>
-      </div>
+      </template>
 
-      <!-- ════ D: Has history but no current — history as main content ════ -->
+      <!-- ════ B: Has history but no current — history as main content ════ -->
       <div v-else-if="allVideoUrls.length > 0" class="pp-hist-main">
         <div class="pp-hist-main-header">
           <span class="pp-hist-main-title">历史视频</span>
@@ -96,6 +82,32 @@
             <div class="pp-hist-card-label">视频 {{ idx + 1 }}</div>
           </button>
         </div>
+      </div>
+
+      <!-- ════ C: Render in flight ════ -->
+      <div v-else-if="renderInFlight" class="pp-state">
+        <svg class="pp-state-svg pp-spin" viewBox="0 0 60 60" fill="none">
+          <circle cx="30" cy="30" r="24" stroke="currentColor" stroke-opacity="0.15" stroke-width="4"/>
+          <path d="M30 6 A24 24 0 0 1 54 30" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+        </svg>
+        <div class="pp-state-title">视频合成中…</div>
+        <div class="pp-state-desc">画面、音频与字幕正在拼接渲染</div>
+      </div>
+
+      <!-- ════ D: Workflow processing ════ -->
+      <div v-else-if="isProcessing" class="pp-state pp-state--proc">
+        <div class="pp-steps">
+          <div
+            v-for="step in progressSteps"
+            :key="step.id"
+            :class="['pp-step', `pp-step--${step.state}`]"
+          >
+            <span class="pp-step-dot"/>
+            <span class="pp-step-label">{{ step.label }}</span>
+            <span v-if="step.state === 'active'" class="pp-step-pulse"/>
+          </div>
+        </div>
+        <div v-if="statusLabel" class="pp-status-label">{{ statusLabel }}</div>
       </div>
 
       <!-- ════ E: Completely empty — illustrated empty state ════ -->
@@ -738,6 +750,172 @@ const progressSteps = computed(() => {
 .pp-history-list::-webkit-scrollbar        { height: 3px; }
 .pp-history-list::-webkit-scrollbar-track  { background: transparent; }
 .pp-history-list::-webkit-scrollbar-thumb  { background: rgba(245,158,11,0.25); border-radius: 2px; }
+
+/* ── Subtle single-video follow-up panel ── */
+.pp-trail {
+  flex: 1;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.875rem;
+  align-items: center;
+  min-height: 190px;
+  margin: 1rem 1.25rem 1.25rem;
+  padding: 1rem 1.125rem;
+  border-radius: 16px;
+  border: 1px solid rgba(245,158,11,0.12);
+  background:
+    linear-gradient(135deg, rgba(255,255,255,0.06), rgba(245,158,11,0.035)),
+    var(--surface-overlay-soft);
+}
+
+.pp-trail-icon {
+  position: relative;
+  width: 58px;
+  height: 58px;
+  border-radius: 18px;
+  border: 1px solid rgba(245,158,11,0.16);
+  background: rgba(255,255,255,0.045);
+}
+
+.pp-trail-book {
+  position: absolute;
+  left: 15px;
+  top: 15px;
+  width: 26px;
+  height: 28px;
+  border: 1.5px solid var(--arc-400);
+  border-radius: 4px 8px 8px 4px;
+  opacity: 0.72;
+}
+
+.pp-trail-book::before {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: -1.5px;
+  width: 1.5px;
+  height: 28px;
+  background: var(--arc-400);
+  opacity: 0.35;
+}
+
+.pp-trail-play {
+  position: absolute;
+  left: 27px;
+  top: 24px;
+  width: 0;
+  height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 9px solid var(--prism-400);
+  opacity: 0.68;
+}
+
+.pp-trail-star {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--arc-400);
+  opacity: 0.55;
+}
+
+.pp-trail-star--a { right: 11px; top: 11px; }
+.pp-trail-star--b { left: 11px; bottom: 12px; background: var(--prism-400); }
+
+.pp-trail-copy {
+  min-width: 0;
+}
+
+.pp-trail-title {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.pp-trail-desc {
+  margin: 0.35rem 0 0;
+  max-width: 320px;
+  font-size: 0.75rem;
+  line-height: 1.65;
+  color: var(--text-muted);
+}
+
+/* Pearl Dawn: refined acrylic preview surface */
+:global(:root[data-theme="pearl"]) .preview-panel {
+  border-color: rgba(214, 179, 90, 0.20);
+  box-shadow:
+    0 26px 72px rgba(46,42,34,0.085),
+    0 10px 26px rgba(142,197,255,0.075),
+    inset 0 1px 0 rgba(255,255,255,0.92);
+}
+
+:global(:root[data-theme="pearl"]) .pp-header {
+  border-bottom-color: rgba(214, 179, 90, 0.14);
+  background: linear-gradient(180deg, rgba(255,255,255,0.42), rgba(255,255,255,0));
+}
+
+:global(:root[data-theme="pearl"]) .pp-player-wrap {
+  border: 1px solid rgba(214,179,90,0.18);
+  box-shadow:
+    0 24px 64px rgba(46,42,34,0.10),
+    0 8px 28px rgba(142,197,255,0.08),
+    inset 0 1px 0 rgba(255,255,255,0.82);
+}
+
+:global(:root[data-theme="pearl"]) .pp-current-label {
+  background:
+    linear-gradient(90deg, rgba(255,255,255,0.66), rgba(238,247,255,0.50));
+  border-bottom-color: rgba(214,179,90,0.12);
+  backdrop-filter: blur(14px) saturate(1.08);
+  -webkit-backdrop-filter: blur(14px) saturate(1.08);
+}
+
+:global(:root[data-theme="pearl"]) .pp-current-tag {
+  background: linear-gradient(135deg, rgba(248,232,198,0.78), rgba(229,242,255,0.56));
+  border-color: rgba(214,179,90,0.28);
+  color: #8b6722;
+  box-shadow:
+    0 0 14px rgba(214,179,90,0.12),
+    inset 0 1px 0 rgba(255,255,255,0.78);
+}
+
+:global(:root[data-theme="pearl"]) .pp-trail,
+:global(:root[data-theme="pearl"]) .pp-empty {
+  background:
+    radial-gradient(circle at 12% 18%, rgba(246, 222, 166, 0.20), transparent 28%),
+    radial-gradient(circle at 86% 78%, rgba(142, 197, 255, 0.16), transparent 36%),
+    linear-gradient(145deg, rgba(255,255,255,0.72), rgba(247,250,252,0.54));
+  border: 1px solid rgba(214,179,90,0.18);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.86),
+    0 18px 46px rgba(46,42,34,0.06);
+  backdrop-filter: blur(18px) saturate(1.08);
+  -webkit-backdrop-filter: blur(18px) saturate(1.08);
+}
+
+:global(:root[data-theme="pearl"]) .pp-empty {
+  margin: 1rem 1.25rem 1.25rem;
+  border-radius: 18px;
+}
+
+:global(:root[data-theme="pearl"]) .pp-trail-icon {
+  background:
+    linear-gradient(145deg, rgba(255,255,255,0.78), rgba(238,247,255,0.44));
+  border-color: rgba(214,179,90,0.22);
+  box-shadow:
+    0 12px 30px rgba(46,42,34,0.06),
+    inset 0 1px 0 rgba(255,255,255,0.82);
+}
+
+:global(:root[data-theme="pearl"]) .pp-trail-title {
+  color: rgba(46,42,34,0.82);
+}
+
+:global(:root[data-theme="pearl"]) .pp-trail-desc,
+:global(:root[data-theme="pearl"]) .pp-current-url {
+  color: rgba(111,106,95,0.76);
+}
 
 /* Thumbnail button */
 .pp-thumb {

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -271,7 +271,6 @@ const progressSteps = computed(() => {
   }))
 })
 
-const historyListRef = ref<HTMLElement | null>(null)
 </script>
 
 <style scoped>

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -895,7 +895,7 @@ const progressSteps = computed(() => {
 }
 
 :global(:root[data-theme="pearl"]) .pp-empty {
-  margin: 1rem 1.25rem 1.25rem;
+  /* margin: 1rem 1.25rem 1.25rem; */
   border-radius: 18px;
 }
 

--- a/frontend/src/components/studio/StudioProgress.vue
+++ b/frontend/src/components/studio/StudioProgress.vue
@@ -23,8 +23,22 @@ defineProps<{
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding: 0.375rem 0 0.125rem;
+  /* Glass strip styling (was on parent .s-progress wrapper, moved here
+     so it only renders when v-if="visible" is true) */
+  padding: 0.45rem 1.5rem 0.35rem 1.25rem;
+  background: var(--sidebar-bg, rgba(9,7,3,0.82));
+  backdrop-filter: blur(24px) saturate(150%);
+  -webkit-backdrop-filter: blur(24px) saturate(150%);
+  border-bottom: 1px solid var(--sidebar-border, rgba(245,158,11,0.10));
   animation: fadeIn 0.25s ease-out;
+}
+
+/* Pearl override — soft white-blue glass */
+:global(:root[data-theme="pearl"]) .studio-progress {
+  background: linear-gradient(90deg, rgba(255,255,255,0.42), rgba(238,247,255,0.30));
+  border-bottom-color: rgba(214, 179, 90, 0.10);
+  box-shadow: 0 8px 22px rgba(90, 110, 130, 0.025);
+  padding-left: 0.5rem;
 }
 .studio-progress__bar {
   display: flex;

--- a/frontend/src/components/studio/StudioProgress.vue
+++ b/frontend/src/components/studio/StudioProgress.vue
@@ -48,4 +48,21 @@ defineProps<{
   background: linear-gradient(90deg, #34d399 0%, var(--arc-400) 100%);
   box-shadow: 0 0 8px rgba(52,211,153,0.60);
 }
+
+:global(:root[data-theme="pearl"]) .studio-progress__pct {
+  color: rgba(138, 112, 64, 0.72);
+}
+
+:global(:root[data-theme="pearl"]) .studio-progress__label {
+  color: rgba(111, 106, 95, 0.68);
+}
+
+:global(:root[data-theme="pearl"]) .studio-progress--complete .progress-fill {
+  background: linear-gradient(
+    90deg,
+    rgba(196, 216, 228, 0.58) 0%,
+    rgba(218, 188, 124, 0.54) 100%
+  );
+  box-shadow: 0 0 6px rgba(188, 215, 232, 0.14);
+}
 </style>

--- a/frontend/src/components/studio/ThemeSwitcher.vue
+++ b/frontend/src/components/studio/ThemeSwitcher.vue
@@ -10,10 +10,10 @@
     >
       <span class="ts-trigger-swatches" aria-hidden="true">
         <span
-          v-for="(c, i) in themeMeta.swatches"
+          v-for="(g, i) in themeMeta.gradients"
           :key="i"
           class="ts-trigger-dot"
-          :style="{ background: c }"
+          :style="{ background: g }"
         />
       </span>
       <span class="ts-trigger-label">{{ themeMeta.short }}</span>
@@ -38,10 +38,10 @@
           <!-- Color swatches -->
           <span class="ts-swatches" aria-hidden="true">
             <span
-              v-for="(c, i) in themes[key].swatches"
+              v-for="(g, i) in themes[key].gradients"
               :key="i"
               class="ts-swatch"
-              :style="{ background: c }"
+              :style="{ background: g }"
             />
           </span>
 
@@ -98,92 +98,97 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
 </script>
 
 <style scoped>
+/* Fixed top-right floating switcher — never affects layout flow */
 .ts-root {
-  position: relative;
+  position: fixed;
+  top: 14px;
+  right: 18px;
+  z-index: 80;
   display: inline-block;
 }
 
-/* ── Trigger pill ── */
+/* ── Trigger pill (horizontal capsule) ── */
 .ts-trigger {
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
   align-items: center;
-  gap: 5px;
-  width: 56px;
-  padding: 8px 4px;
-  border-radius: 12px;
-  border: 1px solid var(--sidebar-border, rgba(245,158,11,0.14));
-  background: transparent;
+  gap: 8px;
+  height: 34px;
+  padding: 0 12px 0 10px;
+  border-radius: 999px;
+  border: 1px solid var(--sidebar-border, rgba(245,158,11,0.18));
+  background: var(--glass-bg-light, rgba(20,16,8,0.78));
+  backdrop-filter: blur(20px) saturate(150%);
+  -webkit-backdrop-filter: blur(20px) saturate(150%);
   cursor: pointer;
   font-family: inherit;
   transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.22);
 }
 
 .ts-trigger:hover {
-  background: var(--item-hover-bg, rgba(245,158,11,0.08));
-  border-color: var(--item-active-border, rgba(245,158,11,0.30));
+  background: var(--item-hover-bg, rgba(245,158,11,0.10));
+  border-color: var(--item-active-border, rgba(245,158,11,0.36));
 }
 
 .ts-trigger[aria-expanded='true'] {
-  background: var(--item-active-bg, rgba(245,158,11,0.14));
-  border-color: var(--item-active-border, rgba(245,158,11,0.42));
-  box-shadow: 0 0 14px var(--item-glow, rgba(245,158,11,0.18));
+  background: var(--item-active-bg, rgba(245,158,11,0.16));
+  border-color: var(--item-active-border, rgba(245,158,11,0.50));
+  box-shadow: 0 0 18px var(--item-glow, rgba(245,158,11,0.22)),
+              0 4px 14px rgba(0,0,0,0.20);
 }
 
-/* Three mini swatches in trigger */
+/* Three mini gradient chips in trigger — bare, no tray */
 .ts-trigger-swatches {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: 3px;
 }
 
 .ts-trigger-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  box-shadow: 0 0 4px currentColor;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.08);
 }
 
 .ts-trigger-label {
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  color: var(--text-muted, rgba(255,255,255,0.40));
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary, rgba(255,255,255,0.70));
 }
 
-/* ── Popover panel ── */
+/* ── Popover panel — opens downward, right-aligned ── */
 .ts-panel {
   position: absolute;
-  bottom: calc(100% + 10px);
-  left: 50%;
-  transform: translateX(-50%);
-  width: 240px;
-  padding: 8px;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 260px;
+  padding: 10px;
   border-radius: 14px;
-  background: var(--glass-bg-light, rgba(20,16,8,0.92));
-  backdrop-filter: blur(24px) saturate(160%);
-  -webkit-backdrop-filter: blur(24px) saturate(160%);
-  border: 1px solid var(--glass-border, rgba(245,158,11,0.16));
+  background: var(--glass-bg-light, rgba(20,16,8,0.94));
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  border: 1px solid var(--glass-border, rgba(245,158,11,0.18));
   box-shadow:
-    0 14px 40px rgba(0,0,0,0.50),
-    0 0 0 1px var(--glass-border, rgba(245,158,11,0.08)),
+    0 18px 48px rgba(0,0,0,0.55),
+    0 0 0 1px var(--glass-border, rgba(245,158,11,0.10)),
     inset 0 1px 0 rgba(255,255,255,0.10);
-  z-index: 80;
+  z-index: 81;
 }
 
-/* Arrow tip pointing down */
+/* Arrow tip pointing up (panel below the button) */
 .ts-panel::after {
   content: '';
   position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 100%;
+  right: 22px;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
-  border-top: 7px solid var(--glass-bg-light, rgba(20,16,8,0.92));
-  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.30));
+  border-bottom: 7px solid var(--glass-bg-light, rgba(20,16,8,0.94));
+  filter: drop-shadow(0 -1px 1px rgba(0,0,0,0.30));
 }
 
 .ts-panel-header {
@@ -235,22 +240,29 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
   border-color: var(--item-active-border, rgba(245,158,11,0.38));
 }
 
+/* Palette tray (option row) — glass card, NOT grey plastic */
 .ts-swatches {
   display: inline-flex;
   flex-shrink: 0;
-  gap: 3px;
-  padding: 3px 5px;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
   border-radius: 6px;
-  background: rgba(0,0,0,0.25);
-  border: 1px solid rgba(255,255,255,0.08);
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  transition: opacity 0.18s;
 }
 
+/* No special hover/active for swatch tray — keeps focus on dots themselves */
+
+/* Individual chip — tiny flat circle */
 .ts-swatch {
   display: block;
   width: 10px;
-  height: 16px;
-  border-radius: 2px;
-  box-shadow: 0 0 4px currentColor;
+  height: 10px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06);
 }
 
 .ts-text {
@@ -287,7 +299,7 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
   color: var(--arc-300, #fbbf24);
 }
 
-/* ── Fade animation ── */
+/* ── Fade animation (drop-down) ── */
 .ts-fade-enter-active,
 .ts-fade-leave-active {
   transition: opacity 0.18s ease, transform 0.18s ease;
@@ -295,6 +307,6 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
 .ts-fade-enter-from,
 .ts-fade-leave-to {
   opacity: 0;
-  transform: translateX(-50%) translateY(4px);
+  transform: translateY(-6px);
 }
 </style>

--- a/frontend/src/components/studio/ThemeSwitcher.vue
+++ b/frontend/src/components/studio/ThemeSwitcher.vue
@@ -98,12 +98,12 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
 </script>
 
 <style scoped>
-/* Fixed top-right floating switcher — never affects layout flow */
+/* Fixed bottom-right floating switcher — never affects layout flow */
 .ts-root {
   position: fixed;
-  top: 56px;
+  bottom: 24px;
   right: 24px;
-  z-index: 120;
+  z-index: 9999;
   display: inline-block;
 }
 
@@ -158,12 +158,15 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
   color: var(--text-secondary, rgba(255,255,255,0.70));
 }
 
-/* ── Popover panel — opens downward, right-aligned ── */
+/* ── Popover panel — opens upward, right-aligned ── */
 .ts-panel {
   position: absolute;
-  top: calc(100% + 10px);
   right: 0;
-  width: 260px;
+  bottom: calc(100% + 12px);
+  width: 248px;
+  max-height: min(420px, calc(100vh - 96px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 10px;
   border-radius: 14px;
   background: var(--glass-bg-light, rgba(20,16,8,0.94));
@@ -174,21 +177,21 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
     0 18px 48px rgba(0,0,0,0.55),
     0 0 0 1px var(--glass-border, rgba(245,158,11,0.10)),
     inset 0 1px 0 rgba(255,255,255,0.10);
-  z-index: 121;
+  z-index: 10000;
 }
 
-/* Arrow tip pointing up (panel below the button) */
+/* Arrow tip pointing down (panel above the button) */
 .ts-panel::after {
   content: '';
   position: absolute;
-  bottom: 100%;
+  top: 100%;
   right: 22px;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
-  border-bottom: 7px solid var(--glass-bg-light, rgba(20,16,8,0.94));
-  filter: drop-shadow(0 -1px 1px rgba(0,0,0,0.30));
+  border-top: 7px solid var(--glass-bg-light, rgba(20,16,8,0.94));
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.30));
 }
 
 .ts-panel-header {
@@ -307,7 +310,7 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
 .ts-fade-enter-from,
 .ts-fade-leave-to {
   opacity: 0;
-  transform: translateY(-6px);
+  transform: translateY(6px);
 }
 
 /* Pearl Dawn: lighter acrylic switcher, no grey capsule feel */
@@ -350,14 +353,19 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
 }
 
 :global(:root[data-theme="pearl"]) .ts-panel::after {
-  border-bottom-color: rgba(255,255,255,0.82);
-  filter: drop-shadow(0 -1px 1px rgba(214,179,90,0.12));
+  border-top-color: rgba(255,255,255,0.82);
+  filter: drop-shadow(0 1px 1px rgba(214,179,90,0.12));
 }
 
 @media (max-width: 768px) {
   .ts-root {
-    top: 54px;
+    bottom: 18px;
     right: 14px;
+  }
+
+  .ts-panel {
+    width: min(248px, calc(100vw - 28px));
+    max-height: min(420px, calc(100vh - 78px));
   }
 }
 </style>

--- a/frontend/src/components/studio/ThemeSwitcher.vue
+++ b/frontend/src/components/studio/ThemeSwitcher.vue
@@ -101,9 +101,9 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
 /* Fixed top-right floating switcher — never affects layout flow */
 .ts-root {
   position: fixed;
-  top: 14px;
-  right: 18px;
-  z-index: 80;
+  top: 56px;
+  right: 24px;
+  z-index: 120;
   display: inline-block;
 }
 
@@ -174,7 +174,7 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
     0 18px 48px rgba(0,0,0,0.55),
     0 0 0 1px var(--glass-border, rgba(245,158,11,0.10)),
     inset 0 1px 0 rgba(255,255,255,0.10);
-  z-index: 81;
+  z-index: 121;
 }
 
 /* Arrow tip pointing up (panel below the button) */
@@ -308,5 +308,56 @@ const vClickOutside: Directive<HTMLElement, () => void> = {
 .ts-fade-leave-to {
   opacity: 0;
   transform: translateY(-6px);
+}
+
+/* Pearl Dawn: lighter acrylic switcher, no grey capsule feel */
+:global(:root[data-theme="pearl"]) .ts-trigger {
+  background:
+    linear-gradient(145deg, rgba(255,255,255,0.86), rgba(255,255,255,0.62));
+  border-color: rgba(214,179,90,0.24);
+  box-shadow:
+    0 12px 34px rgba(46,42,34,0.08),
+    0 4px 14px rgba(142,197,255,0.08),
+    inset 0 1px 0 rgba(255,255,255,0.88);
+}
+
+:global(:root[data-theme="pearl"]) .ts-trigger:hover,
+:global(:root[data-theme="pearl"]) .ts-trigger[aria-expanded='true'] {
+  background:
+    linear-gradient(145deg, rgba(255,255,255,0.92), rgba(240,248,255,0.68));
+  border-color: rgba(214,179,90,0.34);
+  box-shadow:
+    0 16px 40px rgba(46,42,34,0.09),
+    0 0 22px rgba(142,197,255,0.10),
+    inset 0 1px 0 rgba(255,255,255,0.92);
+}
+
+:global(:root[data-theme="pearl"]) .ts-trigger-dot,
+:global(:root[data-theme="pearl"]) .ts-swatch {
+  box-shadow:
+    0 0 0 1px rgba(214,179,90,0.18),
+    0 2px 6px rgba(46,42,34,0.10);
+}
+
+:global(:root[data-theme="pearl"]) .ts-panel {
+  background:
+    linear-gradient(145deg, rgba(255,255,255,0.90), rgba(255,255,255,0.70));
+  border-color: rgba(214,179,90,0.22);
+  box-shadow:
+    0 24px 60px rgba(46,42,34,0.12),
+    0 8px 24px rgba(142,197,255,0.08),
+    inset 0 1px 0 rgba(255,255,255,0.88);
+}
+
+:global(:root[data-theme="pearl"]) .ts-panel::after {
+  border-bottom-color: rgba(255,255,255,0.82);
+  filter: drop-shadow(0 -1px 1px rgba(214,179,90,0.12));
+}
+
+@media (max-width: 768px) {
+  .ts-root {
+    top: 54px;
+    right: 14px;
+  }
 }
 </style>

--- a/frontend/src/components/studio/ThemeSwitcher.vue
+++ b/frontend/src/components/studio/ThemeSwitcher.vue
@@ -1,0 +1,300 @@
+<template>
+  <div class="ts-root" v-click-outside="closePanel">
+    <!-- Trigger button -->
+    <button
+      class="ts-trigger"
+      :aria-expanded="open"
+      aria-haspopup="listbox"
+      :title="`当前主题：${themeMeta.label}`"
+      @click="open = !open"
+    >
+      <span class="ts-trigger-swatches" aria-hidden="true">
+        <span
+          v-for="(c, i) in themeMeta.swatches"
+          :key="i"
+          class="ts-trigger-dot"
+          :style="{ background: c }"
+        />
+      </span>
+      <span class="ts-trigger-label">{{ themeMeta.short }}</span>
+    </button>
+
+    <!-- Popover panel -->
+    <transition name="ts-fade">
+      <div v-if="open" class="ts-panel" role="listbox" :aria-label="'主题切换'">
+        <div class="ts-panel-header">
+          <span class="ts-panel-title">主题</span>
+          <span class="ts-panel-hint">选择你喜欢的风格</span>
+        </div>
+
+        <button
+          v-for="key in themeOrder"
+          :key="key"
+          role="option"
+          :aria-selected="theme === key"
+          :class="['ts-option', { 'is-active': theme === key }]"
+          @click="onPick(key)"
+        >
+          <!-- Color swatches -->
+          <span class="ts-swatches" aria-hidden="true">
+            <span
+              v-for="(c, i) in themes[key].swatches"
+              :key="i"
+              class="ts-swatch"
+              :style="{ background: c }"
+            />
+          </span>
+
+          <!-- Label + tagline -->
+          <span class="ts-text">
+            <span class="ts-label">{{ themes[key].label }}</span>
+            <span class="ts-tagline">{{ themes[key].tagline }}</span>
+          </span>
+
+          <!-- Active check -->
+          <span class="ts-check" aria-hidden="true">
+            <svg v-if="theme === key" width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M3 7.5 L6 10.5 L11.5 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, type Directive } from 'vue'
+import { useTheme, type ThemeKey } from '../../composables/useTheme'
+
+const { theme, themeMeta, themes, themeOrder, setTheme } = useTheme()
+
+const open = ref(false)
+
+function closePanel() {
+  open.value = false
+}
+
+function onPick(key: ThemeKey) {
+  setTheme(key)
+  // brief delay so user sees the check appear before panel closes
+  setTimeout(closePanel, 140)
+}
+
+// Simple click-outside directive — closes panel when clicking elsewhere
+const vClickOutside: Directive<HTMLElement, () => void> = {
+  mounted(el, binding) {
+    const handler = (e: MouseEvent) => {
+      if (!el.contains(e.target as Node)) binding.value()
+    }
+    ;(el as HTMLElement & { __cob?: (e: MouseEvent) => void }).__cob = handler
+    document.addEventListener('mousedown', handler)
+  },
+  unmounted(el) {
+    const handler = (el as HTMLElement & { __cob?: (e: MouseEvent) => void }).__cob
+    if (handler) document.removeEventListener('mousedown', handler)
+  },
+}
+</script>
+
+<style scoped>
+.ts-root {
+  position: relative;
+  display: inline-block;
+}
+
+/* ── Trigger pill ── */
+.ts-trigger {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  width: 56px;
+  padding: 8px 4px;
+  border-radius: 12px;
+  border: 1px solid var(--sidebar-border, rgba(245,158,11,0.14));
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.ts-trigger:hover {
+  background: var(--item-hover-bg, rgba(245,158,11,0.08));
+  border-color: var(--item-active-border, rgba(245,158,11,0.30));
+}
+
+.ts-trigger[aria-expanded='true'] {
+  background: var(--item-active-bg, rgba(245,158,11,0.14));
+  border-color: var(--item-active-border, rgba(245,158,11,0.42));
+  box-shadow: 0 0 14px var(--item-glow, rgba(245,158,11,0.18));
+}
+
+/* Three mini swatches in trigger */
+.ts-trigger-swatches {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.ts-trigger-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  box-shadow: 0 0 4px currentColor;
+}
+
+.ts-trigger-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, rgba(255,255,255,0.40));
+}
+
+/* ── Popover panel ── */
+.ts-panel {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 240px;
+  padding: 8px;
+  border-radius: 14px;
+  background: var(--glass-bg-light, rgba(20,16,8,0.92));
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  border: 1px solid var(--glass-border, rgba(245,158,11,0.16));
+  box-shadow:
+    0 14px 40px rgba(0,0,0,0.50),
+    0 0 0 1px var(--glass-border, rgba(245,158,11,0.08)),
+    inset 0 1px 0 rgba(255,255,255,0.10);
+  z-index: 80;
+}
+
+/* Arrow tip pointing down */
+.ts-panel::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid var(--glass-bg-light, rgba(20,16,8,0.92));
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.30));
+}
+
+.ts-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 8px 8px;
+  border-bottom: 1px solid var(--border-subtle, rgba(245,158,11,0.08));
+  margin-bottom: 4px;
+}
+
+.ts-panel-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--text-muted, rgba(255,255,255,0.45));
+}
+
+.ts-panel-hint {
+  font-size: 10px;
+  color: var(--text-muted, rgba(255,255,255,0.35));
+  letter-spacing: 0.02em;
+}
+
+/* ── Option row ── */
+.ts-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 8px;
+  border-radius: 9px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: background 0.18s, border-color 0.18s, transform 0.18s;
+}
+
+.ts-option:hover {
+  background: var(--item-hover-bg, rgba(245,158,11,0.06));
+  border-color: var(--item-hover-border, rgba(245,158,11,0.20));
+}
+
+.ts-option.is-active {
+  background: var(--item-active-bg, rgba(245,158,11,0.14));
+  border-color: var(--item-active-border, rgba(245,158,11,0.38));
+}
+
+.ts-swatches {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 3px;
+  padding: 3px 5px;
+  border-radius: 6px;
+  background: rgba(0,0,0,0.25);
+  border: 1px solid rgba(255,255,255,0.08);
+}
+
+.ts-swatch {
+  display: block;
+  width: 10px;
+  height: 16px;
+  border-radius: 2px;
+  box-shadow: 0 0 4px currentColor;
+}
+
+.ts-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.ts-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary, rgba(255,255,255,0.92));
+}
+
+.ts-option.is-active .ts-label {
+  color: var(--arc-300, #fbbf24);
+}
+
+.ts-tagline {
+  font-size: 10px;
+  color: var(--text-muted, rgba(255,255,255,0.42));
+  line-height: 1.3;
+}
+
+.ts-check {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--arc-300, #fbbf24);
+}
+
+/* ── Fade animation ── */
+.ts-fade-enter-active,
+.ts-fade-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+.ts-fade-enter-from,
+.ts-fade-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(4px);
+}
+</style>

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -1,0 +1,120 @@
+import { computed, readonly, ref } from 'vue'
+
+export type ThemeKey = 'gold' | 'blue' | 'purple' | 'pearl'
+
+export interface ThemeMeta {
+  /** Stable key persisted to localStorage and written to data-theme */
+  key: ThemeKey
+  /** Display label shown in the switcher */
+  label: string
+  /** Short 1-char tag for compact UIs */
+  short: string
+  /** Short tagline shown below the label in the switcher */
+  tagline: string
+  /** Whether the theme is dark-on-light or light-on-dark */
+  mode: 'dark' | 'light'
+  /** Three swatch colors for the preview chip (CSS color strings) */
+  swatches: [string, string, string]
+}
+
+export const THEMES: Record<ThemeKey, ThemeMeta> = {
+  gold: {
+    key: 'gold',
+    label: '沉金暗调',
+    short: '金',
+    tagline: '黑金科技 · 专业工作台',
+    mode: 'dark',
+    swatches: ['#f59e0b', '#fb923c', '#fbbf24'],
+  },
+  blue: {
+    key: 'blue',
+    label: '极夜蓝调',
+    short: '蓝',
+    tagline: '深空冷光 · 科技未来感',
+    mode: 'dark',
+    swatches: ['#0ea5e9', '#6366f1', '#38bdf8'],
+  },
+  purple: {
+    key: 'purple',
+    label: '暗紫星芒',
+    short: '紫',
+    tagline: '神秘星芒 · 极致创作',
+    mode: 'dark',
+    swatches: ['#a855f7', '#f43f5e', '#c084fc'],
+  },
+  pearl: {
+    key: 'pearl',
+    label: '珍珠晨光',
+    short: '珠',
+    tagline: '香槟金 · 浅色高级',
+    mode: 'light',
+    swatches: ['#c2914a', '#4f8fc0', '#e9cb83'],
+  },
+}
+
+export const THEME_ORDER: ThemeKey[] = ['gold', 'blue', 'purple', 'pearl']
+
+const STORAGE_KEY = 'studio_theme'
+const DEFAULT_THEME: ThemeKey = 'gold'
+
+function readInitial(): ThemeKey {
+  if (typeof window === 'undefined') return DEFAULT_THEME
+  const stored = window.localStorage.getItem(STORAGE_KEY) as ThemeKey | null
+  return stored && stored in THEMES ? stored : DEFAULT_THEME
+}
+
+// Shared singleton state (module-level ref → all components see the same value)
+const currentTheme = ref<ThemeKey>(readInitial())
+
+function applyToDocument(key: ThemeKey) {
+  if (typeof document === 'undefined') return
+  document.documentElement.setAttribute('data-theme', key)
+  document.documentElement.style.colorScheme = THEMES[key].mode
+}
+
+let transitionTimer: ReturnType<typeof setTimeout> | null = null
+
+function withCrossfade(key: ThemeKey) {
+  if (typeof document === 'undefined') {
+    applyToDocument(key)
+    return
+  }
+  const root = document.documentElement
+  root.classList.add('theme-transitioning')
+  applyToDocument(key)
+  if (transitionTimer) clearTimeout(transitionTimer)
+  transitionTimer = setTimeout(() => {
+    root.classList.remove('theme-transitioning')
+    transitionTimer = null
+  }, 500)
+}
+
+// Apply once at module load so theme is correct before first paint
+applyToDocument(currentTheme.value)
+
+export function useTheme() {
+  function setTheme(key: ThemeKey) {
+    if (!(key in THEMES) || currentTheme.value === key) return
+    currentTheme.value = key
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, key)
+    }
+    withCrossfade(key)
+  }
+
+  function cycleTheme() {
+    const idx = THEME_ORDER.indexOf(currentTheme.value)
+    setTheme(THEME_ORDER[(idx + 1) % THEME_ORDER.length])
+  }
+
+  const themeMeta = computed(() => THEMES[currentTheme.value])
+
+  return {
+    theme: readonly(currentTheme),
+    themeMeta,
+    themes: THEMES,
+    themeOrder: THEME_ORDER,
+    setTheme,
+    cycleTheme,
+  }
+}

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -13,8 +13,10 @@ export interface ThemeMeta {
   tagline: string
   /** Whether the theme is dark-on-light or light-on-dark */
   mode: 'dark' | 'light'
-  /** Three swatch colors for the preview chip (CSS color strings) */
+  /** Three solid swatch colors — used as fallback for tinted UI accents */
   swatches: [string, string, string]
+  /** Three CSS gradient strings — preview chips render with these for premium feel */
+  gradients: [string, string, string]
 }
 
 export const THEMES: Record<ThemeKey, ThemeMeta> = {
@@ -25,6 +27,11 @@ export const THEMES: Record<ThemeKey, ThemeMeta> = {
     tagline: '黑金科技 · 专业工作台',
     mode: 'dark',
     swatches: ['#f59e0b', '#fb923c', '#fbbf24'],
+    gradients: [
+      'linear-gradient(135deg, #8A5A14, #F0B23A)',
+      'linear-gradient(135deg, #FF8A3D, #FFCF5A)',
+      'linear-gradient(135deg, #D6B35A, #FFE7A3)',
+    ],
   },
   blue: {
     key: 'blue',
@@ -33,6 +40,11 @@ export const THEMES: Record<ThemeKey, ThemeMeta> = {
     tagline: '深空冷光 · 科技未来感',
     mode: 'dark',
     swatches: ['#0ea5e9', '#6366f1', '#38bdf8'],
+    gradients: [
+      'linear-gradient(135deg, #0EA5E9, #67E8F9)',
+      'linear-gradient(135deg, #6366F1, #A5B4FC)',
+      'linear-gradient(135deg, #22D3EE, #BAE6FD)',
+    ],
   },
   purple: {
     key: 'purple',
@@ -41,6 +53,11 @@ export const THEMES: Record<ThemeKey, ThemeMeta> = {
     tagline: '神秘星芒 · 极致创作',
     mode: 'dark',
     swatches: ['#a855f7', '#f43f5e', '#c084fc'],
+    gradients: [
+      'linear-gradient(135deg, #A855F7, #D8B4FE)',
+      'linear-gradient(135deg, #F43F5E, #FDA4AF)',
+      'linear-gradient(135deg, #C084FC, #F0ABFC)',
+    ],
   },
   pearl: {
     key: 'pearl',
@@ -49,6 +66,11 @@ export const THEMES: Record<ThemeKey, ThemeMeta> = {
     tagline: '香槟金 · 浅色高级',
     mode: 'light',
     swatches: ['#c2914a', '#4f8fc0', '#e9cb83'],
+    gradients: [
+      'linear-gradient(135deg, #D6B35A, #F7E3A1)',
+      'linear-gradient(135deg, #8EC5FF, #DDEBFF)',
+      'linear-gradient(135deg, #F3DF9D, #FFF7D6)',
+    ],
   },
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -182,8 +182,11 @@
                     0 3px 8px   rgba( 46,  42, 34, 0.035),
                     0 0 0 1px   rgba(214, 179, 90, 0.12);
   --shadow-glass:   0 26px 72px rgba( 46,  42, 34, 0.085),
-                    0 10px 26px rgba(142, 197,255, 0.075),
-                    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+                    0 10px 26px rgba(142, 197, 255, 0.075),
+                    0 1px 2px   rgba( 46,  42, 34, 0.04),
+                    0 0 0 1px   rgba(214, 179, 90, 0.10),
+                    inset 0 1px 0 rgba(255, 255, 255, 0.98),
+                    inset 0 0 0 1px rgba(255, 255, 255, 0.40);
 
   /* Input field — near-pure white, champagne gold edge */
   --input-bg:           rgba(255, 255, 255, 0.90);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -40,6 +40,19 @@
   --shadow-float:   0 24px 64px rgba(0,0,0,0.80), 0 0 0 1px rgba(251,191,36,0.06);
   --shadow-glass:   0 8px 32px rgba(0,0,0,0.55), inset 0 1px 0 rgba(251,191,36,0.06);
 
+  /* Page background — themeable via overrides */
+  --page-bg-color:  #09090b;
+  --page-bg-image:
+    radial-gradient(ellipse 65% 50% at 12% 6%,  rgba(245,158,11,0.28) 0%, transparent 52%),
+    radial-gradient(ellipse 60% 50% at 88% 94%, rgba(180,80,10,0.22) 0%, transparent 52%),
+    radial-gradient(ellipse 40% 30% at 55% 48%, rgba(239,68,68,0.07) 0%, transparent 55%);
+  --noise-opacity:  0.028;
+  --noise-blend:    overlay;
+  --scrollbar-color: rgba(245,158,11,0.30);
+  --scrollbar-hover: rgba(245,158,11,0.55);
+  --selection-bg:   rgba(245,158,11,0.28);
+  --selection-fg:   #fff;
+
   font-family: Inter, 'SF Pro Display', system-ui, sans-serif;
   font-size: 15px;
   line-height: 1.5;
@@ -86,21 +99,71 @@
   --shadow-glass:   0 8px 32px rgba(0,0,0,0.55), inset 0 1px 0 rgba(168,85,247,0.06);
 }
 
+/* ═══════════════════════════════════════════════
+   珍珠晨光 · Pearl Dawn — light theme
+═══════════════════════════════════════════════ */
+:root[data-theme="pearl"] {
+  color-scheme: light;
+
+  /* Accent — champagne gold + ice blue */
+  --arc-400:        #c2914a;   /* champagne gold */
+  --arc-300:        #b8843e;
+  --arc-200:        #8a6629;   /* darker for text on light bg */
+  --prism-400:      #4f8fc0;   /* ice blue */
+  --prism-500:      #3a7aae;
+
+  /* Text — deep on light */
+  --text-primary:   rgba(28,24,18,0.92);
+  --text-secondary: rgba(50,44,34,0.66);
+  --text-muted:     rgba(80,72,58,0.45);
+
+  /* Background tones */
+  --bg-void:        #f7f4ec;
+  --bg-deep:        #f0ebde;
+  --bg-surface:     #ece5d2;
+  --bg-elevated:    #e6dcc4;
+  --bg-float:       #ddd1b3;
+
+  /* Borders + glass */
+  --border-subtle:  rgba(194,145,74,0.10);
+  --border-glass:   rgba(194,145,74,0.18);
+  --border-arc:     rgba(194,145,74,0.45);
+  --glass-bg:       rgba(255,252,243,0.78);
+  --glass-bg-light: rgba(255,253,247,0.85);
+  --glass-border:   rgba(194,145,74,0.16);
+
+  /* Glow + shadow — lighter, softer */
+  --glow-arc:       0 0 20px rgba(194,145,74,0.30), 0 0 40px rgba(194,145,74,0.10);
+  --glow-prism:     0 0 20px rgba(79,143,192,0.25), 0 0 40px rgba(79,143,192,0.08);
+  --shadow-float:   0 16px 48px rgba(120,90,40,0.18), 0 0 0 1px rgba(194,145,74,0.10);
+  --shadow-glass:   0 6px 24px rgba(120,90,40,0.10), inset 0 1px 0 rgba(255,255,255,0.60);
+
+  /* Page background — soft pearl gradient */
+  --page-bg-color:  #f5f0e2;
+  --page-bg-image:
+    radial-gradient(ellipse 65% 50% at 12% 6%,  rgba(194,145,74,0.18) 0%, transparent 55%),
+    radial-gradient(ellipse 60% 50% at 88% 94%, rgba(79,143,192,0.14) 0%, transparent 55%),
+    radial-gradient(ellipse 40% 30% at 55% 48%, rgba(233,203,131,0.12) 0%, transparent 60%);
+  --noise-opacity:  0.020;
+  --noise-blend:    multiply;
+  --scrollbar-color: rgba(194,145,74,0.35);
+  --scrollbar-hover: rgba(194,145,74,0.60);
+  --selection-bg:   rgba(194,145,74,0.25);
+  --selection-fg:   #1c1812;
+}
+
 /* ─── Base reset ──────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; }
 
 body {
   margin: 0;
-  background-color: #09090b;
-  /* Warm gold gradient pools — fixed so they stay anchored while scrolling */
-  background-image:
-    radial-gradient(ellipse 65% 50% at 12% 6%,  rgba(245,158,11,0.28) 0%, transparent 52%),
-    radial-gradient(ellipse 60% 50% at 88% 94%,  rgba(180,80,10,0.22) 0%, transparent 52%),
-    radial-gradient(ellipse 40% 30% at 55% 48%,  rgba(239,68,68,0.07) 0%, transparent 55%);
+  background-color: var(--page-bg-color);
+  background-image: var(--page-bg-image);
   background-attachment: fixed;
   color: var(--text-primary);
   min-height: 100vh;
   overflow-x: hidden;
+  transition: background-color 0.3s ease;
 }
 
 /* Noise grain — adds premium texture depth */
@@ -111,18 +174,18 @@ body::before {
   z-index: 9998;
   pointer-events: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
-  opacity: 0.028;
-  mix-blend-mode: overlay;
+  opacity: var(--noise-opacity);
+  mix-blend-mode: var(--noise-blend);
 }
 
 /* Scrollbar */
 ::-webkit-scrollbar              { width: 4px; height: 4px; }
 ::-webkit-scrollbar-track        { background: transparent; }
-::-webkit-scrollbar-thumb        { background: rgba(245,158,11,0.30); border-radius: 2px; }
-::-webkit-scrollbar-thumb:hover  { background: rgba(245,158,11,0.55); }
+::-webkit-scrollbar-thumb        { background: var(--scrollbar-color); border-radius: 2px; }
+::-webkit-scrollbar-thumb:hover  { background: var(--scrollbar-hover); }
 
 /* Selection */
-::selection { background: rgba(245,158,11,0.28); color: #fff; }
+::selection { background: var(--selection-bg); color: var(--selection-fg); }
 
 /* ─── Utility component classes ───────────────────────────────── */
 @layer components {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -40,6 +40,33 @@
   --shadow-float:   0 24px 64px rgba(0,0,0,0.80), 0 0 0 1px rgba(251,191,36,0.06);
   --shadow-glass:   0 8px 32px rgba(0,0,0,0.55), inset 0 1px 0 rgba(251,191,36,0.06);
 
+  /* Input field tokens (dark themes default) */
+  --input-bg:           rgba(4, 8, 22, 0.55);
+  --input-border:       rgba(255, 255, 255, 0.08);
+  --input-focus-border: rgba(245, 158, 11, 0.50);
+  --input-focus-shadow: 0 0 0 3px rgba(245, 158, 11, 0.10);
+  --input-placeholder:  rgba(255, 255, 255, 0.35);
+
+  /* Nested surface overlay (sub-panels, option cards, inset boxes)
+     Dark themes use a subtle black fill; light theme replaces with a
+     warm pearl tint so it doesn't look grey on white. */
+  --surface-overlay-strong: rgba(0,0,0,0.25);
+  --surface-overlay-mid:    rgba(0,0,0,0.18);
+  --surface-overlay-soft:   rgba(0,0,0,0.12);
+
+  /* Chip button (template selectors etc) */
+  --chip-hover-bg:    rgba(245,158,11,0.09);
+  --chip-active-bg:   rgba(245,158,11,0.15);
+  --chip-active-shadow: 0 0 8px rgba(245,158,11,0.20);
+
+  /* Primary CTA button (开始创作 etc) */
+  --cta-bg:           linear-gradient(135deg, #f59e0b 0%, #fb923c 100%);
+  --cta-fg:           #fff;
+  --cta-border:       rgba(245,158,11,0.50);
+  --cta-shadow:       0 6px 22px rgba(245,158,11,0.45), inset 0 1px 0 rgba(255,255,255,0.20);
+  --cta-shadow-hover: 0 8px 28px rgba(245,158,11,0.60), inset 0 1px 0 rgba(255,255,255,0.25);
+
+
   /* Page background — themeable via overrides */
   --page-bg-color:  #09090b;
   --page-bg-image:
@@ -101,71 +128,112 @@
 
 /* ═══════════════════════════════════════════════
    珍珠晨光 · Pearl Dawn — light theme
-   Soft warm cream → cool pearl gradient with champagne gold accents.
+   Pearl white pages, champagne gold accents, ice blue highlights.
 ═══════════════════════════════════════════════ */
 :root[data-theme="pearl"] {
   color-scheme: light;
 
-  /* Accent — champagne gold + ice blue, slightly cooler than V1 */
+  /* Accent — champagne gold + ice blue */
   --arc-400:        #c89a55;   /* champagne gold — main */
-  --arc-300:        #b18638;
-  --arc-200:        #8b6722;   /* darker for badge text on light bg */
+  --arc-300:        #a87f3a;   /* darker so text/icon reads on white */
+  --arc-200:        #8b6722;   /* deepest for badge text */
   --prism-400:      #5b9cce;   /* ice blue accent */
   --prism-500:      #3f80b6;
 
-  /* Text — deep grey on light, target #333~#444 */
-  --text-primary:   rgba(34, 38, 46, 0.94);   /* ~#22262e */
-  --text-secondary: rgba(60, 66, 76, 0.70);   /* ~#3c424c */
-  --text-muted:     rgba(96, 104, 115, 0.55); /* ~#606873 */
+  /* Text — exact targets from spec */
+  --text-primary:   #2E2A22;
+  --text-secondary: #6F6A5F;
+  --text-muted:     #9E978A;
 
-  /* Background tones — bright whites with the faintest cream */
+  /* Background tones */
   --bg-void:        #ffffff;
-  --bg-deep:        #fbfaf6;
-  --bg-surface:     #f6f3eb;
+  --bg-deep:        #fdfcf7;
+  --bg-surface:     #f7f4ec;
   --bg-elevated:    #efece1;
   --bg-float:       #e7e3d4;
 
-  /* Borders + glass — bright white glass with champagne gold edges */
+  /* Borders + glass — translucent white so the flowing light glows through */
   --border-subtle:  rgba(200, 154, 85, 0.10);
   --border-glass:   rgba(200, 154, 85, 0.18);
   --border-arc:     rgba(200, 154, 85, 0.48);
-  --glass-bg:       rgba(255, 255, 255, 0.82);
-  --glass-bg-light: rgba(255, 255, 255, 0.90);
+  --glass-bg:       rgba(255, 253, 247, 0.62);   /* was 0.82 — let aurora bleed through */
+  --glass-bg-light: rgba(255, 254, 250, 0.74);
   --glass-border:   rgba(200, 154, 85, 0.18);
 
-  /* Glow + shadow — soft lift, no heavy black */
-  --glow-arc:       0 0 22px rgba(200, 154, 85, 0.32),
-                    0 0 44px rgba(200, 154, 85, 0.12);
-  --glow-prism:     0 0 22px rgba( 91, 156, 206, 0.28),
-                    0 0 44px rgba( 91, 156, 206, 0.10);
-  --shadow-float:   0 18px 48px rgba(100, 90, 60, 0.16),
-                    0 4px 12px  rgba(100, 90, 60, 0.08),
-                    0 0 0 1px   rgba(200, 154, 85, 0.10);
-  --shadow-glass:   0 8px 26px  rgba(100, 90, 60, 0.10),
-                    0 2px 6px   rgba(100, 90, 60, 0.04),
-                    inset 0 1px 0 rgba(255, 255, 255, 0.80);
+  /* Glow + shadow — layered warm lift, with crisp inner highlight */
+  --glow-arc:       0 0 24px rgba(200, 154, 85, 0.40),
+                    0 0 48px rgba(200, 154, 85, 0.16),
+                    0 0 80px rgba(255, 220, 150, 0.08);
+  --glow-prism:     0 0 24px rgba( 91, 156, 206, 0.34),
+                    0 0 48px rgba( 91, 156, 206, 0.14);
+  --shadow-float:   0 24px 56px rgba(120, 90, 50, 0.18),
+                    0 8px 20px  rgba(120, 90, 50, 0.10),
+                    0 2px 4px   rgba(120, 90, 50, 0.06),
+                    0 0 0 1px   rgba(200, 154, 85, 0.14);
+  --shadow-glass:   0 12px 32px rgba(120, 90, 50, 0.12),
+                    0 4px 10px  rgba(120, 90, 50, 0.06),
+                    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+                    inset 0 -1px 1px rgba(180, 140, 70, 0.06);
 
-  /* Page background — soft warm cream → cool pearl diagonal */
-  --page-bg-color:  #fafaf3;
+  /* Input field tokens — white inputs, champagne gold edges */
+  --input-bg:           rgba(255, 255, 255, 0.82);
+  --input-border:       rgba(200, 154, 85, 0.30);
+  --input-focus-border: rgba(200, 154, 85, 0.70);
+  --input-focus-shadow: 0 0 0 3px rgba(200, 154, 85, 0.14);
+  --input-placeholder:  rgba(158, 151, 138, 0.85);
+
+  /* Nested surface overlays — warm pearl on white, NEVER grey */
+  --surface-overlay-strong: rgba(255, 250, 235, 0.85);
+  --surface-overlay-mid:    rgba(255, 252, 244, 0.70);
+  --surface-overlay-soft:   rgba(255, 254, 248, 0.55);
+
+  /* Chip button — pearl-tinted, refined */
+  --chip-hover-bg:      linear-gradient(135deg, rgba(255,243,212,0.85) 0%, rgba(255,237,196,0.65) 100%);
+  --chip-active-bg:     linear-gradient(135deg, rgba(255,232,178,0.90) 0%, rgba(255,219,150,0.75) 100%);
+  --chip-active-shadow: 0 2px 12px rgba(214,179,90,0.22), inset 0 1px 0 rgba(255,255,255,0.70);
+
+  /* Primary CTA — refined champagne gold, no harsh blue jump */
+  --cta-bg:           linear-gradient(135deg, #d8a861 0%, #c89a55 60%, #b8843e 100%);
+  --cta-fg:           #fff;
+  --cta-border:       rgba(184, 132, 62, 0.42);
+  --cta-shadow:       0 6px 22px rgba(184, 132, 62, 0.35), inset 0 1px 0 rgba(255, 248, 230, 0.60);
+  --cta-shadow-hover: 0 8px 28px rgba(184, 132, 62, 0.48), inset 0 1px 0 rgba(255, 248, 230, 0.75);
+
+
+  /* Page background — multi-layer warm dawn light with cool blue cast */
+  --page-bg-color:  #fdfcf7;
   --page-bg-image:
-    /* Top-left: warm cream/champagne breath */
-    radial-gradient(ellipse 70% 55% at 10% 8%,
-                    rgba(255, 226, 168, 0.55) 0%,
-                    rgba(255, 226, 168, 0.22) 30%,
-                    transparent 70%),
-    /* Bottom-right: cool ice-blue tint */
-    radial-gradient(ellipse 65% 55% at 92% 96%,
-                    rgba(180, 210, 235, 0.40) 0%,
-                    rgba(180, 210, 235, 0.16) 35%,
+    /* Top-left: bright golden sunrise halo */
+    radial-gradient(ellipse 78% 60% at 8% 6%,
+                    rgba(255, 218, 145, 0.78) 0%,
+                    rgba(255, 226, 168, 0.32) 28%,
+                    rgba(255, 235, 195, 0.10) 56%,
+                    transparent 78%),
+    /* Top-right: subtle ice-blue contrast */
+    radial-gradient(ellipse 50% 40% at 95% 14%,
+                    rgba(160, 200, 230, 0.30) 0%,
+                    rgba(180, 215, 235, 0.10) 36%,
+                    transparent 74%),
+    /* Bottom-right: cool pearl-blue mist */
+    radial-gradient(ellipse 75% 60% at 94% 96%,
+                    rgba(140, 185, 220, 0.45) 0%,
+                    rgba(170, 205, 230, 0.20) 32%,
+                    rgba(200, 220, 235, 0.06) 60%,
+                    transparent 80%),
+    /* Bottom-left: rosy cream undertone */
+    radial-gradient(ellipse 50% 40% at 8% 92%,
+                    rgba(255, 220, 195, 0.28) 0%,
+                    rgba(255, 230, 210, 0.10) 38%,
                     transparent 72%),
-    /* Centre: very subtle gold sun */
-    radial-gradient(ellipse 45% 32% at 58% 42%,
-                    rgba(255, 233, 175, 0.22) 0%,
-                    transparent 65%);
-  --noise-opacity:  0.014;
+    /* Centre: warm gold sun halo */
+    radial-gradient(ellipse 42% 30% at 56% 44%,
+                    rgba(255, 235, 175, 0.30) 0%,
+                    rgba(255, 240, 195, 0.10) 38%,
+                    transparent 70%);
+  --noise-opacity:  0.006;
   --noise-blend:    multiply;
-  --scrollbar-color: rgba(200, 154, 85, 0.40);
-  --scrollbar-hover: rgba(200, 154, 85, 0.65);
+  --scrollbar-color: rgba(200, 154, 85, 0.42);
+  --scrollbar-hover: rgba(200, 154, 85, 0.68);
   --selection-bg:   rgba(200, 154, 85, 0.28);
   --selection-fg:   #1c1812;
 }
@@ -223,6 +291,82 @@ body::before {
 
 /* Selection */
 ::selection { background: var(--selection-bg); color: var(--selection-fg); }
+
+/* ─── Custom form controls — Pearl Dawn ONLY ─────────────────────
+   Dark themes (gold/blue/purple) keep native browser controls with
+   accent-color tinted per theme — unchanged.
+─────────────────────────────────────────────────────────────────── */
+:root[data-theme="pearl"] input[type="radio"],
+:root[data-theme="pearl"] input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  flex-shrink: 0;
+  background: rgba(255,255,255,0.85);
+  border: 1.5px solid rgba(184, 132, 62, 0.40);
+  cursor: pointer;
+  position: relative;
+  transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+}
+
+:root[data-theme="pearl"] input[type="radio"]    { border-radius: 50%; }
+:root[data-theme="pearl"] input[type="checkbox"] { border-radius: 4px;  }
+
+:root[data-theme="pearl"] input[type="radio"]:hover,
+:root[data-theme="pearl"] input[type="checkbox"]:hover {
+  border-color: rgba(184, 132, 62, 0.65);
+}
+
+:root[data-theme="pearl"] input[type="radio"]:focus-visible,
+:root[data-theme="pearl"] input[type="checkbox"]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(184, 132, 62, 0.20);
+}
+
+/* ── Radio checked: golden dot with glow ── */
+:root[data-theme="pearl"] input[type="radio"]:checked {
+  border-color: #b8843e;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(184, 132, 62, 0.25);
+}
+:root[data-theme="pearl"] input[type="radio"]:checked::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #d8a861, #b8843e);
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 6px rgba(184, 132, 62, 0.55), inset 0 1px 0 rgba(255,248,230,0.50);
+}
+
+/* ── Checkbox checked: gold fill + white check ── */
+:root[data-theme="pearl"] input[type="checkbox"]:checked {
+  border-color: #b8843e;
+  background: linear-gradient(135deg, #d8a861, #b8843e);
+  box-shadow: 0 2px 8px rgba(184, 132, 62, 0.30), inset 0 1px 0 rgba(255,248,230,0.55);
+}
+:root[data-theme="pearl"] input[type="checkbox"]:checked::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 9px;
+  height: 5px;
+  border-left: 1.8px solid #fff;
+  border-bottom: 1.8px solid #fff;
+  transform: translate(-50%, -65%) rotate(-45deg);
+}
+
+:root[data-theme="pearl"] input[type="radio"]:disabled,
+:root[data-theme="pearl"] input[type="checkbox"]:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 
 /* ─── Utility component classes ───────────────────────────────── */
 @layer components {
@@ -295,21 +439,21 @@ body::before {
 
   /* Studio input */
   .studio-input {
-    background: rgba(4,8,22,0.55);
+    background: var(--input-bg);
     backdrop-filter: blur(8px);
-    border: 1px solid rgba(255,255,255,0.08);
+    border: 1px solid var(--input-border);
     border-radius: 0.625rem;
     color: var(--text-primary);
     padding: 0.625rem 0.875rem;
     width: 100%;
-    transition: border-color 0.2s, box-shadow 0.2s;
+    transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
     font-size: 0.875rem;
     outline: none;
   }
-  .studio-input::placeholder { color: var(--text-muted); }
+  .studio-input::placeholder { color: var(--input-placeholder); }
   .studio-input:focus {
-    border-color: rgba(245,158,11,0.50);
-    box-shadow: 0 0 0 3px rgba(245,158,11,0.10);
+    border-color: var(--input-focus-border);
+    box-shadow: var(--input-focus-shadow);
   }
 
   /* Studio button — primary */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -101,54 +101,72 @@
 
 /* ═══════════════════════════════════════════════
    珍珠晨光 · Pearl Dawn — light theme
+   Soft warm cream → cool pearl gradient with champagne gold accents.
 ═══════════════════════════════════════════════ */
 :root[data-theme="pearl"] {
   color-scheme: light;
 
-  /* Accent — champagne gold + ice blue */
-  --arc-400:        #c2914a;   /* champagne gold */
-  --arc-300:        #b8843e;
-  --arc-200:        #8a6629;   /* darker for text on light bg */
-  --prism-400:      #4f8fc0;   /* ice blue */
-  --prism-500:      #3a7aae;
+  /* Accent — champagne gold + ice blue, slightly cooler than V1 */
+  --arc-400:        #c89a55;   /* champagne gold — main */
+  --arc-300:        #b18638;
+  --arc-200:        #8b6722;   /* darker for badge text on light bg */
+  --prism-400:      #5b9cce;   /* ice blue accent */
+  --prism-500:      #3f80b6;
 
-  /* Text — deep on light */
-  --text-primary:   rgba(28,24,18,0.92);
-  --text-secondary: rgba(50,44,34,0.66);
-  --text-muted:     rgba(80,72,58,0.45);
+  /* Text — deep grey on light, target #333~#444 */
+  --text-primary:   rgba(34, 38, 46, 0.94);   /* ~#22262e */
+  --text-secondary: rgba(60, 66, 76, 0.70);   /* ~#3c424c */
+  --text-muted:     rgba(96, 104, 115, 0.55); /* ~#606873 */
 
-  /* Background tones */
-  --bg-void:        #f7f4ec;
-  --bg-deep:        #f0ebde;
-  --bg-surface:     #ece5d2;
-  --bg-elevated:    #e6dcc4;
-  --bg-float:       #ddd1b3;
+  /* Background tones — bright whites with the faintest cream */
+  --bg-void:        #ffffff;
+  --bg-deep:        #fbfaf6;
+  --bg-surface:     #f6f3eb;
+  --bg-elevated:    #efece1;
+  --bg-float:       #e7e3d4;
 
-  /* Borders + glass */
-  --border-subtle:  rgba(194,145,74,0.10);
-  --border-glass:   rgba(194,145,74,0.18);
-  --border-arc:     rgba(194,145,74,0.45);
-  --glass-bg:       rgba(255,252,243,0.78);
-  --glass-bg-light: rgba(255,253,247,0.85);
-  --glass-border:   rgba(194,145,74,0.16);
+  /* Borders + glass — bright white glass with champagne gold edges */
+  --border-subtle:  rgba(200, 154, 85, 0.10);
+  --border-glass:   rgba(200, 154, 85, 0.18);
+  --border-arc:     rgba(200, 154, 85, 0.48);
+  --glass-bg:       rgba(255, 255, 255, 0.82);
+  --glass-bg-light: rgba(255, 255, 255, 0.90);
+  --glass-border:   rgba(200, 154, 85, 0.18);
 
-  /* Glow + shadow — lighter, softer */
-  --glow-arc:       0 0 20px rgba(194,145,74,0.30), 0 0 40px rgba(194,145,74,0.10);
-  --glow-prism:     0 0 20px rgba(79,143,192,0.25), 0 0 40px rgba(79,143,192,0.08);
-  --shadow-float:   0 16px 48px rgba(120,90,40,0.18), 0 0 0 1px rgba(194,145,74,0.10);
-  --shadow-glass:   0 6px 24px rgba(120,90,40,0.10), inset 0 1px 0 rgba(255,255,255,0.60);
+  /* Glow + shadow — soft lift, no heavy black */
+  --glow-arc:       0 0 22px rgba(200, 154, 85, 0.32),
+                    0 0 44px rgba(200, 154, 85, 0.12);
+  --glow-prism:     0 0 22px rgba( 91, 156, 206, 0.28),
+                    0 0 44px rgba( 91, 156, 206, 0.10);
+  --shadow-float:   0 18px 48px rgba(100, 90, 60, 0.16),
+                    0 4px 12px  rgba(100, 90, 60, 0.08),
+                    0 0 0 1px   rgba(200, 154, 85, 0.10);
+  --shadow-glass:   0 8px 26px  rgba(100, 90, 60, 0.10),
+                    0 2px 6px   rgba(100, 90, 60, 0.04),
+                    inset 0 1px 0 rgba(255, 255, 255, 0.80);
 
-  /* Page background — soft pearl gradient */
-  --page-bg-color:  #f5f0e2;
+  /* Page background — soft warm cream → cool pearl diagonal */
+  --page-bg-color:  #fafaf3;
   --page-bg-image:
-    radial-gradient(ellipse 65% 50% at 12% 6%,  rgba(194,145,74,0.18) 0%, transparent 55%),
-    radial-gradient(ellipse 60% 50% at 88% 94%, rgba(79,143,192,0.14) 0%, transparent 55%),
-    radial-gradient(ellipse 40% 30% at 55% 48%, rgba(233,203,131,0.12) 0%, transparent 60%);
-  --noise-opacity:  0.020;
+    /* Top-left: warm cream/champagne breath */
+    radial-gradient(ellipse 70% 55% at 10% 8%,
+                    rgba(255, 226, 168, 0.55) 0%,
+                    rgba(255, 226, 168, 0.22) 30%,
+                    transparent 70%),
+    /* Bottom-right: cool ice-blue tint */
+    radial-gradient(ellipse 65% 55% at 92% 96%,
+                    rgba(180, 210, 235, 0.40) 0%,
+                    rgba(180, 210, 235, 0.16) 35%,
+                    transparent 72%),
+    /* Centre: very subtle gold sun */
+    radial-gradient(ellipse 45% 32% at 58% 42%,
+                    rgba(255, 233, 175, 0.22) 0%,
+                    transparent 65%);
+  --noise-opacity:  0.014;
   --noise-blend:    multiply;
-  --scrollbar-color: rgba(194,145,74,0.35);
-  --scrollbar-hover: rgba(194,145,74,0.60);
-  --selection-bg:   rgba(194,145,74,0.25);
+  --scrollbar-color: rgba(200, 154, 85, 0.40);
+  --scrollbar-hover: rgba(200, 154, 85, 0.65);
+  --selection-bg:   rgba(200, 154, 85, 0.28);
   --selection-fg:   #1c1812;
 }
 
@@ -163,7 +181,26 @@ body {
   color: var(--text-primary);
   min-height: 100vh;
   overflow-x: hidden;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.35s ease, color 0.35s ease;
+}
+
+/* ─── Theme transitions ─────────────────────────────
+   Apply a brief crossfade when the theme changes so colors
+   morph smoothly instead of snapping. Use a class added to
+   :root for ~600ms when the user picks a new theme.
+─────────────────────────────────────────────────────── */
+:root.theme-transitioning,
+:root.theme-transitioning *,
+:root.theme-transitioning *::before,
+:root.theme-transitioning *::after {
+  transition:
+    background-color 0.40s ease,
+    background-image 0.40s ease,
+    border-color     0.40s ease,
+    box-shadow       0.40s ease,
+    color            0.40s ease,
+    fill             0.40s ease,
+    stroke           0.40s ease !important;
 }
 
 /* Noise grain — adds premium texture depth */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -127,70 +127,81 @@
 }
 
 /* ═══════════════════════════════════════════════
-   珍珠晨光 · Pearl Dawn — light theme
-   Pearl white pages, champagne gold accents, ice blue highlights.
+   珍珠晨光 · Pearl Dawn — light theme V4
+   Color ratio target:
+     · Pearl/ice white  70%
+     · Champagne gold   15%
+     · Cool blue tint   10%
+     · Warm yellow      ≤5%
+   Earlier versions were too yellow ("土色"). This iteration uses
+   cool pearl whites as base with gold only as accent.
 ═══════════════════════════════════════════════ */
 :root[data-theme="pearl"] {
   color-scheme: light;
 
   /* Accent — champagne gold + ice blue */
   --arc-400:        #c89a55;   /* champagne gold — main */
-  --arc-300:        #a87f3a;   /* darker so text/icon reads on white */
-  --arc-200:        #8b6722;   /* deepest for badge text */
-  --prism-400:      #5b9cce;   /* ice blue accent */
+  --arc-300:        #a87f3a;
+  --arc-200:        #8b6722;
+  --prism-400:      #5b9cce;   /* ice blue */
   --prism-500:      #3f80b6;
 
-  /* Text — exact targets from spec */
+  /* Text */
   --text-primary:   #2E2A22;
   --text-secondary: #6F6A5F;
   --text-muted:     #9E978A;
 
-  /* Background tones */
-  --bg-void:        #ffffff;
-  --bg-deep:        #fdfcf7;
-  --bg-surface:     #f7f4ec;
-  --bg-elevated:    #efece1;
-  --bg-float:       #e7e3d4;
+  /* Cool pearl whites — no yellow undertone */
+  --bg-void:        #FFFFFF;
+  --bg-deep:        #F8F7F2;
+  --bg-surface:     #F3F4F6;
+  --bg-elevated:    #EDEFF2;
+  --bg-float:       #E5E8ED;
 
-  /* Borders + glass — translucent white so the flowing light glows through */
-  --border-subtle:  rgba(200, 154, 85, 0.10);
-  --border-glass:   rgba(200, 154, 85, 0.18);
-  --border-arc:     rgba(200, 154, 85, 0.48);
-  --glass-bg:       rgba(255, 253, 247, 0.62);   /* was 0.82 — let aurora bleed through */
-  --glass-bg-light: rgba(255, 254, 250, 0.74);
-  --glass-border:   rgba(200, 154, 85, 0.18);
+  /* Borders + glass — cleaner, less yellow */
+  --border-subtle:  rgba(214, 179, 90, 0.10);
+  --border-glass:   rgba(214, 179, 90, 0.22);
+  --border-arc:     rgba(214, 179, 90, 0.48);
+  --glass-bg:       rgba(255, 255, 255, 0.78);
+  --glass-bg-light: rgba(255, 255, 255, 0.88);
+  --glass-border:   rgba(214, 179, 90, 0.22);
+  --pearl-glass-bg: linear-gradient(
+                      145deg,
+                      rgba(255, 255, 255, 0.88) 0%,
+                      rgba(255, 255, 255, 0.66) 100%
+                    );
+  --pearl-glass-edge: rgba(214, 179, 90, 0.20);
 
-  /* Glow + shadow — layered warm lift, with crisp inner highlight */
-  --glow-arc:       0 0 24px rgba(200, 154, 85, 0.40),
-                    0 0 48px rgba(200, 154, 85, 0.16),
-                    0 0 80px rgba(255, 220, 150, 0.08);
-  --glow-prism:     0 0 24px rgba( 91, 156, 206, 0.34),
-                    0 0 48px rgba( 91, 156, 206, 0.14);
-  --shadow-float:   0 24px 56px rgba(120, 90, 50, 0.18),
-                    0 8px 20px  rgba(120, 90, 50, 0.10),
-                    0 2px 4px   rgba(120, 90, 50, 0.06),
-                    0 0 0 1px   rgba(200, 154, 85, 0.14);
-  --shadow-glass:   0 12px 32px rgba(120, 90, 50, 0.12),
-                    0 4px 10px  rgba(120, 90, 50, 0.06),
-                    inset 0 1px 0 rgba(255, 255, 255, 0.95),
-                    inset 0 -1px 1px rgba(180, 140, 70, 0.06);
+  /* Shadow — neutral cool grey-warm hybrid, not heavy yellow */
+  --glow-arc:       0 0 22px rgba(214, 179, 90, 0.32),
+                    0 0 48px rgba(214, 179, 90, 0.12);
+  --glow-prism:     0 0 22px rgba( 91, 156, 206, 0.30),
+                    0 0 44px rgba( 91, 156, 206, 0.12);
+  --shadow-float:   0 28px 72px rgba( 46,  42, 34, 0.09),
+                    0 10px 26px rgba(142, 197,255, 0.08),
+                    0 3px 8px   rgba( 46,  42, 34, 0.035),
+                    0 0 0 1px   rgba(214, 179, 90, 0.12);
+  --shadow-glass:   0 26px 72px rgba( 46,  42, 34, 0.085),
+                    0 10px 26px rgba(142, 197,255, 0.075),
+                    inset 0 1px 0 rgba(255, 255, 255, 0.92);
 
-  /* Input field tokens — white inputs, champagne gold edges */
-  --input-bg:           rgba(255, 255, 255, 0.82);
-  --input-border:       rgba(200, 154, 85, 0.30);
-  --input-focus-border: rgba(200, 154, 85, 0.70);
-  --input-focus-shadow: 0 0 0 3px rgba(200, 154, 85, 0.14);
-  --input-placeholder:  rgba(158, 151, 138, 0.85);
+  /* Input field — near-pure white, champagne gold edge */
+  --input-bg:           rgba(255, 255, 255, 0.90);
+  --input-border:       rgba(214, 179, 90, 0.22);
+  --input-focus-border: rgba(214, 179, 90, 0.52);
+  --input-focus-shadow: 0 0 0 3px rgba(214, 179, 90, 0.10),
+                        0 0 18px rgba(142, 197, 255, 0.12);
+  --input-placeholder:  rgba(158, 151, 138, 0.75);
 
-  /* Nested surface overlays — warm pearl on white, NEVER grey */
-  --surface-overlay-strong: rgba(255, 250, 235, 0.85);
-  --surface-overlay-mid:    rgba(255, 252, 244, 0.70);
-  --surface-overlay-soft:   rgba(255, 254, 248, 0.55);
+  /* Nested surface overlays — cool pearl, not yellow */
+  --surface-overlay-strong: rgba(255, 255, 255, 0.85);
+  --surface-overlay-mid:    rgba(252, 252, 250, 0.72);
+  --surface-overlay-soft:   rgba(250, 251, 253, 0.58);
 
-  /* Chip button — pearl-tinted, refined */
-  --chip-hover-bg:      linear-gradient(135deg, rgba(255,243,212,0.85) 0%, rgba(255,237,196,0.65) 100%);
-  --chip-active-bg:     linear-gradient(135deg, rgba(255,232,178,0.90) 0%, rgba(255,219,150,0.75) 100%);
-  --chip-active-shadow: 0 2px 12px rgba(214,179,90,0.22), inset 0 1px 0 rgba(255,255,255,0.70);
+  /* Chip button — clean white hover, restrained gold for active state */
+  --chip-hover-bg:      rgba(255, 255, 255, 0.85);
+  --chip-active-bg:     linear-gradient(135deg, rgba(248, 232, 198, 0.90) 0%, rgba(240, 218, 170, 0.75) 100%);
+  --chip-active-shadow: 0 2px 12px rgba(214, 179, 90, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.70);
 
   /* Primary CTA — refined champagne gold, no harsh blue jump */
   --cta-bg:           linear-gradient(135deg, #d8a861 0%, #c89a55 60%, #b8843e 100%);
@@ -200,42 +211,64 @@
   --cta-shadow-hover: 0 8px 28px rgba(184, 132, 62, 0.48), inset 0 1px 0 rgba(255, 248, 230, 0.75);
 
 
-  /* Page background — multi-layer warm dawn light with cool blue cast */
-  --page-bg-color:  #fdfcf7;
+  /* Page background — clean pearl white + ice mist, gold only as small accent */
+  --page-bg-color:  #fffdf7;
   --page-bg-image:
-    /* Top-left: bright golden sunrise halo */
-    radial-gradient(ellipse 78% 60% at 8% 6%,
-                    rgba(255, 218, 145, 0.78) 0%,
-                    rgba(255, 226, 168, 0.32) 28%,
-                    rgba(255, 235, 195, 0.10) 56%,
-                    transparent 78%),
-    /* Top-right: subtle ice-blue contrast */
-    radial-gradient(ellipse 50% 40% at 95% 14%,
-                    rgba(160, 200, 230, 0.30) 0%,
-                    rgba(180, 215, 235, 0.10) 36%,
-                    transparent 74%),
-    /* Bottom-right: cool pearl-blue mist */
-    radial-gradient(ellipse 75% 60% at 94% 96%,
-                    rgba(140, 185, 220, 0.45) 0%,
-                    rgba(170, 205, 230, 0.20) 32%,
-                    rgba(200, 220, 235, 0.06) 60%,
-                    transparent 80%),
-    /* Bottom-left: rosy cream undertone */
-    radial-gradient(ellipse 50% 40% at 8% 92%,
-                    rgba(255, 220, 195, 0.28) 0%,
-                    rgba(255, 230, 210, 0.10) 38%,
-                    transparent 72%),
-    /* Centre: warm gold sun halo */
-    radial-gradient(ellipse 42% 30% at 56% 44%,
-                    rgba(255, 235, 175, 0.30) 0%,
-                    rgba(255, 240, 195, 0.10) 38%,
-                    transparent 70%);
+    radial-gradient(circle at 18% 8%,
+                    rgba(246, 222, 166, 0.22) 0%,
+                    transparent 30%),
+    radial-gradient(circle at 82% 78%,
+                    rgba(210, 232, 255, 0.34) 0%,
+                    transparent 38%),
+    radial-gradient(ellipse 58% 44% at 90% 14%,
+                    rgba(190, 215, 235, 0.28) 0%,
+                    transparent 68%),
+    linear-gradient(135deg, #fffdf7 0%, #f7f8fb 46%, #eef6f9 100%);
   --noise-opacity:  0.006;
   --noise-blend:    multiply;
   --scrollbar-color: rgba(200, 154, 85, 0.42);
   --scrollbar-hover: rgba(200, 154, 85, 0.68);
   --selection-bg:   rgba(200, 154, 85, 0.28);
   --selection-fg:   #1c1812;
+}
+
+:root[data-theme="pearl"] .progress-track {
+  height: 1px;
+  background: rgba(135, 155, 175, 0.055);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.64);
+}
+
+:root[data-theme="pearl"] .progress-fill {
+  background: linear-gradient(
+    90deg,
+    rgba(218, 188, 124, 0.30) 0%,
+    rgba(188, 215, 232, 0.38) 100%
+  );
+  box-shadow: 0 0 4px rgba(188, 215, 232, 0.08);
+}
+
+:root[data-theme="pearl"] .glass-card {
+  background: var(--pearl-glass-bg);
+  backdrop-filter: blur(22px) saturate(1.12);
+  -webkit-backdrop-filter: blur(22px) saturate(1.12);
+  border-color: var(--pearl-glass-edge);
+  box-shadow:
+    var(--shadow-glass),
+    inset 0 1px 0 rgba(255, 255, 255, 0.88);
+}
+
+:root[data-theme="pearl"] .studio-input {
+  background: var(--input-bg);
+  border-color: var(--input-border);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.90),
+    0 4px 12px rgba(46,42,34,0.035);
+}
+
+:root[data-theme="pearl"] .studio-input:focus {
+  background: rgba(255,255,255,0.94);
+  border-color: var(--input-focus-border);
+  box-shadow: var(--input-focus-shadow);
 }
 
 /* ─── Base reset ──────────────────────────────────────────────── */


### PR DESCRIPTION
# Summary
Added **Pearl Dawn** light theme as the 4th selectable theme. The original single-cycle theme button has been upgraded to a floating pop-up selector in the bottom-right corner. Existing dark themes (Gilded Dusk, Midnight Blue, Violet Starlight) remain unchanged.

## Key Changes
### 1. New ThemeSwitcher Component
- Fixed trigger at the bottom-right corner (3-color dots + single-character label), position independent of page layout.
- Click to expand a 248px floating panel that opens upward with an arrow pointing to the trigger.
- Each theme entry includes color preview swatch, theme name, subtitle and checkmark for active state.
- Collapses via the custom `v-click-outside` directive with smooth fade transition.
- Removed the old cycle button at the bottom of the sidebar.

### 2. New useTheme Composable
- Implemented as a global singleton with module-level refs, shared across all components.
- Exposed properties and methods: `theme`, `themes`, `setTheme`, `cycleTheme`, `themeMeta`.
- Automatically applies the selected theme on module load for correct initial display.
- Persists theme preference in `localStorage` under the key `studio_theme`.
- Adds the `.theme-transitioning` class during theme switch to enable a 500ms crossfade color transition.

### 3. Pearl Dawn Theme
- **Color palette**: 70% Pearl White, 15% Champagne Gold, 10% Ice Blue, ≤5% Warm Yellow.
- Background: 5-layer radial gradient consisting of warm gold halo, frosted white, blue-purple pearlescent tone, rose cream and central sun glow.
- Cards: Semi-transparent frosted glass style with double inset inner rings and warm amber drop shadow.
- Text colors: Primary `#2E2A22`, secondary `#6F6A5F`.
- Light stream layer: Two conic gradient layers with blur effect, rotating in opposite directions with durations of 26s and 36s to create a flowing dawn visual effect.
- Input fields: Near-pure white background with champagne gold border and dual halo effect on focus.
- Radio & Checkbox: Custom styled exclusively for Pearl Dawn (golden ring + gradient checkmark); dark themes retain native browser `accent-color`.
- CTA Buttons: Three-stop champagne gold gradient (`#d8a861` → `#c89a55` → `#b8843e`).

### 4. CSS Token Refactoring
Eliminated dull yellow and flat grey plastic-style colors. All hardcoded dark color values are replaced with new design tokens:
- `--surface-overlay-{strong,mid,soft}`: Background for nested panels
- `--chip-{hover,active}-bg`: Background for tag-style buttons
- `--cta-{bg,fg,border,shadow,shadow-hover}`: Styles for primary action buttons
- `--input-{bg,border,focus-border,focus-shadow,placeholder}`: Form field styles
- `--swatch-tray-*`: Deprecated; replaced with transparent borderless style

Tokens applied to: WorkflowRunPanel, FinalVideoPanel, InteractiveImageReview, SampleAssetsPanel, StudioPreviewPanel, DiagnosticsPanel and App.vue.

### 5. Layout Adjustments
- Updated padding of `.s-main` in StudioLayout from 1.75rem to 1.25rem; further reduced to 0.5rem under Pearl Dawn theme.
- Moved frosted glass style of progress bar from outer wrapper into the `<StudioProgress>` component, removing empty grey placeholder bar when hidden.
- Changed preview panel positioning to `align-self: start` to fix excessive blank space when only one history video exists.

## Test Plan
- [ ] Verify all four themes (Gilded Dusk, Midnight Blue, Violet Starlight, Pearl Dawn) switch correctly via the bottom-right selector
- [ ] Confirm theme preference persists after page refresh
- [ ] Ensure no dull yellow or flat grey plastic visual issues under Pearl Dawn theme
- [ ] Keep consistent spacing for sidebar and cards between Pearl Dawn and dark themes
- [ ] Progress bar only appears during generation; no residual grey bar when idle
- [ ] All controls, buttons and cards render correctly on all dark themes

## Out of Scope for This PR
Phase B workspace upgrades (Studio Header redesign, collapsible form sections, current works panel, export function, configuration reuse and regenerate feature) will be delivered in a separate PR from branch: `feature/jinsie-workspace-v2`.

`npm --prefix frontend run check` ✅ Passed