### PR TITLE
feat: support cancellable workflow execution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,13 @@ from app.schemas.workflow import (
     WorkflowRunRequest,
     WorkflowRunResponse,
 )
+from app.services.cancellation import (
+    clear as _clear_cancel,
+    is_cancelled as _is_cancelled,
+    request_cancel as _request_cancel,
+)
 from app.services.runner import UnknownStepError, WorkflowRunner
+from app.services.runner_errors import WorkflowCancelledError
 
 app = FastAPI(title="jinsie-multimodal-generation-workflow", version="0.1.0")
 
@@ -165,16 +171,34 @@ def run_workflow(req: dict = Body(...)):
         with open(_workflow_outputs_path(workflow_id), "w", encoding="utf-8") as f:
             json.dump(outputs, f, ensure_ascii=False, indent=2)
         _write_workflow_status(workflow_id, "completed")
+        _clear_cancel(workflow_id)
         print(f"[AsyncRunner] workflow {workflow_id} completed.")
 
     def on_error(error: Exception):
+        # Distinguish user-initiated cancel from real failures so the
+        # client can tell them apart in the status UI.
+        if isinstance(error, WorkflowCancelledError):
+            _write_workflow_status(
+                workflow_id,
+                "cancelled",
+                detail={"message": "user cancelled"},
+            )
+            _clear_cancel(workflow_id)
+            print(f"[AsyncRunner] workflow {workflow_id} cancelled by user.")
+            return
         _write_workflow_status(
             workflow_id,
             "failed",
             detail={"message": str(error) or error.__class__.__name__},
         )
+        _clear_cancel(workflow_id)
 
     def on_progress(progress: dict):
+        # A cancel request might land before the runner reaches its next
+        # checkpoint — keep the file status as "cancel_requested" rather
+        # than letting later progress events overwrite it.
+        if _is_cancelled(workflow_id):
+            return
         _write_workflow_status(workflow_id, "processing", detail=progress)
 
     _runner._run_async(
@@ -185,6 +209,47 @@ def run_workflow(req: dict = Body(...)):
     )
 
     return {"workflow_id": workflow_id, "status": "processing"}
+
+
+@app.post("/v1/workflow/cancel")
+def cancel_workflow(req: dict = Body(...)):
+    """Mark an in-flight workflow for cancellation.
+
+    The runner polls the cancellation registry at each step boundary and
+    raises WorkflowCancelledError when the flag is set. This endpoint
+    only flips the flag and reflects the request in the status file;
+    actual cancellation takes effect at the next checkpoint, so the UI
+    should show "cancel_requested" until the runner reaches one.
+    """
+    workflow_id = str(req.get("workflow_id") or "").strip()
+    if not workflow_id:
+        raise HTTPException(status_code=400, detail="workflow_id is required")
+
+    # If the workflow already settled, there's nothing to cancel.
+    status_path = _workflow_status_path(workflow_id)
+    if status_path.exists():
+        try:
+            with open(status_path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+            if content:
+                existing = json.loads(content)
+                existing_status = str(existing.get("status") or "").strip().lower()
+                if existing_status in {"completed", "failed", "cancelled"}:
+                    return {
+                        "workflow_id": workflow_id,
+                        "status": existing_status,
+                        "already_settled": True,
+                    }
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    _request_cancel(workflow_id)
+    _write_workflow_status(
+        workflow_id,
+        "cancel_requested",
+        detail={"message": "user requested cancel"},
+    )
+    return {"workflow_id": workflow_id, "status": "cancel_requested"}
 
 
 @app.get("/v1/workflow/status/{workflow_id}")

--- a/app/services/cancellation.py
+++ b/app/services/cancellation.py
@@ -1,0 +1,42 @@
+"""In-memory cancellation registry for in-flight workflow runs.
+
+Lightweight by design: a thread-safe set of workflow_ids that have been
+marked for cancellation. The workflow runner polls is_cancelled() at
+step boundaries and raises WorkflowCancelledError when the flag is set.
+
+Single-process FastAPI deployment is assumed. Switch to Redis / DB if
+multi-worker deployment is ever introduced.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Set
+
+
+_lock = threading.Lock()
+_cancelled: Set[str] = set()
+
+
+def request_cancel(workflow_id: str) -> None:
+    """Mark a workflow as cancel-requested. Idempotent."""
+    if not workflow_id:
+        return
+    with _lock:
+        _cancelled.add(str(workflow_id))
+
+
+def is_cancelled(workflow_id: str) -> bool:
+    """Return True if the workflow has been marked for cancellation."""
+    if not workflow_id:
+        return False
+    with _lock:
+        return str(workflow_id) in _cancelled
+
+
+def clear(workflow_id: str) -> None:
+    """Remove the workflow from the registry (on terminal state)."""
+    if not workflow_id:
+        return
+    with _lock:
+        _cancelled.discard(str(workflow_id))

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -23,7 +23,12 @@ from app.schemas.workflow import (
 from app.services.runner_audio_render_support import RunnerAudioRenderSupport
 from app.services.runner_character_labels import RunnerCharacterLabelsSupport
 from app.services.runner_character_manifest import RunnerCharacterManifestSupport
-from app.services.runner_errors import UnknownStepError, UnknownVideoProviderError
+from app.services.cancellation import is_cancelled as _is_cancelled
+from app.services.runner_errors import (
+    UnknownStepError,
+    UnknownVideoProviderError,
+    WorkflowCancelledError,
+)
 from app.services.runner_image_asset_refs import RunnerImageAssetRefsSupport
 from app.services.runner_image_prompts_support import RunnerImagePromptsSupport
 from app.services.runner_image_review import RunnerImageReviewSupport
@@ -898,7 +903,24 @@ class WorkflowRunner:
             except Exception as error:
                 print(f"[WorkflowRunner] progress callback failed: {error}")
 
+        def _check_cancelled():
+            """Raise WorkflowCancelledError if the user has requested a
+            cancel. Best-effort persists partial outputs first so the
+            client can still see what was produced before the stop."""
+            if not _is_cancelled(req.workflow_id):
+                return
+            try:
+                out_dir = PROJECT_ROOT / "assets" / "mock" / str(req.workflow_id)
+                out_dir.mkdir(parents=True, exist_ok=True)
+                with open(out_dir / "outputs.json", "w", encoding="utf-8") as f:
+                    json.dump(aggregated_outputs, f, ensure_ascii=False, indent=2, default=str)
+            except Exception as error:  # noqa: BLE001
+                print(f"[WorkflowRunner] partial-output save on cancel failed: {error}")
+            raise WorkflowCancelledError(req.workflow_id, partial_outputs=aggregated_outputs)
+
         for step_index, step in enumerate(req.steps, start=1):
+            _check_cancelled()
+
             name = step.name.strip()
             handler = self._handlers.get(name)
             if handler is None:
@@ -914,6 +936,8 @@ class WorkflowRunner:
                 output = self._image_review.build_deferred_image_assets_output(ctx)
             else:
                 output = handler(ctx, aggregated_outputs)
+
+            _check_cancelled()
 
             step_results.append(
                 StepResult(name=name, status="COMPLETED", output=output)

--- a/app/services/runner_errors.py
+++ b/app/services/runner_errors.py
@@ -17,3 +17,14 @@ class UnknownStepError(Exception):
 class UnknownVideoProviderError(Exception):
     """Raised when a request asks for a video_provider that the runner
     does not know how to dispatch (e.g. neither mock / kling / jimeng)."""
+
+
+class WorkflowCancelledError(Exception):
+    """Raised by the workflow runner when a cancel request is observed at
+    a step boundary. Carries the workflow_id and any partial outputs that
+    were aggregated before cancellation so the caller can persist them."""
+
+    def __init__(self, workflow_id, partial_outputs=None):
+        super().__init__(f"workflow {workflow_id} cancelled")
+        self.workflow_id = workflow_id
+        self.partial_outputs = partial_outputs or {}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -279,6 +279,12 @@ const workflowRunElapsedSec = ref(0)
 const workflowStatusData = ref<WorkflowStatusResponse | null>(null)
 const resultText = ref('')
 
+// The workflow_id of the currently in-flight run — needed to POST cancel.
+const activeWorkflowId = ref<string>('')
+// True after user clicks cancel and before the runner reaches its next
+// checkpoint; UI flips button text to "正在取消…".
+const cancelRequested = ref(false)
+
 const storyText = ref('')
 const storyboardText = ref('')
 const imagePromptsText = ref('')
@@ -711,7 +717,30 @@ function formatElapsedTime(totalSec: number): string {
   return `${minutes} 分 ${seconds} 秒`
 }
 
+// Single source of truth for the workflow lifecycle. Components downstream
+// (CTA, progress bar, video preview, image review) should derive their
+// running / cancelling / idle visuals from this rather than reading the
+// individual loading / refreshing / cancelRequested refs.
+type RuntimeState = 'idle' | 'running' | 'cancelling'
+const runtimeState = computed<RuntimeState>(() => {
+  const anyRunning =
+    loading.value || refreshingImageReview.value || finalVideoRenderInFlight.value
+  if (cancelRequested.value && anyRunning) return 'cancelling'
+  if (anyRunning) return 'running'
+  return 'idle'
+})
+
+// Standard cancelling copy — every place that used to read "正在生成…"
+// during workflow run should swap to this when runtimeState === 'cancelling'.
+const cancellingLabel = '正在取消生成，等待当前步骤结束…'
+
 const workflowRunStatusMessage = computed(() => {
+  // While the user is cancelling, every running surface should reflect that
+  // single state, regardless of which step the runner is on.
+  if (runtimeState.value === 'cancelling') {
+    return cancellingLabel
+  }
+
   if (!workflowIsProcessing.value) {
     return ''
   }
@@ -737,6 +766,30 @@ const workflowRunStatusMessage = computed(() => {
 
   return `Workflow 仍在运行，已等待 ${elapsed}。${stepCopy}真实接口较慢时可能需要几分钟，请保持页面打开。`
 })
+
+// Unified cleanup invoked when the server confirms a workflow has been
+// cancelled (status === 'cancelled'). Brings every running indicator back
+// to idle so the UI no longer needs a page refresh after a cancel.
+function resetWorkflowRuntimeState() {
+  loading.value = false
+  cancelRequested.value = false
+  activeWorkflowId.value = ''
+  finalVideoRenderInFlight.value = false
+  finalVideoRendering.value = false
+  refreshingImageReview.value = false
+  workflowRunElapsedSec.value = 0
+  workflowStatusData.value = null
+  currentWorkflowResponse.value = null
+  imageReviewRefreshCancelled.value = false
+  sceneRefreshQueue.value = []
+  sceneRefreshingId.value = ''
+  clearImageReviewAutoRefreshTimer()
+  try {
+    localStorage.removeItem(STORAGE_KEY_WORKFLOW)
+  } catch {
+    /* localStorage unavailable — best-effort */
+  }
+}
 
 const workflowStatusProgress = computed(() => {
   const progress = workflowStatusData.value?.progress_percent
@@ -1584,6 +1637,32 @@ async function enhanceImageReviewScene(sceneId: string) {
   }
 }
 
+async function cancelWorkflow() {
+  // Cancellation only makes sense while a run is actually in flight and
+  // we know which workflow_id to target. Re-clicking the button has no
+  // additional effect — the registry is idempotent.
+  const workflowId = activeWorkflowId.value
+  if (!workflowId || cancelRequested.value) {
+    return
+  }
+  cancelRequested.value = true
+  try {
+    await fetch(`${apiBaseUrl}/v1/workflow/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workflow_id: workflowId }),
+    })
+    // Don't flip loading off here — the polling loop will see the status
+    // turn 'cancelled' once the runner reaches its next checkpoint and
+    // resolve the run normally.
+  } catch (error) {
+    // Network failure shouldn't lock the UI; allow the user to retry.
+    cancelRequested.value = false
+    errorMessage.value =
+      error instanceof Error ? `取消失败：${error.message}` : '取消失败'
+  }
+}
+
 function cancelImageReviewRefresh() {
   if (!refreshingImageReview.value) {
     return
@@ -1751,8 +1830,19 @@ async function waitForAsyncWorkflowOutputs(
     workflowStatusData.value = statusData
     const status = String(statusData.status || '').trim().toLowerCase()
 
-    if (status === 'processing') {
+    if (status === 'processing' || status === 'cancel_requested') {
+      // Either still working or waiting for the next checkpoint to honour
+      // the cancel — keep polling until we reach a terminal state.
       continue
+    }
+
+    if (status === 'cancelled') {
+      // Soft-terminate: don't throw (cancel isn't an error). Unify the UI
+      // back to idle here so every running surface — top progress bar,
+      // CTA, timeline, video preview, image review — drops "生成中"
+      // without waiting for a page refresh.
+      resetWorkflowRuntimeState()
+      return null
     }
 
     if (status === 'failed') {
@@ -2003,6 +2093,8 @@ async function runWorkflow() {
 
   // ✅ 点击 Run 立刻给 UI 反馈（跨 tab 都能感知）
   loading.value = true
+  activeWorkflowId.value = workflowId
+  cancelRequested.value = false
   workflowRunElapsedSec.value = 0
   workflowStatusData.value = {
     workflow_id: workflowId,
@@ -2052,6 +2144,8 @@ async function runWorkflow() {
     errorMessage.value = error instanceof Error ? error.message : 'Request failed'
   } finally {
     loading.value = false
+    activeWorkflowId.value = ''
+    cancelRequested.value = false
   }
 }
 </script>
@@ -2063,11 +2157,14 @@ async function runWorkflow() {
         :visible="workflowIsProcessing || refreshingImageReview"
         :percent="workflowStatusProgress ?? (refreshingImageReview ? reviewRefreshProgress.percent : 0)"
         :label="workflowIsProcessing ? workflowRunStatusMessage : reviewRefreshProgress.text"
+        :cancellable="Boolean(activeWorkflowId)"
+        :cancel-requested="cancelRequested"
+        @cancel="cancelWorkflow"
       />
     </template>
     <div class="studio-tab-content">
     <section v-if="activeTab === 'run'" class="studio-home-grid">
-      <StudioCreatePanel :loading="loading">
+      <StudioCreatePanel :loading="loading" :cancel-requested="cancelRequested">
         <WorkflowRunPanel
           :loading="loading || refreshingImageReview || finalVideoRenderInFlight"
           :can-submit="canSubmit"
@@ -2075,9 +2172,16 @@ async function runWorkflow() {
           :form-state="workflowForm"
           :selected-steps="selectedSteps"
           :step-options="STEP_OPTIONS"
+          :cancellable="Boolean(activeWorkflowId)"
+          :cancel-requested="cancelRequested"
+          :status-label="workflowRunStatusMessage"
+          :elapsed-sec="workflowRunElapsedSec"
+          :current-step-index="workflowStatusData?.current_step_index ?? 0"
+          :total-steps="workflowStatusData?.total_steps ?? 0"
           @update:form-state="onUpdateFormState"
           @update:selected-steps="onUpdateSelectedSteps"
           @run="runWorkflow"
+          @cancel="cancelWorkflow"
         />
       </StudioCreatePanel>
 
@@ -2090,8 +2194,11 @@ async function runWorkflow() {
         :status-label="workflowRunStatusMessage || (refreshingImageReview ? reviewRefreshProgress.text : '')"
         :completed-steps="workflowStatusData?.completed_steps ?? 0"
         :total-steps="workflowStatusData?.total_steps ?? 0"
+        :cancellable="Boolean(activeWorkflowId)"
+        :cancel-requested="cancelRequested"
         :example-topics="EXAMPLE_TOPICS"
         @set-topic="setExampleTopic"
+        @cancel="cancelWorkflow"
       />
     </section>
       <section v-if="activeTab === 'review'" class="review-layout">
@@ -2121,6 +2228,7 @@ async function runWorkflow() {
                 :render-in-flight="finalVideoRenderInFlight"
                 :loading="workflowIsProcessing || refreshingImageReview || finalVideoRenderInFlight"
                 :refreshing-images="refreshingImageReview"
+                :cancel-requested="cancelRequested"
                 :error-message="errorMessage"
                 :workflow-status-message="workflowRunStatusMessage"
                 :workflow-status-progress="workflowStatusProgress"
@@ -2148,7 +2256,11 @@ async function runWorkflow() {
               <div class="review-section-header">
                 <span class="review-section-icon" aria-hidden="true">◈</span>
                 <span class="review-section-title">画面审核</span>
-                <span v-if="refreshingImageReview" class="badge badge-arc" style="font-size:0.6rem;">生成中</span>
+                <span
+                  v-if="refreshingImageReview || cancelRequested"
+                  class="badge badge-arc"
+                  style="font-size:0.6rem;"
+                >{{ cancelRequested ? '取消中' : '生成中' }}</span>
               </div>
               <div class="review-images-body">
                 <InteractiveImageReview
@@ -2157,13 +2269,16 @@ async function runWorkflow() {
                   :api-base-url="apiBaseUrl"
                   :loading="loading || refreshingImageReview"
                   :selecting-scene-id="selectingSceneId || sceneRefreshingId"
-                  :progress-text="reviewRefreshProgress.text"
+                  :progress-text="cancelRequested ? cancellingLabel : reviewRefreshProgress.text"
                   :progress-percent="reviewRefreshProgress.percent"
                   :can-cancel="refreshingImageReview"
+                  :cancel-requested="cancelRequested"
+                  :cancellable="Boolean(activeWorkflowId)"
                   @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
                   @retry-scene="retryImageReviewScene"
                   @enhance-scene="enhanceImageReviewScene"
                   @cancel-refresh="cancelImageReviewRefresh"
+                  @cancel-workflow="cancelWorkflow"
                 />
               </div>
             </div>

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -75,6 +75,7 @@ const props = defineProps<{
   renderInFlight: boolean
   loading: boolean
   refreshingImages?: boolean   // true when image review refresh is running (top bar already covers it)
+  cancelRequested?: boolean    // user has clicked "取消生成"; overrides running titles
   errorMessage?: string
   workflowStatusMessage?: string
   workflowStatusProgress?: number | null
@@ -167,6 +168,10 @@ const progressPct = computed(() => {
 })
 
 const progressLabel = computed(() => {
+  // Cancel state wins over every "running" label so the user doesn't see
+  // contradictory progress copy while the runner walks to its next
+  // checkpoint.
+  if (props.cancelRequested) return '正在取消生成…'
   if (hasBlockingError.value) return `候选图生成失败（${imageAssetCount.value}/${sceneCount.value || '?'}）`
   if (workflowInFlight.value) return '处理中…'
   if (indeterminate.value) return '准备中…'
@@ -178,6 +183,7 @@ const progressLabel = computed(() => {
 })
 
 const placeholderTitle = computed(() => {
+  if (props.cancelRequested) return '正在取消生成'
   if (hasBlockingError.value) return '候选图生成失败'
   if (workflowInFlight.value) return '正在生成分镜'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '正在生成视频'
@@ -187,6 +193,9 @@ const placeholderTitle = computed(() => {
 })
 
 const placeholderDesc = computed(() => {
+  if (props.cancelRequested) {
+    return '已发送取消请求，等待当前步骤结束后会停止后续生成。'
+  }
   if (hasBlockingError.value) {
     return blockingErrorMessage.value
   }

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import InlineStatusPulse from './studio/InlineStatusPulse.vue'
 
 type ImageAssetRef = {
   scene_id?: string
@@ -69,6 +70,13 @@ const props = defineProps<{
   progressText?: string
   progressPercent?: number
   canCancel?: boolean
+  // True after the user clicks "取消生成" on the workflow run — every
+  // "正在生成…" label inside this panel must switch to "正在取消生成…".
+  cancelRequested?: boolean
+  // True while a workflow run is still in flight at the App level. Drives
+  // the lightweight "取消生成" entry inside this panel so the user can
+  // cancel the whole workflow without leaving the review tab.
+  cancellable?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -83,6 +91,9 @@ const emit = defineEmits<{
   (e: 'retry-scene', sceneId: string): void
   (e: 'enhance-scene', sceneId: string): void
   (e: 'cancel-refresh'): void
+  // Top-level workflow cancel (uses App.vue cancelWorkflow). Distinct from
+  // 'cancel-refresh' which only stops the current image-refresh batch.
+  (e: 'cancel-workflow'): void
 }>()
 
 function toAssetHref(path?: string): string {
@@ -165,7 +176,7 @@ function onCancelRefresh() {
 
 function placeholderStatusText(state: 'waiting' | 'refreshing' | 'done' | 'failed'): string {
   if (state === 'refreshing') {
-    return '正在生成'
+    return props.cancelRequested ? '正在取消生成' : '正在生成'
   }
   if (state === 'done') {
     return '已完成'
@@ -173,12 +184,14 @@ function placeholderStatusText(state: 'waiting' | 'refreshing' | 'done' | 'faile
   if (state === 'failed') {
     return '生成失败'
   }
-  return '等待生成'
+  return props.cancelRequested ? '正在取消生成' : '等待生成'
 }
 
 function selectedStatusCopy(state: 'waiting' | 'refreshing' | 'done' | 'failed'): string {
   if (state === 'refreshing') {
-    return '正在生成当前预览图'
+    return props.cancelRequested
+      ? '正在取消生成…'
+      : '正在生成当前预览图'
   }
   if (state === 'done') {
     return '当前预览图已生成'
@@ -186,7 +199,9 @@ function selectedStatusCopy(state: 'waiting' | 'refreshing' | 'done' | 'failed')
   if (state === 'failed') {
     return '当前预览图生成失败'
   }
-  return '等待生成当前预览图'
+  return props.cancelRequested
+    ? '正在取消生成…'
+    : '等待生成当前预览图'
 }
 
 function reviewStatusLabel(status: string | undefined): string {
@@ -201,7 +216,9 @@ function reviewStatusLabel(status: string | undefined): string {
 
 function candidateStatusCopy(state: 'waiting' | 'refreshing' | 'done' | 'failed', index: 'A' | 'B'): string {
   if (state === 'refreshing') {
-    return `正在生成候选图 ${index}`
+    return props.cancelRequested
+      ? `候选图 ${index} 正在取消生成…`
+      : `正在生成候选图 ${index}`
   }
   if (state === 'done') {
     return `候选图 ${index} 已生成`
@@ -209,7 +226,9 @@ function candidateStatusCopy(state: 'waiting' | 'refreshing' | 'done' | 'failed'
   if (state === 'failed') {
     return `候选图 ${index} 生成失败`
   }
-  return `等待生成候选图 ${index}`
+  return props.cancelRequested
+    ? `候选图 ${index} 正在取消生成…`
+    : `等待生成候选图 ${index}`
 }
 
 function candidateLabel(candidate: ImageAssetRef, fallbackIndex: number): string {
@@ -305,7 +324,11 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 
     <!-- Progress text only — bar is shown in the global sticky header -->
     <div v-if="progressText" class="review-progress-inline">
-      <span class="review-progress-copy">{{ progressText }}</span>
+      <InlineStatusPulse
+        class="review-progress-copy"
+        :variant="cancelRequested ? 'cancelling' : 'running'"
+        :text="progressText"
+      />
       <button
         v-if="canCancel"
         type="button"
@@ -313,6 +336,39 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
         @click="onCancelRefresh"
       >
         停止生成
+      </button>
+      <!-- Workflow-level cancel — separate concept from canCancel (which
+           only stops the image-refresh batch). Visible whenever a workflow
+           run is still in flight. -->
+      <button
+        v-if="cancellable"
+        type="button"
+        class="cancel-workflow-link"
+        :disabled="cancelRequested"
+        @click="$emit('cancel-workflow')"
+      >
+        {{ cancelRequested ? '正在取消…' : '取消生成' }}
+      </button>
+    </div>
+
+    <!-- Lightweight workflow cancel entry shown when there's no progress
+         text (initial workflow phase before image refresh kicks in). -->
+    <div
+      v-else-if="cancellable"
+      class="review-workflow-cancel-bar"
+    >
+      <InlineStatusPulse
+        class="review-workflow-cancel-text"
+        :variant="cancelRequested ? 'cancelling' : 'running'"
+        :text="cancelRequested ? '正在取消生成，等待当前步骤结束' : '工作流运行中'"
+      />
+      <button
+        type="button"
+        class="cancel-workflow-link"
+        :disabled="cancelRequested"
+        @click="$emit('cancel-workflow')"
+      >
+        {{ cancelRequested ? '正在取消…' : '取消生成' }}
       </button>
     </div>
 
@@ -662,10 +718,10 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   >
                     {{
                       entry.state === 'refreshing'
-                        ? '生成中'
+                        ? (cancelRequested ? '取消中' : '生成中')
                         : entry.state === 'failed'
                           ? '失败'
-                          : '等待中'
+                          : (cancelRequested ? '取消中' : '等待中')
                     }}
                   </span>
                 </div>
@@ -746,10 +802,10 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                       >
                         {{
                           entry.state === 'refreshing'
-                            ? '生成中'
+                            ? (cancelRequested ? '取消中' : '生成中')
                             : entry.state === 'failed'
                               ? '失败'
-                              : '等待中'
+                              : (cancelRequested ? '取消中' : '等待中')
                         }}
                       </span>
                     </div>
@@ -802,10 +858,10 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                       >
                         {{
                           entry.state === 'refreshing'
-                            ? '生成中'
+                            ? (cancelRequested ? '取消中' : '生成中')
                             : entry.state === 'failed'
                               ? '失败'
-                              : '等待中'
+                              : (cancelRequested ? '取消中' : '等待中')
                         }}
                       </span>
                     </div>
@@ -1580,6 +1636,55 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   color: #fca5a5;
   background: rgba(248,113,133,0.08);
   transform: translateY(-1px);
+}
+
+/* Lightweight workflow-cancel pill — sits alongside / inside the inline
+   progress strip without competing with the larger image-refresh stop. */
+.cancel-workflow-link {
+  appearance: none;
+  flex-shrink: 0;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 55%, transparent);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: 4px 11px;
+  font-size: 0.6875rem;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: border-color 0.18s, color 0.18s, background 0.18s;
+}
+.cancel-workflow-link:hover:not(:disabled) {
+  border-color: rgba(248, 113, 133, 0.55);
+  color: #fca5a5;
+  background: rgba(248, 113, 133, 0.06);
+}
+.cancel-workflow-link:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+/* Independent strip shown when there's no progressText (initial workflow
+   phase before image refresh kicks in). */
+.review-workflow-cancel-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 4px 0 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-glass);
+  background: var(--surface-overlay-soft);
+}
+.review-workflow-cancel-text {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @keyframes reviewShimmer {

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import ThemedSelect from './studio/ThemedSelect.vue'
+import InlineStatusPulse from './studio/InlineStatusPulse.vue'
 
 type StepName = string
 
@@ -50,13 +51,29 @@ const props = defineProps<{
   formState: WorkflowRunFormState
   selectedSteps: StepName[]
   stepOptions: StepOption[]
+  // Optional cancellation state — App.vue passes these in while a run
+  // is in flight so the button can switch to a stoppable affordance.
+  cancellable?: boolean
+  cancelRequested?: boolean
+  statusLabel?: string
+  elapsedSec?: number
+  currentStepIndex?: number
+  totalSteps?: number
 }>()
 
 const emit = defineEmits<{
   (e: 'update:formState', v: WorkflowRunFormState): void
   (e: 'update:selectedSteps', v: StepName[]): void
   (e: 'run'): void
+  (e: 'cancel'): void
 }>()
+
+// Compact elapsed-time label for the run-state line ("1 分 24 秒" / "12 秒").
+function formatElapsedLabel(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds || 0))
+  if (total < 60) return `${total} 秒`
+  return `${Math.floor(total / 60)} 分 ${total % 60} 秒`
+}
 
 // Local-only collapse state — does NOT affect payload, just UI grouping.
 const voiceCollapsed  = ref(true)   // 配音与字幕 — default collapsed for clean first paint
@@ -485,8 +502,44 @@ function getTopicManualMismatchWarning(): string {
         :disabled="!canSubmit"
         @click="emit('run')"
       >
-        {{ loading ? '正在生成…' : '开始创作' }}
+        {{
+          cancelRequested
+            ? '正在取消生成…'
+            : loading
+              ? '正在生成…'
+              : '开始创作'
+        }}
       </button>
+
+      <!-- Inline run-state strip: current step + elapsed + cancel.
+           Shown only while a run is in flight so the form panel stays
+           compact during idle. Reuses statusLabel + workflow status data
+           from App.vue; nothing here owns workflow state. -->
+      <div v-if="loading || cancellable" class="runState">
+        <div class="runStateInfo">
+          <InlineStatusPulse
+            :variant="cancelRequested ? 'cancelling' : 'running'"
+            :text="statusLabel || '正在准备'"
+          />
+          <span
+            v-if="totalSteps && currentStepIndex"
+            class="runStateStep"
+          >{{ currentStepIndex }} / {{ totalSteps }}</span>
+          <span
+            v-if="elapsedSec !== undefined && elapsedSec > 0"
+            class="runStateElapsed"
+          >· 已等待 {{ formatElapsedLabel(elapsedSec) }}</span>
+        </div>
+        <button
+          v-if="cancellable"
+          type="button"
+          class="cancelLink"
+          :disabled="cancelRequested"
+          @click="emit('cancel')"
+        >
+          {{ cancelRequested ? '正在取消…' : '取消生成' }}
+        </button>
+      </div>
     </div>
 
     <!-- ═══════════ 渲染与输出 (collapsible) ═══════════ -->
@@ -1303,6 +1356,87 @@ select.input {
   opacity: 0.42;
   cursor: not-allowed;
   box-shadow: none;
+}
+
+/* Compact run-state strip — sits directly below the CTA. */
+.runState {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-glass);
+  background: var(--surface-overlay-soft);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.runStateInfo {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+  color: var(--text-secondary);
+}
+
+.runStateDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--arc-300);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--arc-300) 55%, transparent);
+  animation: runStatePulse 1.6s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+.runStateText {
+  color: var(--text-primary);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 240px;
+}
+
+.runStateStep {
+  color: var(--arc-300);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.runStateElapsed {
+  color: var(--text-muted);
+}
+
+.cancelLink {
+  flex-shrink: 0;
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 60%, transparent);
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.18s, color 0.18s, background 0.18s;
+}
+.cancelLink:hover:not(:disabled) {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.06);
+}
+.cancelLink:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+@keyframes runStatePulse {
+  0%, 100% { opacity: 0.55; transform: scale(0.9);  }
+  50%      { opacity: 1;    transform: scale(1.15); }
 }
 
 .hint {

--- a/frontend/src/components/studio/InlineStatusPulse.vue
+++ b/frontend/src/components/studio/InlineStatusPulse.vue
@@ -1,0 +1,113 @@
+<template>
+  <span class="inline-status" :class="`inline-status--${variant}`">
+    <span
+      v-if="variant !== 'idle'"
+      class="inline-status__dot"
+      aria-hidden="true"
+    ></span>
+    <span v-if="text" class="inline-status__text">{{ text }}</span>
+    <span
+      v-if="showDots && variant !== 'idle'"
+      class="inline-status__dots"
+      aria-hidden="true"
+    >
+      <span></span><span></span><span></span>
+    </span>
+  </span>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    variant?: 'running' | 'cancelling' | 'idle'
+    text?: string
+    showDots?: boolean
+  }>(),
+  {
+    variant: 'running',
+    text: '',
+    showDots: true,
+  },
+)
+</script>
+
+<style scoped>
+.inline-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: inherit;
+  min-width: 0;
+}
+
+.inline-status__dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  animation: inline-status-pulse 1.6s ease-in-out infinite;
+  box-shadow: 0 0 6px color-mix(in srgb, currentColor 45%, transparent);
+}
+
+.inline-status__text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  letter-spacing: 0.01em;
+}
+
+.inline-status__dots {
+  flex-shrink: 0;
+  display: inline-flex;
+  gap: 2px;
+  align-items: center;
+}
+.inline-status__dots span {
+  display: inline-block;
+  width: 3px;
+  height: 3px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.22;
+  animation: inline-status-dots 1.6s ease-in-out infinite;
+}
+.inline-status__dots span:nth-child(1) { animation-delay: 0s;    }
+.inline-status__dots span:nth-child(2) { animation-delay: 0.3s;  }
+.inline-status__dots span:nth-child(3) { animation-delay: 0.6s;  }
+
+/* ── Variants ────────────────────────────────────────────────
+   currentColor drives both the leading dot and the trailing
+   ellipsis, so changing the wrapper's color is enough to retint
+   the entire badge. ─────────────────────────────────────────── */
+.inline-status--running   { color: var(--arc-300); }
+.inline-status--cancelling { color: rgba(252, 165, 165, 0.82); }
+.inline-status--idle       { color: var(--text-muted); }
+
+.inline-status--cancelling .inline-status__text {
+  color: rgba(252, 165, 165, 0.92);
+}
+.inline-status--running .inline-status__text {
+  /* Stay readable on dark glass — text stays in the secondary copy
+     palette, while only the dot + ellipsis carry the accent hue. */
+  color: var(--text-secondary);
+}
+
+@keyframes inline-status-pulse {
+  0%, 100% { opacity: 0.50; transform: scale(0.85); }
+  50%      { opacity: 1;    transform: scale(1.15); }
+}
+@keyframes inline-status-dots {
+  0%, 60%, 100% { opacity: 0.22; }
+  20%, 40%      { opacity: 1;    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inline-status__dot,
+  .inline-status__dots span {
+    animation: none;
+  }
+}
+</style>

--- a/frontend/src/components/studio/StudioCreatePanel.vue
+++ b/frontend/src/components/studio/StudioCreatePanel.vue
@@ -3,7 +3,11 @@
     <div class="create-panel__header">
       <span class="create-panel__icon" aria-hidden="true">✦</span>
       <span class="create-panel__title">创作故事</span>
-      <span v-if="loading" class="badge badge-arc" style="font-size:0.6rem;">生成中</span>
+      <span
+        v-if="loading"
+        class="badge badge-arc"
+        style="font-size:0.6rem;"
+      >{{ cancelRequested ? '取消中' : '生成中' }}</span>
     </div>
     <div class="create-panel__body">
       <slot />
@@ -14,6 +18,7 @@
 <script setup lang="ts">
 defineProps<{
   loading?: boolean
+  cancelRequested?: boolean
 }>()
 </script>
 

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -38,7 +38,13 @@
             </div>
             <span :class="['pp-work-badge', { 'pp-work-badge--live': workInProgress }]">
               <span class="pp-work-badge-dot" aria-hidden="true"></span>
-              {{ workInProgress ? '生成中 · 工作流' : '已完成 · 完整视频' }}
+              {{
+                cancelRequested
+                  ? '取消中 · 工作流'
+                  : workInProgress
+                    ? '生成中 · 工作流'
+                    : '已完成 · 完整视频'
+              }}
             </span>
           </div>
 
@@ -61,6 +67,15 @@
             <span class="pp-work-foot-text">
               已完成 {{ doneCount }} / {{ workflowChain.length }} 步骤
             </span>
+            <button
+              v-if="cancellable"
+              type="button"
+              class="pp-cancel-link"
+              :disabled="cancelRequested"
+              @click="$emit('cancel')"
+            >
+              {{ cancelRequested ? '正在取消…' : '取消生成' }}
+            </button>
           </div>
         </div>
 
@@ -123,6 +138,15 @@
             <span class="pp-work-foot-text">
               已完成 {{ doneCount }} / {{ workflowChain.length }} 步骤
             </span>
+            <button
+              v-if="cancellable"
+              type="button"
+              class="pp-cancel-link"
+              :disabled="cancelRequested"
+              @click="$emit('cancel')"
+            >
+              {{ cancelRequested ? '正在取消…' : '取消生成' }}
+            </button>
           </div>
         </div>
 
@@ -305,10 +329,14 @@ const props = defineProps<{
   completedSteps?: number
   totalSteps?: number
   exampleTopics?: string[]
+  // Cancel affordance for the in-flight workflow (driven by App.vue).
+  cancellable?: boolean
+  cancelRequested?: boolean
 }>()
 
 defineEmits<{
   (e: 'set-topic', topic: string): void
+  (e: 'cancel'): void
 }>()
 
 // ── All unique video URLs (current first, then history) ──
@@ -1118,6 +1146,32 @@ const doneCount = computed(
   font-size: 0.7rem;
   color: var(--text-muted);
   margin-top: 2px;
+}
+
+/* Trailing "取消生成" link inside the work card foot — sits at the
+   far right (margin-left: auto) and only shows when a run is in flight. */
+.pp-cancel-link {
+  margin-left: auto;
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 55%, transparent);
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: border-color 0.18s, color 0.18s, background 0.18s;
+}
+.pp-cancel-link:hover:not(:disabled) {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.06);
+}
+.pp-cancel-link:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .pp-work-foot-check {

--- a/frontend/src/components/studio/StudioProgress.vue
+++ b/frontend/src/components/studio/StudioProgress.vue
@@ -5,16 +5,41 @@
         <div class="progress-fill" :style="{ width: `${Math.min(100, percent)}%` }" />
       </div>
       <span class="studio-progress__pct">{{ Math.round(percent) }}%</span>
+      <!-- Global cancel entry — visible on every tab whenever a workflow
+           run is in flight. Reuses cancelWorkflow via @cancel emit; pure
+           UI, no new state. -->
+      <button
+        v-if="cancellable"
+        type="button"
+        class="studio-progress__cancel"
+        :disabled="cancelRequested"
+        @click="$emit('cancel')"
+      >
+        {{ cancelRequested ? '正在取消…' : '取消' }}
+      </button>
     </div>
-    <span v-if="label" class="studio-progress__label">{{ label }}</span>
+    <InlineStatusPulse
+      v-if="label"
+      class="studio-progress__label"
+      :variant="cancelRequested ? 'cancelling' : 'running'"
+      :text="label"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import InlineStatusPulse from './InlineStatusPulse.vue'
+
 defineProps<{
   percent: number
   label?: string
   visible?: boolean
+  cancellable?: boolean
+  cancelRequested?: boolean
+}>()
+
+defineEmits<{
+  (e: 'cancel'): void
 }>()
 </script>
 
@@ -57,6 +82,31 @@ defineProps<{
   font-size: 0.6875rem;
   color: var(--text-muted);
   letter-spacing: 0.03em;
+}
+
+/* Lightweight cancel link on the right of the global progress bar. */
+.studio-progress__cancel {
+  flex-shrink: 0;
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 55%, transparent);
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: border-color 0.18s, color 0.18s, background 0.18s;
+}
+.studio-progress__cancel:hover:not(:disabled) {
+  border-color: rgba(248, 113, 133, 0.55);
+  color: #fca5a5;
+  background: rgba(248, 113, 133, 0.06);
+}
+.studio-progress__cancel:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 .studio-progress--complete .progress-fill {
   background: linear-gradient(90deg, #34d399 0%, var(--arc-400) 100%);


### PR DESCRIPTION
## Summary

This PR adds end-to-end workflow cancellation support for the AI story-to-video generation workflow.

It covers backend cancellation state management, runner checkpoint cancellation, frontend runtime state synchronization, cross-tab cancel entry points, and lightweight animated status feedback for running/cancelling states.

## Changes

### Backend

- Add an in-memory thread-safe workflow cancellation registry.
- Add `WorkflowCancelledError` for controlled cancellation exits.
- Add `POST /v1/workflow/cancel`.
- Add runner checkpoint checks before and after workflow steps.
- Preserve partial outputs before raising cancellation.
- Clear cancellation registry when workflow reaches a terminal state.

### Frontend

- Add unified runtime state handling for `running`, `cancelling`, and `idle`.
- Treat `cancel_requested` as a non-terminal state and keep polling.
- Treat `cancelled` as a normal terminal state without surfacing an error.
- Reset all runtime state after cancellation completes.
- Add cancel entry points across:
  - Create panel
  - Global progress bar
  - Image review waiting/progress states
- Keep image-review batch cancellation separate from workflow-level cancellation.
- Add `InlineStatusPulse` for lightweight animated running/cancelling feedback.

## UX Behavior

- During workflow execution, users can cancel from the create panel, global progress bar, or image review state.
- After cancel is requested, all panels switch to cancelling copy such as:
  - `正在取消生成…`
  - `正在取消生成，等待当前步骤结束…`
- The UI keeps polling until the runner reaches the next checkpoint.
- Once backend status becomes `cancelled`, the frontend resets automatically without requiring page refresh.

## Validation

- `npm --prefix frontend run check`
- Frontend vue-tsc passed
- Vite build passed
- Acceptance voice check passed
- Backend cancel endpoint state machine verified
- Runner checkpoint cancellation verified with `WorkflowCancelledError`

## Notes

- Cancellation takes effect at workflow step boundaries.
- Long-running provider calls may still finish before the runner reaches the next checkpoint.
- The current cancellation registry is in-process and suitable for single-worker local deployment.
- Multi-worker deployment can later replace it with Redis or a task queue backed cancellation registry.