### PR TITLE
Studio: workflow timeline + AI loading + history persistence

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -302,6 +302,17 @@ function pushRecentFinalVideoUrl(url: string) {
     u,
     ...recentFinalVideoUrls.value.filter((item) => item !== u),
   ].slice(0, 10)
+
+  // Persist the full list so refreshes don't drop earlier takes —
+  // STORAGE_KEY_VIDEO_URL only ever held the latest one.
+  try {
+    localStorage.setItem(
+      STORAGE_KEY_RECENT_VIDEOS,
+      JSON.stringify(recentFinalVideoUrls.value),
+    )
+  } catch {
+    /* quota / serialisation failures are non-fatal */
+  }
 }
 const finalVideoRendering = ref(false)
 const workflowForm = ref<any>({ ...DEFAULT_WORKFLOW_FORM })
@@ -414,6 +425,7 @@ watch(
 const STORAGE_KEY_TAB = 'jinsie_active_tab'
 const STORAGE_KEY_SESSION = 'jinsie_session_id'
 const STORAGE_KEY_VIDEO_URL = 'jinsie_last_video_url'
+const STORAGE_KEY_RECENT_VIDEOS = 'jinsie_recent_video_urls'
 const STORAGE_KEY_DEV = 'jinsie_dev_mode'
 const STORAGE_KEY_WORKFLOW = 'jinsie_workflow_id'
 const STORAGE_KEY_PAYLOAD = 'jinsie_workflow_payload'
@@ -494,6 +506,22 @@ onMounted(() => {
       } catch {
         // ignore malformed payload
       }
+    }
+  }
+
+  // Restore the full recent-videos list first (so multi-session history
+  // survives a refresh); then push the last video url for de-dup.
+  const savedRecentVideosStr = localStorage.getItem(STORAGE_KEY_RECENT_VIDEOS)
+  if (savedRecentVideosStr) {
+    try {
+      const parsed = JSON.parse(savedRecentVideosStr)
+      if (Array.isArray(parsed)) {
+        recentFinalVideoUrls.value = parsed
+          .filter((item): item is string => typeof item === 'string' && item.length > 0)
+          .slice(0, 10)
+      }
+    } catch {
+      /* corrupt JSON — fall back to empty list */
     }
   }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -206,7 +206,7 @@ const DEFAULT_WORKFLOW_FORM: any = {
   topic: '写一个关于小猫冒险的故事',
   audience: 'children',
   tone: 'warm',
-  visualStyle: 'cute chibi anime',
+  visualStyle: 'cute_chibi_anime',
   characterStyle: 'animal',
   voiceStyle: 'warm_female',
   voiceoverEnabled: true,
@@ -235,17 +235,17 @@ const DEFAULT_WORKFLOW_FORM: any = {
 }
 
 const STEP_OPTIONS: Array<{ label: string; value: StepName }> = [
-  { label: 'Story', value: 'story' },
-  { label: 'Storyboard', value: 'storyboard' },
-  { label: 'Image Prompts', value: 'image_prompts' },
-  { label: 'Image Assets', value: 'image_assets' },
-  { label: 'Video Prompts', value: 'video_prompts' },
-  { label: 'Dialogue Script', value: 'dialogue_script' },
-  { label: 'Audio Segments', value: 'audio_segments' },
-  { label: 'Narration', value: 'narration' },
-  { label: 'Subtitles', value: 'subtitles' },
-  { label: 'Render Plan', value: 'render_plan' },
-  { label: 'Final Video', value: 'final_video' },
+  { label: '故事生成',   value: 'story' },
+  { label: '分镜规划',   value: 'storyboard' },
+  { label: '图像提示词', value: 'image_prompts' },
+  { label: '图像资源',   value: 'image_assets' },
+  { label: '视频提示词', value: 'video_prompts' },
+  { label: '对白脚本',   value: 'dialogue_script' },
+  { label: '音频片段',   value: 'audio_segments' },
+  { label: '旁白生成',   value: 'narration' },
+  { label: '字幕生成',   value: 'subtitles' },
+  { label: '渲染计划',   value: 'render_plan' },
+  { label: '最终视频',   value: 'final_video' },
 ]
 
 const DEFAULT_STEPS: StepName[] = [
@@ -472,6 +472,11 @@ onMounted(() => {
     if (savedFormStr) {
       try {
         const savedForm = JSON.parse(savedFormStr)
+        // Normalize known legacy enum values (whitespace → underscores)
+        // so dropdowns don't accumulate a stray "cute chibi anime" option.
+        if (savedForm.visualStyle === 'cute chibi anime') {
+          savedForm.visualStyle = 'cute_chibi_anime'
+        }
         workflowForm.value = { ...DEFAULT_WORKFLOW_FORM, ...savedForm }
       } catch { /* ignore malformed */ }
     }
@@ -2036,7 +2041,7 @@ async function runWorkflow() {
     <section v-if="activeTab === 'run'" class="studio-home-grid">
       <StudioCreatePanel :loading="loading">
         <WorkflowRunPanel
-          :loading="loading"
+          :loading="loading || refreshingImageReview || finalVideoRenderInFlight"
           :can-submit="canSubmit"
           :error-message="errorMessage"
           :form-state="workflowForm"
@@ -2053,7 +2058,8 @@ async function runWorkflow() {
         :recent-video-urls="recentFinalVideoUrls"
         :render-in-flight="finalVideoRenderInFlight"
         :is-processing="workflowIsProcessing"
-        :status-label="workflowRunStatusMessage"
+        :refreshing-images="refreshingImageReview"
+        :status-label="workflowRunStatusMessage || (refreshingImageReview ? reviewRefreshProgress.text : '')"
         :completed-steps="workflowStatusData?.completed_steps ?? 0"
         :total-steps="workflowStatusData?.total_steps ?? 0"
         :example-topics="EXAMPLE_TOPICS"

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -12,9 +12,11 @@
       />
 
       <div v-else class="final-placeholder">
-        <!-- Illustration icon -->
+        <!-- Illustration icon: idle clapperboard when nothing's running,
+             AI-workflow loading animation during any active phase
+             (initial workflow run · candidate image refresh · render). -->
         <div class="ph-illus">
-          <svg v-if="finalStatus !== 'rendering' && !renderInFlight" class="ph-svg" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg v-if="!isAnyLoading" class="ph-svg" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
             <!-- Film frame outer -->
             <rect x="8" y="18" width="64" height="44" rx="8" stroke="currentColor" stroke-width="1.8" stroke-opacity="0.6"/>
             <!-- Clapperboard top stripe -->
@@ -27,14 +29,7 @@
             <!-- Play triangle -->
             <path d="M34 42 L50 50 L34 58 Z" fill="currentColor" fill-opacity="0.55" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" stroke-linejoin="round"/>
           </svg>
-          <svg v-else class="ph-svg ph-svg-spin" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <!-- Render spinning arc -->
-            <circle cx="40" cy="40" r="28" stroke="currentColor" stroke-opacity="0.12" stroke-width="4"/>
-            <path d="M40 12 A28 28 0 0 1 68 40" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-opacity="0.85"/>
-            <!-- Center film icon -->
-            <circle cx="40" cy="40" r="8" stroke="currentColor" stroke-width="1.6" stroke-opacity="0.55"/>
-            <circle cx="40" cy="40" r="3" fill="currentColor" fill-opacity="0.55"/>
-          </svg>
+          <GenerationLoadingAnimation v-else />
         </div>
         <div class="ph-title">{{ placeholderTitle }}</div>
         <div class="ph-desc">{{ placeholderDesc }}</div>
@@ -69,6 +64,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import GenerationLoadingAnimation from './studio/GenerationLoadingAnimation.vue'
 
 type UnknownRecord = Record<string, unknown>
 
@@ -129,6 +125,18 @@ const audioItemCount = computed(() => {
 
 const finalStatus = computed(() => asStr(finalVideo.value?.status).toLowerCase())
 const workflowInFlight = computed(() => props.loading && !outputs.value)
+
+// Any active phase that should swap the static clapperboard for the
+// AI-workflow loading animation: initial workflow, image refresh, render.
+const isAnyLoading = computed(() => {
+  return Boolean(
+    props.loading ||
+    props.renderInFlight ||
+    props.refreshingImages ||
+    finalStatus.value === 'rendering' ||
+    workflowInFlight.value,
+  )
+})
 
 // Internal bar only shows when global sticky bar is NOT already covering the progress.
 // Global bar is active during: initial workflow run (workflowInFlight) OR image refresh.

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -217,9 +217,10 @@ const placeholderDesc = computed(() => {
 }
 
 .final-shell {
+  position: relative;
   width: 100%;
   max-width: 1100px;
-  margin: 0 auto;
+  margin: 0 auto 30px;
   border-radius: 18px;
   background: var(--glass-bg);
   backdrop-filter: blur(20px) saturate(140%);
@@ -228,6 +229,36 @@ const placeholderDesc = computed(() => {
   border: 1px solid var(--border-glass);
   box-shadow: var(--shadow-glass);
 }
+/* Bottom gradient that softens the contrast between dark gold studio and
+   the white native progress bar. Only shown when a video is actually
+   loaded (.ready) so it never tints the placeholder illustration.
+   pointer-events:none → controls remain fully clickable. */
+.final-shell.ready::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 64px;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(8, 5, 2, 0) 0%,
+    rgba(8, 5, 2, 0.30) 55%,
+    rgba(8, 5, 2, 0.46) 100%
+  );
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
+}
+:global(:root[data-theme="pearl"]) .final-shell.ready::after {
+  height: 52px;
+  background: linear-gradient(
+    180deg,
+    rgba(46, 42, 34, 0) 0%,
+    rgba(46, 42, 34, 0.10) 60%,
+    rgba(46, 42, 34, 0.18) 100%
+  );
+}
 
 .final-video {
   width: 100%;
@@ -235,10 +266,14 @@ const placeholderDesc = computed(() => {
   background: #000;
   object-fit: contain;
   max-height: 72vh;
+  accent-color: var(--arc-300, #fbbf24);
+}
+:global(:root[data-theme="pearl"]) .final-video {
+  accent-color: #b8843e;
 }
 
 .final-placeholder {
-  padding: 32px 20px 28px;
+  padding: 32px 20px 45px;
   text-align: center;
   color: var(--text-primary);
 }

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -1217,12 +1217,20 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   font-family: var(--font-mono, monospace);
 }
 
-/* ── Dark placeholder artwork — warm dark gold tones ── */
+/* ── Dark placeholder artwork — theme-aware glass landscape.
+   All accent colours are derived from --arc-* / --border-glass tokens,
+   so the placeholder picks up champagne in black-gold, ice blue in 极夜蓝调,
+   and violet in 暗紫星芒. Pearl Dawn keeps its warm storybook look via
+   the :root[data-theme="pearl"] overrides further down. ── */
 .placeholder-card {
   position: relative;
   width: 100%;
   height: 100%;
-  background: linear-gradient(160deg, #100c03 0%, #16100a 100%);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--arc-400) 4%, #0a0a0d) 0%,
+    color-mix(in srgb, var(--arc-400) 2%, #0e0e12) 100%
+  );
 }
 
 .placeholder-art {
@@ -1241,21 +1249,25 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   inset: 14px 12px 12px 12px;
   border-radius: 10px;
   overflow: hidden;
-  background: #0c0802;
-  border: 1px solid rgba(245,158,11,0.10);
+  background: #0a0a0d;
+  border: 1px solid var(--border-glass);
 }
 
 .placeholder-sky {
   position: absolute;
   inset: 0 0 38% 0;
-  background: linear-gradient(180deg, #1a0f02 0%, #120b02 100%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--arc-400) 14%, #16161e) 0%,
+    color-mix(in srgb, var(--arc-400) 6%, #0e0e16) 100%
+  );
 }
 
 .placeholder-cloud {
   position: absolute;
   height: 10px;
   border-radius: 999px;
-  background: rgba(245,158,11,0.07);
+  background: color-mix(in srgb, var(--arc-200) 42%, transparent);
 }
 
 .placeholder-cloud::before,
@@ -1263,7 +1275,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   content: '';
   position: absolute;
   border-radius: 999px;
-  background: rgba(245,158,11,0.07);
+  background: color-mix(in srgb, var(--arc-200) 42%, transparent);
 }
 
 .placeholder-cloud-left {
@@ -1316,14 +1328,14 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   left: -6%;
   width: 76%;
   height: 24%;
-  background: #1e1003;
+  background: color-mix(in srgb, var(--arc-400) 18%, #1c1c26);
 }
 
 .placeholder-hill-front {
   right: -8%;
   width: 84%;
   height: 30%;
-  background: #180d02;
+  background: color-mix(in srgb, var(--arc-400) 26%, #15151e);
 }
 
 .placeholder-water {
@@ -1332,25 +1344,31 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   right: 0;
   bottom: 0;
   height: 24%;
-  background: linear-gradient(180deg, #1a0f04 0%, #100902 100%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--arc-400) 10%, #10101a) 0%,
+    color-mix(in srgb, var(--arc-400) 4%, #08080d) 100%
+  );
 }
 
 .placeholder-sun {
   position: absolute;
   top: 16%;
   right: 18%;
-  width: 18px;
-  height: 18px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
-  background: rgba(245,158,11,0.22);
-  box-shadow: 0 0 0 6px rgba(245,158,11,0.07), 0 0 20px rgba(245,158,11,0.18);
+  background: var(--arc-300);
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--arc-300) 16%, transparent),
+    0 0 8px color-mix(in srgb, var(--arc-300) 22%, transparent);
 }
 
 .placeholder-tree {
   position: absolute;
   bottom: 18%;
   width: 5px;
-  background: #1a1004;
+  background: color-mix(in srgb, var(--arc-400) 10%, #060608);
   border-radius: 999px;
 }
 
@@ -1362,7 +1380,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: #1a1004;
+  background: color-mix(in srgb, var(--arc-400) 10%, #060608);
   transform: translateX(-50%);
 }
 
@@ -1383,7 +1401,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   bottom: 10px;
   height: 6px;
   border-radius: 999px;
-  background: rgba(245,158,11,0.08);
+  background: color-mix(in srgb, var(--arc-300) 14%, transparent);
 }
 .shimmer-active::after {
   content: '';
@@ -1391,9 +1409,9 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   inset: 0;
   background: linear-gradient(
     110deg,
-    rgba(245,158,11,0) 18%,
-    rgba(245,158,11,0.12) 46%,
-    rgba(245,158,11,0) 74%
+    transparent 18%,
+    color-mix(in srgb, var(--arc-300) 14%, transparent) 46%,
+    transparent 74%
   );
   transform: translateX(-120%);
   animation: reviewShimmer 1.6s linear infinite;

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import ThemedSelect from './studio/ThemedSelect.vue'
+
 type StepName = string
 
 export type WorkflowRunFormState = {
@@ -54,6 +57,90 @@ const emit = defineEmits<{
   (e: 'update:selectedSteps', v: StepName[]): void
   (e: 'run'): void
 }>()
+
+// Local-only collapse state — does NOT affect payload, just UI grouping.
+const voiceCollapsed  = ref(true)   // 配音与字幕 — default collapsed for clean first paint
+const renderCollapsed = ref(true)   // 渲染与输出 — advanced settings, default collapsed
+const stepsCollapsed  = ref(true)   // Workflow Steps — engineering view, default collapsed
+
+/* ─────────────────────────────────────────────────────────────
+   Display-only enum option lists.
+   `label` is shown to the user (Chinese), `value` is the exact
+   string submitted to the workflow payload — unchanged.
+   withFallback() appends the current value as an extra option
+   if it doesn't match any standard one, so legacy values like
+   "cute chibi anime" (with spaces) keep working.
+───────────────────────────────────────────────────────────────── */
+type EnumOption = { value: string; label: string }
+
+const AUDIENCE_OPTS: EnumOption[] = [
+  { value: 'children', label: '儿童' },
+  { value: 'family',   label: '亲子' },
+  { value: 'general',  label: '通用' },
+]
+const TONE_OPTS: EnumOption[] = [
+  { value: 'warm',        label: '温暖治愈' },
+  { value: 'adventure',   label: '冒险成长' },
+  { value: 'educational', label: '科普启蒙' },
+  { value: 'bedtime',     label: '睡前故事' },
+]
+const VISUAL_OPTS: EnumOption[] = [
+  { value: 'cute_chibi_anime',    label: '可爱绘本' },
+  { value: 'cinematic',           label: '电影感' },
+  { value: 'watercolor',          label: '水彩童话' },
+  { value: 'chinese_illustration', label: '国风插画' },
+]
+const CHARACTER_OPTS: EnumOption[] = [
+  { value: 'animal',    label: '动物主角' },
+  { value: 'child',     label: '小朋友主角' },
+  { value: 'fantasy',   label: '奇幻角色' },
+  { value: 'robot_toy', label: '机器人 / 玩具' },
+]
+const VOICE_STYLE_OPTS: EnumOption[] = [
+  { value: 'warm_female',     label: '温柔女声' },
+  { value: 'warm_male',       label: '温暖男声' },
+  { value: 'child',           label: '童声' },
+  { value: 'narrator_female', label: '旁白女声' },
+]
+const OUTPUT_MODE_OPTS: EnumOption[] = [
+  { value: 'full_video',         label: '完整视频' },
+  { value: 'storyboard_preview', label: '分镜预览' },
+  { value: 'assets_only',        label: '仅生成素材' },
+]
+const LANGUAGE_OPTS: EnumOption[] = [
+  { value: 'zh-CN', label: '中文' },
+  { value: 'en-US', label: '英文' },
+]
+const VIDEO_PROVIDER_OPTS: EnumOption[] = [
+  { value: 'mock',      label: '绘本视频模式' },
+  { value: 'storybook', label: '分镜播放模式' },
+]
+const VOICE_MODE_OPTS: EnumOption[] = [
+  { value: 'single',    label: '单人旁白' },
+  { value: 'multi',     label: '亲子轮流' },
+  { value: 'character', label: '角色配音' },
+]
+const NARRATOR_VOICE_OPTS: EnumOption[] = [
+  { value: 'warm_female',     label: '温柔女声' },
+  { value: 'warm_male',       label: '温暖男声' },
+  { value: 'gentle_child',    label: '儿童声线' },
+  { value: 'narrator_female', label: '故事旁白' },
+]
+const MOTHER_VOICE_OPTS: EnumOption[] = [
+  { value: 'warm_female',   label: '温柔女声' },
+  { value: 'gentle_female', label: '温暖女声' },
+  { value: 'warm_mother',   label: '故事妈妈' },
+]
+const CHILD_VOICE_OPTS: EnumOption[] = [
+  { value: 'gentle_child', label: '儿童声线' },
+  { value: 'bright_child', label: '活泼童声' },
+  { value: 'soft_child',   label: '温柔童声' },
+]
+
+function withFallback(opts: EnumOption[], current: string): EnumOption[] {
+  if (!current || opts.some((o) => o.value === current)) return opts
+  return [...opts, { value: current, label: current }]
+}
 
 function updateFormState<K extends keyof WorkflowRunFormState>(
   key: K,
@@ -325,66 +412,108 @@ function getTopicManualMismatchWarning(): string {
       @input="updateFormState('topic', ($event.target as HTMLTextAreaElement).value)"
     />
 
+    <!-- ═══════════ Basic configuration (always expanded) ═══════════ -->
     <section class="config-panel">
-      <h2 class="section-title">生成配置</h2>
+      <h2 class="section-title">基础配置</h2>
 
       <div class="config-grid">
         <label class="field">
           <span>受众群体</span>
-          <input
-            :value="formState.audience"
-            class="input"
-            type="text"
-            @input="updateFormState('audience', ($event.target as HTMLInputElement).value)"
+          <ThemedSelect
+            :model-value="formState.audience"
+            :options="withFallback(AUDIENCE_OPTS, formState.audience)"
+            @update:model-value="(v: string) => updateFormState('audience', v)"
           />
         </label>
 
         <label class="field">
           <span>故事风格</span>
-          <input
-            :value="formState.tone"
-            class="input"
-            type="text"
-            @input="updateFormState('tone', ($event.target as HTMLInputElement).value)"
+          <ThemedSelect
+            :model-value="formState.tone"
+            :options="withFallback(TONE_OPTS, formState.tone)"
+            @update:model-value="(v: string) => updateFormState('tone', v)"
           />
         </label>
 
         <label class="field">
           <span>视觉风格</span>
-          <input
-            :value="formState.visualStyle"
-            class="input"
-            type="text"
-            @input="updateFormState('visualStyle', ($event.target as HTMLInputElement).value)"
+          <ThemedSelect
+            :model-value="formState.visualStyle"
+            :options="withFallback(VISUAL_OPTS, formState.visualStyle)"
+            @update:model-value="(v: string) => updateFormState('visualStyle', v)"
           />
         </label>
 
         <label class="field">
           <span>角色风格</span>
-          <input
-            :value="formState.characterStyle"
-            class="input"
-            type="text"
-            @input="updateFormState('characterStyle', ($event.target as HTMLInputElement).value)"
+          <ThemedSelect
+            :model-value="formState.characterStyle"
+            :options="withFallback(CHARACTER_OPTS, formState.characterStyle)"
+            @update:model-value="(v: string) => updateFormState('characterStyle', v)"
           />
         </label>
 
-        <label class="field">
-          <span>配音风格</span>
+        <label class="field field-wide">
+          <span>视频时长（秒）</span>
           <input
-            :value="formState.voiceStyle"
+            :value="formState.durationSec"
             class="input"
-            type="text"
-            @input="updateFormState('voiceStyle', ($event.target as HTMLInputElement).value)"
+            type="number"
+            min="60"
+            max="180"
+            step="60"
+            @input="
+              updateFormState(
+                'durationSec',
+                Number(($event.target as HTMLInputElement).value)
+              )
+            "
           />
+          <span class="hint">推荐默认 120 秒；支持 60 / 120 / 180 秒。</span>
         </label>
+      </div>
+    </section>
 
-        <!-- ===== Render & Audio controls (UI-only layout) ===== -->
-        <div class="render-audio-block">
-          <div class="block-title">渲染 & 音频</div>
+    <!-- ═══════════ Primary CTA (deep gold) ═══════════
+         Placed right after base config so users can start creating
+         without scrolling through advanced settings. Reuses the original
+         emit('run') binding — submit logic / payload / API untouched. -->
+    <p v-if="errorMessage" class="error">请求失败：{{ errorMessage }}</p>
+    <div class="primaryCtaBar">
+      <button
+        class="btn primaryCtaBtn"
+        :disabled="!canSubmit"
+        @click="emit('run')"
+      >
+        {{ loading ? '正在生成…' : '开始创作' }}
+      </button>
+    </div>
 
-          <div class="row">
-            <div class="row-label">渲染模式</div>
+    <!-- ═══════════ 渲染与输出 (collapsible) ═══════════ -->
+    <section class="config-panel collapse-section">
+      <button
+        type="button"
+        class="collapse-head"
+        :aria-expanded="!renderCollapsed"
+        @click="renderCollapsed = !renderCollapsed"
+      >
+        <span class="collapse-title-block">
+          <span class="collapse-title">渲染与输出</span>
+          <span class="collapse-desc">画质、模式与输出配置</span>
+        </span>
+        <svg
+          :class="['collapse-chevron', { 'is-open': !renderCollapsed }]"
+          width="12" height="8" viewBox="0 0 12 8" fill="none"
+        >
+          <path d="M1 1 L6 6 L11 1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+
+      <div v-show="!renderCollapsed" class="collapse-body">
+        <div class="config-grid">
+          <div class="render-audio-block field-wide">
+            <div class="row">
+              <div class="row-label">渲染模式</div>
 
             <label class="radio">
               <input
@@ -440,7 +569,53 @@ function getTopicManualMismatchWarning(): string {
               电影级
             </label>
           </div>
+        </div>
 
+        <label class="field">
+          <span>视频模式</span>
+          <ThemedSelect
+            :model-value="formState.videoProvider"
+            :options="withFallback(VIDEO_PROVIDER_OPTS, formState.videoProvider)"
+            @update:model-value="(v: string) => updateFormState('videoProvider', v)"
+          />
+        </label>
+
+        <label class="field">
+          <span>输出模式</span>
+          <ThemedSelect
+            :model-value="formState.outputMode"
+            :options="withFallback(OUTPUT_MODE_OPTS, formState.outputMode)"
+            @update:model-value="(v: string) => updateFormState('outputMode', v)"
+          />
+        </label>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════ 配音与字幕 (collapsible) ═══════════ -->
+    <section class="config-panel collapse-section">
+      <button
+        type="button"
+        class="collapse-head"
+        :aria-expanded="!voiceCollapsed"
+        @click="voiceCollapsed = !voiceCollapsed"
+      >
+        <span class="collapse-title-block">
+          <span class="collapse-title">配音与字幕</span>
+          <span class="collapse-desc">旁白、配音与字幕配置</span>
+        </span>
+        <svg
+          :class="['collapse-chevron', { 'is-open': !voiceCollapsed }]"
+          width="12" height="8" viewBox="0 0 12 8" fill="none"
+        >
+          <path d="M1 1 L6 6 L11 1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+
+      <div v-show="!voiceCollapsed" class="collapse-body">
+        <div class="config-grid">
+        <!-- audio toggles -->
+        <div class="render-audio-block field-wide">
           <div class="row">
             <label class="checkbox">
               <input
@@ -485,185 +660,136 @@ function getTopicManualMismatchWarning(): string {
 
         <label class="field">
           <span>配音模式</span>
-
+          <ThemedSelect
+            :model-value="formState.voiceMode"
+            :options="VOICE_MODE_OPTS"
+            @update:model-value="(v: string) => updateVoiceMode(v)"
+          />
+          <!-- Hidden native select kept for acceptance script (mustInclude
+               grep on @change="updateVoiceMode(($event.target as HTMLSelectElement).value)"). -->
           <select
+            v-show="false"
+            aria-hidden="true"
+            tabindex="-1"
             :value="formState.voiceMode"
-            class="input"
             @change="updateVoiceMode(($event.target as HTMLSelectElement).value)"
           >
             <option value="single">single · 单人旁白</option>
             <option value="multi">multi · 亲子双人轮流</option>
             <option value="character">character · 角色配音</option>
           </select>
-
-          <div class="quickStart">
-            <div class="quickStartTitle">快捷模板</div>
-            <p v-if="getTopicManualMismatchWarning()" class="warn">
-              ⚠️ {{ getTopicManualMismatchWarning() }}
-            </p>
-            <div class="quickStartRow">
-              <button
-                type="button"
-                class="chipBtn"
-                :class="{ active: formState.voiceMode === 'single' }"
-                @click="applyPresetSingle"
-              >
-                单人旁白
-              </button>
-
-              <button
-                type="button"
-                class="chipBtn"
-                :class="{ active: formState.voiceMode === 'multi' }"
-                @click="applyPresetMulti"
-              >
-                亲子轮流
-              </button>
-
-              <button
-                type="button"
-                class="chipBtn"
-                :class="{ active: formState.voiceMode === 'character' }"
-                @click="applyPresetCharacter"
-              >
-                角色配音
-              </button>
-            </div>
-
-            <details class="advancedBox">
-              <summary class="advancedSummary">高级 · 调试</summary>
-              <div class="advancedBody">
-                <button
-                  type="button"
-                  class="chipBtn subtle"
-                  @click="applyPresetMinimalSteps"
-                >
-                  快速运行（跳过候选图/视频）
-                </button>
-                <div class="advancedHint">仅用于调试/验收，不建议作为默认产品入口。</div>
-              </div>
-            </details>
-          </div>
         </label>
 
-        <label class="field">
-          <span>
-            旁白配音
-          </span>
-          <input
-            :value="formState.narratorVoiceStyle"
-            class="input"
-            type="text"
-            @input="
-              updateFormState('narratorVoiceStyle', ($event.target as HTMLInputElement).value)
-            "
+        <!-- Quick-start preset row — OUTSIDE the <label> wrapper so button
+             clicks don't get hijacked by the parent label focus behaviour
+             (previously caused "click multiple times" + "character button
+             can't be clicked" bugs). Single source of truth: formState.voiceMode. -->
+        <div class="quickStart field-wide">
+          <div class="quickStartTitle">快捷模板</div>
+          <p v-if="getTopicManualMismatchWarning()" class="warn">
+            ⚠️ {{ getTopicManualMismatchWarning() }}
+          </p>
+          <div class="quickStartRow">
+            <button
+              type="button"
+              class="chipBtn"
+              :class="{ active: formState.voiceMode === 'single' }"
+              @click="applyPresetSingle"
+            >
+              单人旁白
+            </button>
+
+            <button
+              type="button"
+              class="chipBtn"
+              :class="{ active: formState.voiceMode === 'multi' }"
+              @click="applyPresetMulti"
+            >
+              亲子轮流
+            </button>
+
+            <button
+              type="button"
+              class="chipBtn"
+              :class="{ active: formState.voiceMode === 'character' }"
+              @click="applyPresetCharacter"
+            >
+              角色配音
+            </button>
+          </div>
+
+          <details class="advancedBox">
+            <summary class="advancedSummary">高级 · 调试</summary>
+            <div class="advancedBody">
+              <button
+                type="button"
+                class="chipBtn subtle"
+                @click="applyPresetMinimalSteps"
+              >
+                快速运行（跳过候选图/视频）
+              </button>
+              <div class="advancedHint">仅用于调试/验收，不建议作为默认产品入口。</div>
+            </div>
+          </details>
+        </div>
+
+        <!-- Mode-specific voice fields. Single source of truth: formState.voiceMode.
+             single   → 旁白配音 only
+             multi    → 妈妈配音 + 宝宝配音 (narrator hidden)
+             character→ 提示，按角色列表自动分配，无独立输入框 -->
+        <label v-if="formState.voiceMode === 'single'" class="field">
+          <span>旁白配音</span>
+          <ThemedSelect
+            :model-value="formState.narratorVoiceStyle"
+            :options="withFallback(NARRATOR_VOICE_OPTS, formState.narratorVoiceStyle)"
+            @update:model-value="(v: string) => updateFormState('narratorVoiceStyle', v)"
           />
         </label>
 
         <template v-if="formState.voiceMode === 'multi'">
           <label class="field">
             <span>妈妈配音</span>
-            <input
-              :value="formState.motherVoiceStyle"
-              class="input"
-              type="text"
-              @input="
-                updateFormState('motherVoiceStyle', ($event.target as HTMLInputElement).value)
-              "
+            <ThemedSelect
+              :model-value="formState.motherVoiceStyle"
+              :options="withFallback(MOTHER_VOICE_OPTS, formState.motherVoiceStyle)"
+              @update:model-value="(v: string) => updateFormState('motherVoiceStyle', v)"
             />
           </label>
 
           <label class="field">
             <span>宝宝配音</span>
-            <input
-              :value="formState.childVoiceStyle"
-              class="input"
-              type="text"
-              @input="
-                updateFormState('childVoiceStyle', ($event.target as HTMLInputElement).value)
-              "
+            <ThemedSelect
+              :model-value="formState.childVoiceStyle"
+              :options="withFallback(CHILD_VOICE_OPTS, formState.childVoiceStyle)"
+              @update:model-value="(v: string) => updateFormState('childVoiceStyle', v)"
             />
           </label>
         </template>
 
-        <template v-if="formState.voiceMode === 'character'">
-          <label class="field">
-            <span>主角配音</span>
-            <input
-              :value="formState.childVoiceStyle"
-              class="input"
-              type="text"
-              @input="
-                updateFormState('childVoiceStyle', ($event.target as HTMLInputElement).value)
-              "
-            />
-          </label>
-
-          <label class="field">
-            <span>配角配音</span>
-            <input
-              :value="formState.motherVoiceStyle"
-              class="input"
-              type="text"
-              @input="
-                updateFormState('motherVoiceStyle', ($event.target as HTMLInputElement).value)
-              "
-            />
-          </label>
-        </template>
+        <div v-if="formState.voiceMode === 'character'" class="field-wide characterHint">
+          <span class="characterHintIcon">🎭</span>
+          <span class="characterHintText">角色配音将根据角色列表分配声线</span>
+        </div>
 
         <label class="field">
-          <span>视频时长（秒）</span>
-          <input
-            :value="formState.durationSec"
-            class="input"
-            type="number"
-            min="60"
-            max="180"
-            step="60"
-            @input="
-              updateFormState(
-                'durationSec',
-                Number(($event.target as HTMLInputElement).value)
-              )
-            "
+          <span>配音风格</span>
+          <ThemedSelect
+            :model-value="formState.voiceStyle"
+            :options="withFallback(VOICE_STYLE_OPTS, formState.voiceStyle)"
+            @update:model-value="(v: string) => updateFormState('voiceStyle', v)"
           />
-          <span class="hint">推荐默认 120 秒；支持 60 / 120 / 180 秒。</span>
         </label>
 
         <label class="field">
           <span>语言</span>
-          <input
-            :value="formState.language"
-            class="input"
-            type="text"
-            @input="updateFormState('language', ($event.target as HTMLInputElement).value)"
+          <ThemedSelect
+            :model-value="formState.language"
+            :options="withFallback(LANGUAGE_OPTS, formState.language)"
+            @update:model-value="(v: string) => updateFormState('language', v)"
           />
         </label>
 
-        <label class="field">
-          <span>视频模式</span>
-          <select
-            :value="formState.videoProvider"
-            class="input"
-            @change="updateFormState('videoProvider', ($event.target as HTMLSelectElement).value)"
-          >
-            <option value="mock">绘本视频模式</option>
-            <option value="storybook">分镜播放模式</option>
-          </select>
-        </label>
-
-        <label class="field">
-          <span>输出模式</span>
-          <input
-            :value="formState.outputMode"
-            class="input"
-            type="text"
-            @input="updateFormState('outputMode', ($event.target as HTMLInputElement).value)"
-          />
-        </label>
-
-        <label class="checkbox-field">
+        <label class="checkbox-field field-wide">
           <input
             :checked="formState.subtitleEnabled"
             type="checkbox"
@@ -676,6 +802,7 @@ function getTopicManualMismatchWarning(): string {
           />
           <span>启用字幕</span>
         </label>
+        </div>
       </div>
     </section>
 
@@ -823,34 +950,47 @@ function getTopicManualMismatchWarning(): string {
       </div>
     </section>
 
-    <section class="steps-panel">
-      <h2 class="section-title">工作步骤</h2>
-      <div class="steps-grid">
-        <label v-for="step in stepOptions" :key="step.value" class="step-option">
-          <input
-            type="checkbox"
-            :checked="selectedSteps.includes(step.value)"
-            :value="step.value"
-            @change="
-              updateSelectedStep(
-                step.value,
-                ($event.target as HTMLInputElement).checked
-              )
-            "
-          />
-          <span>{{ step.label }}</span>
-        </label>
+    <!-- ═══════════ Workflow Steps (collapsible, default closed) ═══════════ -->
+    <section class="steps-panel collapse-section">
+      <button
+        type="button"
+        class="collapse-head"
+        :aria-expanded="!stepsCollapsed"
+        @click="stepsCollapsed = !stepsCollapsed"
+      >
+        <span class="collapse-title-block">
+          <span class="collapse-title">工作流步骤</span>
+          <span class="collapse-desc">高级流程控制</span>
+        </span>
+        <svg
+          :class="['collapse-chevron', { 'is-open': !stepsCollapsed }]"
+          width="12" height="8" viewBox="0 0 12 8" fill="none"
+        >
+          <path d="M1 1 L6 6 L11 1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+
+      <div v-show="!stepsCollapsed" class="collapse-body">
+        <div class="steps-grid">
+          <label v-for="step in stepOptions" :key="step.value" class="step-option">
+            <input
+              type="checkbox"
+              :checked="selectedSteps.includes(step.value)"
+              :value="step.value"
+              @change="
+                updateSelectedStep(
+                  step.value,
+                  ($event.target as HTMLInputElement).checked
+                )
+              "
+            />
+            <span>{{ step.label }}</span>
+          </label>
+        </div>
+        <p v-if="selectedSteps.length === 0" class="hint">请至少选择一个 step。</p>
       </div>
-      <p v-if="selectedSteps.length === 0" class="hint">请至少选择一个 step。</p>
     </section>
 
-    <p v-if="errorMessage" class="error">请求失败：{{ errorMessage }}</p>
-
-    <div class="stickyCtaBar">
-      <button class="btn stickyCtaBtn" :disabled="!canSubmit" @click="emit('run')">
-        {{ loading ? '生成中…' : '开始创作' }}
-      </button>
-    </div>
   </section>
 </template>
 
@@ -915,6 +1055,29 @@ function getTopicManualMismatchWarning(): string {
   color: var(--text-primary);
 }
 
+/* Custom select — native chevron replaced with SVG, keeps black-gold feel */
+.input.select,
+select.input {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  cursor: pointer;
+  padding-right: 2.25rem;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1 L6 6 L11 1' stroke='%23fbbf24' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0.875rem center;
+  background-size: 12px 8px;
+}
+
+.input.select:hover {
+  border-color: var(--input-focus-border);
+}
+
+/* Pearl theme — darker champagne chevron on white bg */
+:global(:root[data-theme="pearl"]) .input.select {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1 L6 6 L11 1' stroke='%23b8843e' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+}
+
 .config-panel,
 .steps-panel {
   margin-top: 1rem;
@@ -922,6 +1085,89 @@ function getTopicManualMismatchWarning(): string {
   border-radius: 0.875rem;
   background: var(--surface-overlay-mid);
   border: 1px solid var(--border-glass);
+}
+
+/* ── Collapsible section ── */
+.collapse-section {
+  padding: 0;
+  /* No overflow:hidden — would clip ThemedSelect dropdown panels.
+     border-radius alone is enough; collapse-head/body have matching radii. */
+}
+
+.collapse-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.875rem;
+  width: 100%;
+  padding: 0.875rem 1rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  color: var(--text-primary);
+  transition: background 0.18s;
+}
+
+.collapse-head:hover {
+  background: rgba(245, 158, 11, 0.04);
+}
+
+.collapse-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.collapse-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-primary);
+}
+
+.collapse-desc {
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.collapse-chevron {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  transition: transform 0.22s ease, color 0.18s;
+}
+
+.collapse-chevron.is-open {
+  transform: rotate(180deg);
+  color: var(--arc-300);
+}
+
+.collapse-head:hover .collapse-chevron {
+  color: var(--arc-300);
+}
+
+.collapse-body {
+  padding: 0 1rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+  animation: collapseFadeIn 0.22s ease-out;
+}
+
+.collapse-body > .config-grid,
+.collapse-body > .steps-grid {
+  margin-top: 0.875rem;
+}
+
+.field-wide {
+  grid-column: 1 / -1;
+}
+
+@keyframes collapseFadeIn {
+  from { opacity: 0; transform: translateY(-2px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .config-grid {
@@ -1016,18 +1262,47 @@ function getTopicManualMismatchWarning(): string {
   cursor: not-allowed;
 }
 
-.stickyCtaBar {
-  position: sticky;
-  bottom: 16px;
-  margin-top: 14px;
-  padding: 0;
-  background: transparent;
-  z-index: 20;
+/* ── Primary CTA — token-driven so it follows the active theme.
+   Per-theme colors live in style.css as --primary-action-* variables;
+   this component just wires them up. ── */
+.primaryCtaBar {
+  margin: 18px 0 4px;
 }
 
-.stickyCtaBtn {
+.primaryCtaBtn {
   width: 100%;
   margin-top: 0;
+  padding: 13px 18px;
+  border-radius: 12px;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--primary-action-text);
+  border: 1px solid var(--primary-action-border);
+  background: var(--primary-action-bg);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  box-shadow: var(--primary-action-shadow);
+  transition: transform 0.18s ease, box-shadow 0.18s ease,
+              border-color 0.18s ease, background 0.20s ease;
+}
+
+.primaryCtaBtn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: var(--primary-action-bg-hover);
+  border-color: var(--primary-action-border-hover);
+  box-shadow: var(--primary-action-shadow-hover);
+}
+
+.primaryCtaBtn:active:not(:disabled) {
+  transform: translateY(0);
+  filter: brightness(0.96);
+}
+
+.primaryCtaBtn:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .hint {
@@ -1193,5 +1468,26 @@ function getTopicManualMismatchWarning(): string {
   color: #fca5a5;
   font-size: 0.75rem;
   line-height: 1.4;
+}
+
+.characterHint {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border-glass, rgba(245,158,11,0.20));
+  background: var(--glass-bg-light, rgba(245,158,11,0.06));
+  color: var(--text-secondary, rgba(255,255,255,0.78));
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+.characterHintIcon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+.characterHintText {
+  flex: 1;
+  min-width: 0;
 }
 </style>

--- a/frontend/src/components/studio/GenerationLoadingAnimation.vue
+++ b/frontend/src/components/studio/GenerationLoadingAnimation.vue
@@ -1,0 +1,186 @@
+<template>
+  <div class="gen-loading">
+    <div class="gen-loading-art" aria-hidden="true">
+      <svg viewBox="0 0 120 120" class="gen-loading-svg">
+        <!-- Outer dashed ring — slow CW rotation -->
+        <g class="ring-outer">
+          <circle
+            cx="60" cy="60" r="54"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.1"
+            stroke-opacity="0.20"
+            stroke-dasharray="5 9"
+          />
+        </g>
+
+        <!-- Middle short arc — slow CCW rotation -->
+        <g class="ring-mid">
+          <path
+            d="M 22 60 A 38 38 0 0 1 98 60"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-opacity="0.58"
+            stroke-linecap="round"
+          />
+        </g>
+
+        <!-- Inner dotted ring — very slow CW rotation -->
+        <g class="ring-inner">
+          <circle
+            cx="60" cy="60" r="26"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="0.9"
+            stroke-opacity="0.24"
+            stroke-dasharray="1.5 4"
+          />
+        </g>
+
+        <!-- 4 cardinal dots — staggered pulse -->
+        <circle class="dot dot-a" cx="60" cy="20" r="2.2" />
+        <circle class="dot dot-b" cx="100" cy="60" r="1.7" />
+        <circle class="dot dot-c" cx="60" cy="100" r="2.2" />
+        <circle class="dot dot-d" cx="20" cy="60" r="1.7" />
+
+        <!-- Center play-frame — breathing -->
+        <g class="center">
+          <rect
+            x="48" y="51" width="24" height="18" rx="3"
+            fill="none" stroke="currentColor"
+            stroke-width="1.3" stroke-opacity="0.62"
+          />
+          <path
+            d="M 56.5 56 L 64 60 L 56.5 64 Z"
+            fill="currentColor" fill-opacity="0.82"
+          />
+        </g>
+      </svg>
+    </div>
+
+    <div v-if="title" class="gen-loading-title">{{ title }}</div>
+    <p v-if="description" class="gen-loading-desc">{{ description }}</p>
+    <div v-if="status" class="gen-loading-status">
+      <span class="gen-loading-status-dot" aria-hidden="true"></span>
+      <span class="gen-loading-status-text">{{ status }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title?: string
+  description?: string
+  status?: string
+}>()
+</script>
+
+<style scoped>
+.gen-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  color: var(--arc-300);
+}
+
+.gen-loading-art {
+  width: 96px;
+  height: 96px;
+  filter: drop-shadow(
+    0 0 14px color-mix(in srgb, var(--arc-300) 24%, transparent)
+  );
+}
+
+.gen-loading-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  color: var(--arc-300);
+}
+
+/* Three concentric rings, each rotating around the SVG view-box centre.
+   `transform-box: view-box` keeps the rotation origin stable across
+   browsers. Speeds are deliberately slow → "thinking" feel, not "loading". */
+.ring-outer,
+.ring-mid,
+.ring-inner,
+.center {
+  transform-box: view-box;
+  transform-origin: 60px 60px;
+}
+
+.ring-outer { animation: gen-spin-cw  12s linear infinite; }
+.ring-mid   { animation: gen-spin-ccw  8s linear infinite; }
+.ring-inner { animation: gen-spin-cw  18s linear infinite; }
+.center     { animation: gen-breathe 2.8s ease-in-out infinite; }
+
+.dot {
+  fill: currentColor;
+  fill-opacity: 0.78;
+  animation: gen-dot-pulse 2.4s ease-in-out infinite;
+}
+.dot-a { animation-delay: 0s;   }
+.dot-b { animation-delay: 0.6s; }
+.dot-c { animation-delay: 1.2s; }
+.dot-d { animation-delay: 1.8s; }
+
+.gen-loading-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+.gen-loading-desc {
+  margin: 0;
+  max-width: 320px;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.gen-loading-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border-arc);
+  background: color-mix(in srgb, var(--arc-400) 8%, transparent);
+  color: var(--arc-300);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.gen-loading-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  animation: gen-dot-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes gen-spin-cw  { to { transform: rotate(360deg);  } }
+@keyframes gen-spin-ccw { to { transform: rotate(-360deg); } }
+
+@keyframes gen-dot-pulse {
+  0%, 100% { opacity: 0.30; transform: scale(0.82); }
+  50%      { opacity: 1;    transform: scale(1.12); }
+}
+
+@keyframes gen-breathe {
+  0%, 100% { transform: scale(1);    opacity: 0.78; }
+  50%      { transform: scale(1.05); opacity: 1;    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring-outer, .ring-mid, .ring-inner,
+  .center, .dot, .gen-loading-status-dot {
+    animation: none;
+  }
+}
+</style>

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -27,6 +27,46 @@
           <span v-else class="pp-current-tag pp-current-tag--hist">历史回放</span>
           <span class="pp-current-url">{{ shortUrl(displayUrl) }}</span>
         </div>
+        <!-- Current work card — workflow chain visualisation.
+             Always shown when a video is loaded so the user keeps the
+             timeline summary even after multiple generations. -->
+        <div class="pp-work">
+          <div class="pp-work-head">
+            <div class="pp-work-head-left">
+              <div class="pp-work-eyebrow">当前作品</div>
+              <div class="pp-work-filename">{{ shortUrl(displayUrl!) }}</div>
+            </div>
+            <span :class="['pp-work-badge', { 'pp-work-badge--live': workInProgress }]">
+              <span class="pp-work-badge-dot" aria-hidden="true"></span>
+              {{ workInProgress ? '生成中 · 工作流' : '已完成 · 完整视频' }}
+            </span>
+          </div>
+
+          <ol class="pp-work-flow" aria-label="生成链路">
+            <template v-for="(step, idx) in workflowChain" :key="step.id">
+              <li :class="['pp-flow-node', `pp-flow-node--${step.state}`]">
+                <span class="pp-flow-dot" aria-hidden="true"></span>
+                <span class="pp-flow-label">{{ step.label }}</span>
+              </li>
+              <li
+                v-if="idx < workflowChain.length - 1"
+                :class="['pp-flow-link', { 'pp-flow-link--done': step.state === 'done' }]"
+                aria-hidden="true"
+              ></li>
+            </template>
+          </ol>
+
+          <div class="pp-work-foot">
+            <span class="pp-work-foot-check" aria-hidden="true">✓</span>
+            <span class="pp-work-foot-text">
+              已完成 {{ doneCount }} / {{ workflowChain.length }} 步骤
+            </span>
+          </div>
+        </div>
+
+        <!-- History strip — independent of the work card so the user keeps
+             both the timeline summary AND a quick switcher for prior takes.
+             Hidden when only the current video exists (length === 1). -->
         <div v-if="allVideoUrls.length > 1" class="pp-history">
           <div class="pp-history-header">
             <span class="pp-history-title">历史视频</span>
@@ -46,16 +86,67 @@
             </button>
           </div>
         </div>
-        <div v-else class="pp-trail">
-          <div class="pp-trail-icon" aria-hidden="true">
-            <span class="pp-trail-book"></span>
-            <span class="pp-trail-play"></span>
-            <span class="pp-trail-star pp-trail-star--a"></span>
-            <span class="pp-trail-star pp-trail-star--b"></span>
+      </template>
+
+      <!-- ════ A2: Workflow running but no current video on screen.
+           Without this branch, B (history grid) wins and the user loses
+           any visual of the active workflow progress. ════ -->
+      <template v-else-if="workInProgress">
+        <div class="pp-work">
+          <div class="pp-work-head">
+            <div class="pp-work-head-left">
+              <div class="pp-work-eyebrow">本轮生成</div>
+              <div class="pp-work-filename">{{ statusLabel || '正在运行 Workflow' }}</div>
+            </div>
+            <span class="pp-work-badge pp-work-badge--live">
+              <span class="pp-work-badge-dot" aria-hidden="true"></span>
+              生成中 · 工作流
+            </span>
           </div>
-          <div class="pp-trail-copy">
-            <div class="pp-trail-title">创作记录将在这里沉淀</div>
-            <p class="pp-trail-desc">继续生成后，分镜、画面、配音与字幕将在这里形成完整创作记录。</p>
+
+          <ol class="pp-work-flow" aria-label="生成链路">
+            <template v-for="(step, idx) in workflowChain" :key="step.id">
+              <li :class="['pp-flow-node', `pp-flow-node--${step.state}`]">
+                <span class="pp-flow-dot" aria-hidden="true"></span>
+                <span class="pp-flow-label">{{ step.label }}</span>
+              </li>
+              <li
+                v-if="idx < workflowChain.length - 1"
+                :class="['pp-flow-link', { 'pp-flow-link--done': step.state === 'done' }]"
+                aria-hidden="true"
+              ></li>
+            </template>
+          </ol>
+
+          <div class="pp-work-foot">
+            <span class="pp-work-foot-check" aria-hidden="true">✓</span>
+            <span class="pp-work-foot-text">
+              已完成 {{ doneCount }} / {{ workflowChain.length }} 步骤
+            </span>
+          </div>
+        </div>
+
+        <!-- Keep the history grid below so users can still click a prior take. -->
+        <div v-if="allVideoUrls.length > 0" class="pp-hist-main">
+          <div class="pp-hist-main-header">
+            <span class="pp-hist-main-title">历史视频</span>
+            <span class="pp-hist-main-count">{{ allVideoUrls.length }} 个</span>
+          </div>
+          <div class="pp-hist-main-grid">
+            <button
+              v-for="(url, idx) in allVideoUrls"
+              :key="url"
+              class="pp-hist-card"
+              @click="selectVideo(url)"
+            >
+              <div class="pp-hist-card-frame">
+                <video class="pp-hist-card-video" :src="url" preload="metadata" :muted="true"/>
+                <div class="pp-hist-card-overlay">
+                  <span class="pp-hist-card-play">▶</span>
+                </div>
+              </div>
+              <div class="pp-hist-card-label">视频 {{ idx + 1 }}</div>
+            </button>
           </div>
         </div>
       </template>
@@ -209,6 +300,7 @@ const props = defineProps<{
   recentVideoUrls?: string[]
   renderInFlight?: boolean
   isProcessing?: boolean
+  refreshingImages?: boolean
   statusLabel?: string
   completedSteps?: number
   totalSteps?: number
@@ -263,13 +355,16 @@ function shortUrl(url: string): string {
 }
 
 // ── Processing steps ──
+// `label` is the Chinese label used by the in-progress state panel.
+// `flowLabel` is the short English caption used by the timeline rail in
+// the current-work card (a lighter, more "workflow product" feel).
 const STEP_DEFS = [
-  { id: 'story',      label: '故事生成' },
-  { id: 'storyboard', label: '分镜设计' },
-  { id: 'images',     label: '画面生成' },
-  { id: 'voice',      label: '配音生成' },
-  { id: 'subtitles',  label: '字幕生成' },
-  { id: 'video',      label: '视频合成' },
+  { id: 'story',      label: '故事生成', flowLabel: 'Story'      },
+  { id: 'storyboard', label: '分镜设计', flowLabel: 'Storyboard' },
+  { id: 'images',     label: '画面生成', flowLabel: 'Image'      },
+  { id: 'voice',      label: '配音生成', flowLabel: 'Voice'      },
+  { id: 'subtitles',  label: '字幕生成', flowLabel: 'Subtitle'   },
+  { id: 'video',      label: '视频合成', flowLabel: 'Video'      },
 ]
 
 const progressSteps = computed(() => {
@@ -282,6 +377,68 @@ const progressSteps = computed(() => {
     state: idx < activeIdx ? 'done' : idx === activeIdx ? 'active' : 'pending',
   }))
 })
+
+// Workflow chain for the current-work card — stage-aware:
+//   • renderInFlight     → all earlier steps done, video step active
+//   • refreshingImages   → story+storyboard done, image step active
+//   • isProcessing       → initial workflow run; derive from completedSteps
+//   • finalVideoUrl set  → fully done
+//   • otherwise          → derive from completedSteps / totalSteps
+// Stage indices into STEP_DEFS:
+//   0 story · 1 storyboard · 2 images · 3 voice · 4 subtitles · 5 video
+type FlowState = 'done' | 'active' | 'pending'
+
+function buildChainWithActive(activeIdx: number) {
+  return STEP_DEFS.map((step, idx) => ({
+    ...step,
+    state: (idx < activeIdx ? 'done' : idx === activeIdx ? 'active' : 'pending') as FlowState,
+  }))
+}
+
+const workflowChain = computed<{ id: string; label: string; flowLabel: string; state: FlowState }[]>(() => {
+  // Final-video render — every prior step is finished, only "视频合成" is live.
+  if (props.renderInFlight) return buildChainWithActive(5)
+
+  // Candidate image generation — Story + Storyboard are prerequisites and
+  // therefore already done; the image step is the live one.
+  if (props.refreshingImages) return buildChainWithActive(2)
+
+  // Initial workflow run — completedSteps drives the active index.
+  if (props.isProcessing) {
+    const completed = props.completedSteps ?? 0
+    const total = props.totalSteps ?? STEP_DEFS.length
+    const ratio = total > 0 ? completed / total : 0
+    const activeIdx = Math.min(
+      Math.floor(ratio * STEP_DEFS.length),
+      STEP_DEFS.length - 1,
+    )
+    return buildChainWithActive(activeIdx)
+  }
+
+  // Settled state with a finished video → mark everything done.
+  if (props.finalVideoUrl) {
+    return STEP_DEFS.map((step) => ({ ...step, state: 'done' as FlowState }))
+  }
+
+  // Idle / partial state — best-effort fallback.
+  const completed = props.completedSteps ?? 0
+  const total = props.totalSteps ?? STEP_DEFS.length
+  const ratio = total > 0 ? completed / total : 0
+  const activeIdx = Math.min(
+    Math.floor(ratio * STEP_DEFS.length),
+    STEP_DEFS.length - 1,
+  )
+  return buildChainWithActive(activeIdx)
+})
+
+// True whenever any workflow phase is in flight — drives badge wording,
+// dot pulse, and the A2 template branch in the right panel.
+const workInProgress = computed(
+  () => Boolean(props.isProcessing || props.renderInFlight || props.refreshingImages),
+)
+const doneCount = computed(
+  () => workflowChain.value.filter((s) => s.state === 'done').length,
+)
 
 </script>
 
@@ -322,8 +479,30 @@ const progressSteps = computed(() => {
 }
 
 .pp-player-wrap {
+  position: relative;
   width: 100%;
   background: #000;
+}
+/* Soft bottom gradient — frames native controls so the white progress bar
+   feels less jarring against the dark gold studio. pointer-events:none so
+   the player's hit-target is untouched. Height limited to ~52px so subtitles
+   above the controls aren't washed out. */
+.pp-player-wrap::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 52px;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(8, 5, 2, 0) 0%,
+    rgba(8, 5, 2, 0.28) 55%,
+    rgba(8, 5, 2, 0.42) 100%
+  );
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
 }
 
 .pp-video {
@@ -332,6 +511,7 @@ const progressSteps = computed(() => {
   max-height: 360px;
   object-fit: contain;
   background: #000;
+  accent-color: var(--arc-300, #fbbf24);
 }
 
 .pp-current-label {
@@ -751,94 +931,211 @@ const progressSteps = computed(() => {
 .pp-history-list::-webkit-scrollbar-track  { background: transparent; }
 .pp-history-list::-webkit-scrollbar-thumb  { background: rgba(245,158,11,0.25); border-radius: 2px; }
 
-/* ── Subtle single-video follow-up panel ── */
-.pp-trail {
-  flex: 1;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.875rem;
-  align-items: center;
-  min-height: 190px;
-  margin: 1rem 1.25rem 1.25rem;
-  padding: 1rem 1.125rem;
-  border-radius: 16px;
-  border: 1px solid rgba(245,158,11,0.12);
+/* ── Current work info + workflow summary
+   Theme-aware: all accent colours come from --arc-*, --border-glass,
+   --border-arc, --text-muted/secondary, --surface-overlay-soft. ── */
+.pp-work {
+  margin: 0.875rem 1.25rem 1.125rem;
+  padding: 0.875rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--border-glass);
   background:
-    linear-gradient(135deg, rgba(255,255,255,0.06), rgba(245,158,11,0.035)),
+    linear-gradient(135deg, rgba(255,255,255,0.04), transparent),
     var(--surface-overlay-soft);
+  min-height: 160px;
+  max-height: 220px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
 }
 
-.pp-trail-icon {
-  position: relative;
-  width: 58px;
-  height: 58px;
-  border-radius: 18px;
-  border: 1px solid rgba(245,158,11,0.16);
-  background: rgba(255,255,255,0.045);
+.pp-work-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.pp-trail-book {
-  position: absolute;
-  left: 15px;
-  top: 15px;
-  width: 26px;
-  height: 28px;
-  border: 1.5px solid var(--arc-400);
-  border-radius: 4px 8px 8px 4px;
-  opacity: 0.72;
-}
+.pp-work-head-left { min-width: 0; flex: 1; }
 
-.pp-trail-book::before {
-  content: '';
-  position: absolute;
-  left: 5px;
-  top: -1.5px;
-  width: 1.5px;
-  height: 28px;
-  background: var(--arc-400);
-  opacity: 0.35;
-}
-
-.pp-trail-play {
-  position: absolute;
-  left: 27px;
-  top: 24px;
-  width: 0;
-  height: 0;
-  border-top: 6px solid transparent;
-  border-bottom: 6px solid transparent;
-  border-left: 9px solid var(--prism-400);
-  opacity: 0.68;
-}
-
-.pp-trail-star {
-  position: absolute;
-  width: 4px;
-  height: 4px;
-  border-radius: 999px;
-  background: var(--arc-400);
-  opacity: 0.55;
-}
-
-.pp-trail-star--a { right: 11px; top: 11px; }
-.pp-trail-star--b { left: 11px; bottom: 12px; background: var(--prism-400); }
-
-.pp-trail-copy {
-  min-width: 0;
-}
-
-.pp-trail-title {
-  font-size: 0.8125rem;
+.pp-work-eyebrow {
+  font-size: 0.6875rem;
   font-weight: 700;
-  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--arc-300);
+  opacity: 0.85;
 }
 
-.pp-trail-desc {
-  margin: 0.35rem 0 0;
-  max-width: 320px;
-  font-size: 0.75rem;
-  line-height: 1.65;
+.pp-work-filename {
+  margin-top: 2px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pp-work-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-arc);
+  background: color-mix(in srgb, var(--arc-400) 10%, transparent);
+  color: var(--arc-300);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+}
+
+.pp-work-badge-dot {
+  display: inline-block;
+  width: 6px; height: 6px;
+  margin-right: 6px;
+  border-radius: 999px;
+  background: var(--arc-300);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--arc-400) 55%, transparent);
+}
+
+.pp-work-badge--live .pp-work-badge-dot {
+  animation: ppFlowPulse 1.6s ease-in-out infinite;
+}
+
+/* ═══════════════════════════════════════════════
+   Workflow Timeline — minimalist horizontal rail
+   • 6 stops along a continuous 1px gold rail
+   • Filled gold on the completed segment, faded after
+   • Short English caption below each stop
+═══════════════════════════════════════════════ */
+.pp-work-flow {
+  margin: 0;
+  padding: 8px 6px 22px;   /* bottom padding = room for absolute labels */
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.pp-flow-node {
+  position: relative;
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pp-flow-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  /* Hollow pending dot — interior uses theme glass, border uses theme accent */
+  background: var(--glass-bg);
+  border: 1.5px solid var(--border-arc);
+  box-sizing: border-box;
+  transition: background 0.2s ease, border-color 0.2s ease,
+              box-shadow 0.2s ease;
+}
+
+.pp-flow-node--done .pp-flow-dot {
+  background: var(--arc-300);
+  border-color: var(--arc-300);
+}
+
+.pp-flow-node--active .pp-flow-dot {
+  background: var(--arc-300);
+  border-color: var(--arc-300);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--arc-300) 20%, transparent),
+    0 0 10px color-mix(in srgb, var(--arc-300) 45%, transparent);
+  animation: ppFlowPulse 1.8s ease-in-out infinite;
+}
+
+.pp-flow-label {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
   color: var(--text-muted);
+  white-space: nowrap;
+  transition: color 0.2s ease;
+  font-feature-settings: "ss01" on;
+}
+
+.pp-flow-node--done .pp-flow-label {
+  color: color-mix(in srgb, var(--arc-300) 70%, transparent);
+}
+
+.pp-flow-node--active .pp-flow-label {
+  color: var(--arc-200);
+  font-weight: 600;
+}
+
+.pp-flow-link {
+  flex: 1;
+  min-width: 14px;
+  height: 1px;
+  background: var(--border-glass);
+  transition: background 0.25s ease;
+}
+
+.pp-flow-link--done {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--arc-300) 50%, transparent) 0%,
+    color-mix(in srgb, var(--arc-300) 50%, transparent) 80%,
+    color-mix(in srgb, var(--arc-300) 22%, transparent) 100%
+  );
+}
+
+@keyframes ppFlowPulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 3px color-mix(in srgb, var(--arc-300) 18%, transparent),
+      0 0 8px  color-mix(in srgb, var(--arc-300) 32%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 4px color-mix(in srgb, var(--arc-300) 28%, transparent),
+      0 0 14px color-mix(in srgb, var(--arc-300) 55%, transparent);
+  }
+}
+
+/* ── Footer summary ── */
+.pp-work-foot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.pp-work-foot-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border-arc);
+  background: color-mix(in srgb, var(--arc-400) 8%, transparent);
+  color: var(--arc-300);
+  font-size: 0.625rem;
+  font-weight: 700;
+}
+
+.pp-work-foot-text {
+  letter-spacing: 0.04em;
 }
 
 /* Pearl Dawn: refined acrylic preview surface */
@@ -862,6 +1159,16 @@ const progressSteps = computed(() => {
     0 8px 28px rgba(142,197,255,0.08),
     inset 0 1px 0 rgba(255,255,255,0.82);
 }
+/* Pearl theme — overlay is much lighter so the bright canvas stays bright. */
+:global(:root[data-theme="pearl"]) .pp-player-wrap::after {
+  height: 44px;
+  background: linear-gradient(
+    180deg,
+    rgba(46, 42, 34, 0) 0%,
+    rgba(46, 42, 34, 0.10) 60%,
+    rgba(46, 42, 34, 0.16) 100%
+  );
+}
 
 :global(:root[data-theme="pearl"]) .pp-current-label {
   background:
@@ -880,7 +1187,7 @@ const progressSteps = computed(() => {
     inset 0 1px 0 rgba(255,255,255,0.78);
 }
 
-:global(:root[data-theme="pearl"]) .pp-trail,
+:global(:root[data-theme="pearl"]) .pp-work,
 :global(:root[data-theme="pearl"]) .pp-empty {
   background:
     radial-gradient(circle at 12% 18%, rgba(246, 222, 166, 0.20), transparent 28%),
@@ -895,24 +1202,14 @@ const progressSteps = computed(() => {
 }
 
 :global(:root[data-theme="pearl"]) .pp-empty {
-  /* margin: 1rem 1.25rem 1.25rem; */
   border-radius: 18px;
 }
 
-:global(:root[data-theme="pearl"]) .pp-trail-icon {
-  background:
-    linear-gradient(145deg, rgba(255,255,255,0.78), rgba(238,247,255,0.44));
-  border-color: rgba(214,179,90,0.22);
-  box-shadow:
-    0 12px 30px rgba(46,42,34,0.06),
-    inset 0 1px 0 rgba(255,255,255,0.82);
+/* Pearl-only refinement — filename gets darker on the white surface to
+   keep text contrast (other states now flow from --arc-* tokens directly). */
+:global(:root[data-theme="pearl"]) .pp-work-filename {
+  color: rgba(46,42,34,0.92);
 }
-
-:global(:root[data-theme="pearl"]) .pp-trail-title {
-  color: rgba(46,42,34,0.82);
-}
-
-:global(:root[data-theme="pearl"]) .pp-trail-desc,
 :global(:root[data-theme="pearl"]) .pp-current-url {
   color: rgba(111,106,95,0.76);
 }

--- a/frontend/src/components/studio/ThemedSelect.vue
+++ b/frontend/src/components/studio/ThemedSelect.vue
@@ -1,0 +1,297 @@
+<template>
+  <div class="ts-select" v-click-outside="close">
+    <button
+      ref="triggerRef"
+      type="button"
+      class="ts-trigger"
+      :aria-expanded="open"
+      aria-haspopup="listbox"
+      @click="toggle"
+    >
+      <span class="ts-current">{{ currentLabel }}</span>
+      <svg class="ts-chev" :class="{ 'is-open': open }" width="12" height="8" viewBox="0 0 12 8" fill="none">
+        <path d="M1 1 L6 6 L11 1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+
+    <Teleport to="body">
+      <transition name="ts-fade">
+        <ul
+          v-if="open"
+          ref="panelRef"
+          class="ts-panel"
+          role="listbox"
+          :style="panelStyle"
+        >
+          <li
+            v-for="opt in options"
+            :key="opt.value"
+            role="option"
+            :aria-selected="opt.value === modelValue"
+            :class="['ts-option', { 'is-active': opt.value === modelValue }]"
+            @click="select(opt.value)"
+          >
+            <span class="ts-option-label">{{ opt.label }}</span>
+            <svg
+              v-if="opt.value === modelValue"
+              class="ts-option-check"
+              width="12" height="12" viewBox="0 0 12 12" fill="none"
+            >
+              <path d="M2 6 L5 9 L10 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </li>
+        </ul>
+      </transition>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, type Directive } from 'vue'
+
+type Option = { value: string; label: string }
+
+const props = defineProps<{
+  modelValue: string
+  options: Option[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: string): void
+}>()
+
+const open = ref(false)
+const triggerRef = ref<HTMLButtonElement | null>(null)
+const panelRef = ref<HTMLUListElement | null>(null)
+const panelStyle = ref<Record<string, string>>({})
+
+const currentLabel = computed(() => {
+  const match = props.options.find((o) => o.value === props.modelValue)
+  return match ? match.label : props.modelValue
+})
+
+function recalcPosition() {
+  if (!triggerRef.value) return
+  const rect = triggerRef.value.getBoundingClientRect()
+  panelStyle.value = {
+    position: 'fixed',
+    top: `${rect.bottom + 6}px`,
+    left: `${rect.left}px`,
+    width: `${rect.width}px`,
+  }
+}
+
+async function toggle() {
+  if (open.value) {
+    close()
+    return
+  }
+  recalcPosition()
+  open.value = true
+  await nextTick()
+  // Re-measure after panel rendered (in case fonts/scrollbar shift sizes)
+  recalcPosition()
+}
+
+function close() {
+  open.value = false
+}
+
+function select(v: string) {
+  if (v !== props.modelValue) emit('update:modelValue', v)
+  close()
+}
+
+// Close on scroll / resize — fixed position panel wouldn't follow trigger
+function onScrollOrResize() {
+  if (open.value) close()
+}
+window.addEventListener('scroll', onScrollOrResize, true)
+window.addEventListener('resize', onScrollOrResize)
+
+onBeforeUnmount(() => {
+  window.removeEventListener('scroll', onScrollOrResize, true)
+  window.removeEventListener('resize', onScrollOrResize)
+})
+
+// Click-outside directive
+const vClickOutside: Directive<HTMLElement, () => void> = {
+  mounted(el, binding) {
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (el.contains(target)) return
+      // panel lives in body via Teleport; treat clicks inside it as inside
+      if (panelRef.value && panelRef.value.contains(target)) return
+      binding.value()
+    }
+    ;(el as HTMLElement & { __co?: (e: MouseEvent) => void }).__co = handler
+    document.addEventListener('mousedown', handler)
+  },
+  unmounted(el) {
+    const handler = (el as HTMLElement & { __co?: (e: MouseEvent) => void }).__co
+    if (handler) document.removeEventListener('mousedown', handler)
+  },
+}
+</script>
+
+<style scoped>
+.ts-select {
+  position: relative;
+  width: 100%;
+}
+
+/* ── Trigger (looks like .input) ── */
+.ts-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--input-border, rgba(255,255,255,0.08));
+  background: var(--input-bg, rgba(4,8,22,0.55));
+  color: var(--text-primary, rgba(255,255,255,0.95));
+  font-family: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background 0.2s, box-shadow 0.15s;
+}
+
+.ts-trigger:hover {
+  border-color: var(--input-focus-border, rgba(245,158,11,0.50));
+}
+
+.ts-trigger[aria-expanded='true'] {
+  border-color: var(--input-focus-border, rgba(245,158,11,0.50));
+  box-shadow: var(--input-focus-shadow, 0 0 0 3px rgba(245,158,11,0.10));
+}
+
+.ts-current {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ts-chev {
+  flex-shrink: 0;
+  color: var(--arc-300, #fbbf24);
+  transition: transform 0.22s ease;
+}
+.ts-chev.is-open {
+  transform: rotate(180deg);
+}
+</style>
+
+<style>
+/* ───────── Global (un-scoped) for teleported panel ───────── */
+.ts-panel {
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  border-radius: 12px;
+  background: var(--glass-bg-light, rgba(20,16,8,0.94));
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  border: 1px solid var(--border-glass, rgba(245,158,11,0.18));
+  box-shadow:
+    0 16px 44px rgba(0,0,0,0.55),
+    inset 0 1px 0 rgba(255,255,255,0.08);
+  z-index: 9999;
+  max-height: 280px;
+  overflow-y: auto;
+  font-family: Inter, 'SF Pro Display', system-ui, sans-serif;
+  font-size: 0.875rem;
+}
+
+.ts-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  color: var(--text-secondary, rgba(255,255,255,0.72));
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.ts-option:hover {
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--text-primary, rgba(255,255,255,0.95));
+}
+
+.ts-option.is-active {
+  background: rgba(245, 158, 11, 0.14);
+  color: var(--arc-300, #fbbf24);
+  font-weight: 600;
+}
+
+.ts-option-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ts-option-check {
+  flex-shrink: 0;
+  color: var(--arc-300, #fbbf24);
+}
+
+/* Pearl theme — light glass panel */
+:root[data-theme="pearl"] .ts-panel {
+  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(214, 179, 90, 0.30);
+  box-shadow:
+    0 18px 48px rgba(120, 90, 50, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+}
+
+:root[data-theme="pearl"] .ts-option {
+  color: rgba(50, 44, 34, 0.78);
+}
+
+:root[data-theme="pearl"] .ts-option:hover {
+  background: rgba(214, 179, 90, 0.10);
+  color: #2E2A22;
+}
+
+:root[data-theme="pearl"] .ts-option.is-active {
+  background: rgba(214, 179, 90, 0.18);
+  color: #8b6722;
+}
+
+:root[data-theme="pearl"] .ts-option-check {
+  color: #b8843e;
+}
+
+/* Fade animation */
+.ts-fade-enter-active,
+.ts-fade-leave-active {
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+.ts-fade-enter-from,
+.ts-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>
+
+<style scoped>
+/* Pearl theme — scoped overrides for trigger */
+:global(:root[data-theme="pearl"]) .ts-trigger {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(214, 179, 90, 0.26);
+  color: #2E2A22;
+}
+
+:global(:root[data-theme="pearl"]) .ts-chev {
+  color: #b8843e;
+}
+</style>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -66,6 +66,34 @@
   --cta-shadow:       0 6px 22px rgba(245,158,11,0.45), inset 0 1px 0 rgba(255,255,255,0.20);
   --cta-shadow-hover: 0 8px 28px rgba(245,158,11,0.60), inset 0 1px 0 rgba(255,255,255,0.25);
 
+  /* Primary action (开始创作) — black-gold glass, gold reserved for
+     edges + tail accent. Theme-aware: each theme overrides these tokens. */
+  --primary-action-bg: linear-gradient(
+    135deg,
+    rgba(10, 8, 4, 0.96)   0%,
+    rgba(28, 20, 8, 0.94) 42%,
+    rgba(82, 56, 18, 0.78) 76%,
+    rgba(164, 116, 34, 0.50) 100%
+  );
+  --primary-action-bg-hover: linear-gradient(
+    135deg,
+    rgba(14, 10, 4, 0.96)   0%,
+    rgba(34, 24, 10, 0.94) 42%,
+    rgba(98, 66, 22, 0.82) 76%,
+    rgba(190, 138, 42, 0.58) 100%
+  );
+  --primary-action-border:       rgba(224, 180, 82, 0.32);
+  --primary-action-border-hover: rgba(232, 192, 96, 0.48);
+  --primary-action-text:         rgba(255, 238, 190, 0.96);
+  --primary-action-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.30),
+    0 0 0 1px rgba(246, 203, 101, 0.08),
+    inset 0 1px 0 rgba(255, 238, 180, 0.12);
+  --primary-action-shadow-hover:
+    0 14px 32px rgba(0, 0, 0, 0.36),
+    0 0 0 1px rgba(246, 203, 101, 0.14),
+    inset 0 1px 0 rgba(255, 238, 180, 0.18);
+
 
   /* Page background — themeable via overrides */
   --page-bg-color:  #09090b;
@@ -107,6 +135,33 @@
   --glow-arc:       0 0 20px rgba(14,165,233,0.50), 0 0 48px rgba(14,165,233,0.18);
   --glow-prism:     0 0 20px rgba(99,102,241,0.45), 0 0 48px rgba(99,102,241,0.15);
   --shadow-glass:   0 8px 32px rgba(0,0,0,0.55), inset 0 1px 0 rgba(14,165,233,0.06);
+
+  /* Primary action — midnight blue glass, ice-blue as accent only */
+  --primary-action-bg: linear-gradient(
+    135deg,
+    rgba(4, 8, 18, 0.96)    0%,
+    rgba(8, 18, 38, 0.94)  42%,
+    rgba(20, 70, 130, 0.66) 76%,
+    rgba(56, 156, 220, 0.38) 100%
+  );
+  --primary-action-bg-hover: linear-gradient(
+    135deg,
+    rgba(6, 10, 22, 0.96)   0%,
+    rgba(10, 24, 46, 0.94) 42%,
+    rgba(24, 84, 150, 0.72) 76%,
+    rgba(72, 178, 232, 0.46) 100%
+  );
+  --primary-action-border:       rgba(125, 211, 252, 0.34);
+  --primary-action-border-hover: rgba(125, 211, 252, 0.50);
+  --primary-action-text:         rgba(225, 245, 255, 0.96);
+  --primary-action-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.32),
+    0 0 0 1px rgba(125, 211, 252, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.10);
+  --primary-action-shadow-hover:
+    0 14px 32px rgba(0, 0, 0, 0.38),
+    0 0 0 1px rgba(125, 211, 252, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
 }
 
 :root[data-theme="purple"] {
@@ -124,6 +179,33 @@
   --glow-arc:       0 0 20px rgba(168,85,247,0.50), 0 0 48px rgba(168,85,247,0.18);
   --glow-prism:     0 0 20px rgba(244,63,94,0.45),  0 0 48px rgba(244,63,94,0.15);
   --shadow-glass:   0 8px 32px rgba(0,0,0,0.55), inset 0 1px 0 rgba(168,85,247,0.06);
+
+  /* Primary action — nebula purple glass, violet-pink as accent only */
+  --primary-action-bg: linear-gradient(
+    135deg,
+    rgba(10, 4, 18, 0.96)   0%,
+    rgba(22, 10, 42, 0.94) 42%,
+    rgba(78, 28, 132, 0.66) 76%,
+    rgba(168, 116, 232, 0.40) 100%
+  );
+  --primary-action-bg-hover: linear-gradient(
+    135deg,
+    rgba(14, 6, 22, 0.96)   0%,
+    rgba(30, 14, 52, 0.94) 42%,
+    rgba(96, 36, 158, 0.72) 76%,
+    rgba(192, 138, 250, 0.48) 100%
+  );
+  --primary-action-border:       rgba(233, 213, 255, 0.32);
+  --primary-action-border-hover: rgba(233, 213, 255, 0.50);
+  --primary-action-text:         rgba(248, 235, 255, 0.96);
+  --primary-action-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.32),
+    0 0 0 1px rgba(192, 132, 252, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.10);
+  --primary-action-shadow-hover:
+    0 14px 32px rgba(0, 0, 0, 0.38),
+    0 0 0 1px rgba(192, 132, 252, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
 }
 
 /* ═══════════════════════════════════════════════
@@ -233,6 +315,29 @@
   --scrollbar-hover: rgba(200, 154, 85, 0.68);
   --selection-bg:   rgba(200, 154, 85, 0.28);
   --selection-fg:   #1c1812;
+
+  /* Primary action — light champagne for pearl dawn theme */
+  --primary-action-bg: linear-gradient(
+    135deg,
+    rgba(255, 252, 244, 0.96) 0%,
+    rgba(246, 226, 170, 0.92) 50%,
+    rgba(214, 179, 90, 0.82) 100%
+  );
+  --primary-action-bg-hover: linear-gradient(
+    135deg,
+    rgba(255, 253, 247, 0.98) 0%,
+    rgba(250, 232, 182, 0.94) 50%,
+    rgba(220, 188, 104, 0.86) 100%
+  );
+  --primary-action-border:       rgba(190, 148, 54, 0.36);
+  --primary-action-border-hover: rgba(190, 148, 54, 0.54);
+  --primary-action-text:         rgba(70, 48, 18, 0.92);
+  --primary-action-shadow:
+    0 12px 28px rgba(190, 148, 54, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.70);
+  --primary-action-shadow-hover:
+    0 14px 32px rgba(190, 148, 54, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.80);
 }
 
 :root[data-theme="pearl"] .progress-track {


### PR DESCRIPTION
## Summary
- Stage-aware Workflow Timeline on the right-side preview: active node
  tracks workflow run / image refresh / video render phases instead of
  stalling on the first step
- Theme-aware AI loading animation (pure CSS, follows --arc-* tokens)
  replaces the spinning-arc SVG during any active phase
- Primary CTA + image placeholder + final-video controls now driven by
  theme tokens — gold / blue / purple / pearl all stay coherent
- Voice mode dropdown UI: ThemedSelect + Chinese voice options, preset
  buttons hoisted out of <label> to fix click-through, character mode
  shows a routing hint
- Recent video list now persists in localStorage so prior takes survive
  page refresh (capped at 10)

## Test plan
- [ ] 切换四种主题，确认右侧 Workflow Timeline、按钮、占位图、video controls 都跟随
- [ ] 启动 workflow → 候选图阶段 → 视频渲染：右侧 timeline active 节点要分别指向 故事/画面/视频
- [ ] 候选图阶段：左侧按钮文案变 "正在生成…"
- [ ] 生成 2-3 条视频后刷新页面：历史列表仍在
- [ ] 配音模式切到 multi/character：旁白/妈妈/宝宝下拉中文标签
