### PR TITLE
fix(studio): discard draft clears all runtime state

### DIFF
--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -827,6 +827,10 @@ const workflowRunStatusMessage = computed(() => {
 // Unified cleanup invoked when the server confirms a workflow has been
 // cancelled (status === 'cancelled'). Brings every running indicator back
 // to idle so the UI no longer needs a page refresh after a cancel.
+// NOTE: text fields / reviewPlaceholders / payload are intentionally NOT
+// wiped here — after a cancel the user still needs to see what was
+// produced so they can decide between "立即生成候选图" (resume) and
+// "放弃当前生成" (full reset via performDiscardCurrentDraft).
 function resetWorkflowRuntimeState() {
   loading.value = false
   cancelRequested.value = false
@@ -838,9 +842,13 @@ function resetWorkflowRuntimeState() {
   workflowStatusData.value = null
   currentWorkflowResponse.value = null
   imageReviewRefreshCancelled.value = false
+  imageRefreshPausedByUser.value = false
   sceneRefreshQueue.value = []
   sceneRefreshingId.value = ''
+  selectingSceneId.value = ''
   clearImageReviewAutoRefreshTimer()
+  imageReviewRefreshAbortController?.abort()
+  imageReviewRefreshAbortController = null
   try {
     localStorage.removeItem(STORAGE_KEY_WORKFLOW)
   } catch {
@@ -1902,6 +1910,9 @@ function performDiscardCurrentDraft() {
   clearImageReviewAutoRefreshTimer()
   reviewAutoRefreshFiredOnce = false
   restoreAutoRefreshFired = false
+  // Reactive mirror — without this, the cancelled-refresh marker copy
+  // would leak into the next run's placeholder text.
+  imageRefreshPausedByUser.value = false
 
   // Wipe everything that applyWorkflowResponse populates.
   currentWorkflowResponse.value = null
@@ -1930,13 +1941,32 @@ function performDiscardCurrentDraft() {
   loading.value = false
   finalVideoRenderInFlight.value = false
   finalVideoRendering.value = false
+  // Additional in-flight UI state — without these the next run could
+  // briefly inherit the cancelled run's per-scene selection / timing.
+  workflowRunElapsedSec.value = 0
+  selectingSceneId.value = ''
+  userHasInteractedWithImages.value = false
+  mockAudioIndexUrl.value = ''
+  mockAudioSceneGroups.value = []
+  mockAudioDirectoryText.value = ''
 
-  // Clear draft-related localStorage. Preserve FORM / SESSION / TAB / DEV /
-  // RECENT_VIDEOS / LAST_VIDEO_URL — those are user-level state, not draft.
+  // Regenerate the session id. The backend's RunnerSessionStore keys
+  // its in-memory `previous_session_data` (last_story / last_storyboard /
+  // last_render_plan) by session_id; reusing the same session_id after
+  // a discard would seed the next run's session_memory_summary with the
+  // previous run's topic — the cleanest fix is to mint a fresh session
+  // on discard so the backend treats the next run as brand new.
+  workflowForm.value.sessionId = `demo-session-${Date.now().toString(36)}`
+
+  // Clear draft-related localStorage. Also clear SESSION so a page
+  // reload between discard and the next run doesn't restore the stale
+  // session id. FORM / TAB / DEV / RECENT_VIDEOS / LAST_VIDEO_URL stay
+  // (those are user-level state, not part of this draft).
   try {
     localStorage.removeItem(STORAGE_KEY_WORKFLOW)
     localStorage.removeItem(STORAGE_KEY_PAYLOAD)
     localStorage.removeItem(STORAGE_KEY_REFRESH_CANCELLED)
+    localStorage.removeItem(STORAGE_KEY_SESSION)
   } catch { /* ignore */ }
 
   // Drop the user back on 创作故事 — clean starting point for the next run.
@@ -2150,6 +2180,20 @@ async function waitForAsyncWorkflowOutputs(
 }
 
 async function runWorkflow() {
+  // Defensive belt: abort any lingering image refresh from a previous
+  // (cancelled but not discarded) run before we start a brand new one.
+  // Without this, an orphan refresh promise could resolve mid-run and
+  // overwrite the new image_review / selected_assets with stale data.
+  imageReviewRefreshAbortController?.abort()
+  imageReviewRefreshAbortController = null
+  imageReviewRefreshCancelled.value = false
+  imageRefreshPausedByUser.value = false
+  // Drop the previous run's "paused by user" marker so its presence in
+  // localStorage doesn't shape this run's UI copy.
+  try {
+    localStorage.removeItem(STORAGE_KEY_REFRESH_CANCELLED)
+  } catch { /* ignore */ }
+
   clearImageReviewAutoRefreshTimer()
   resultText.value = ''
   currentWorkflowResponse.value = null
@@ -2168,6 +2212,8 @@ async function runWorkflow() {
   narrationText.value = ''
   subtitlesText.value = ''
   renderPlanText.value = ''
+  characterCandidatesText.value = ''
+  characterManifestText.value = ''
   reviewAutoRefreshFiredOnce = false
   clearImageReviewAutoRefreshTimer()
   finalVideoText.value = ''
@@ -2175,6 +2221,12 @@ async function runWorkflow() {
   finalVideoRendering.value = false
   finalVideoRenderInFlight.value = false
   stepSummaries.value = []
+  errorMessage.value = ''
+  workflowStatusData.value = null
+  userHasInteractedWithImages.value = false
+  mockAudioIndexUrl.value = ''
+  mockAudioSceneGroups.value = []
+  mockAudioDirectoryText.value = ''
   activeTab.value = 'review'
 
   const form = workflowForm.value


### PR DESCRIPTION
## Bug

Repro:
1. Enter topic A, click 开始创作
2. While images are generating, click 取消生成
3. After cancel completes, click 放弃当前生成
4. Enter a new topic B, click 开始创作 again

Expected: B's run is brand new and only contains assets/results for B.
Actual: residual state from A's run leaks into B — the backend's
in-memory `RunnerSessionStore` still has A's `last_story / last_storyboard /
last_render_plan` keyed by the preserved session_id, and several
front-end flags (`imageRefreshPausedByUser`, `selectingSceneId`, etc.)
still hold A's values, which can briefly render old image refs in the
review tab before the new outputs land.

## Root cause

`performDiscardCurrentDraft()` cleared the obvious things (text fields,
`currentWorkflowResponse`, payload, workflow id, image refresh controller)
but **preserved `sessionId` and several minor state refs**. Since the
backend keys its in-memory `RunnerSessionStore.get_session_data()` by
`session_id`, reusing the same session id after a discard caused the
next run to inherit A's session memory.

Additionally `resetWorkflowRuntimeState()` (the cancel-confirm cleanup)
didn't abort the image-refresh `AbortController`, so an in-flight refresh
promise could still resolve and overwrite the new run's image_review.

## Fix

Patches three handlers in `StudioView.vue`:

| Handler | New behaviour |
|---|---|
| `performDiscardCurrentDraft` | Clears `imageRefreshPausedByUser`, `workflowRunElapsedSec`, `selectingSceneId`, `userHasInteractedWithImages`, `mockAudio*`. **Mints a fresh `workflowForm.sessionId` and removes `STORAGE_KEY_SESSION`** so the backend session store can't seed the next run. |
| `runWorkflow` (start) | Defensive belt: aborts any lingering image-refresh AbortController, drops `STORAGE_KEY_REFRESH_CANCELLED`, clears `imageRefreshPausedByUser / errorMessage / workflowStatusData / characterCandidatesText / characterManifestText / userHasInteractedWithImages / mockAudio*` before the new payload is built. |
| `resetWorkflowRuntimeState` | Also clears `imageRefreshPausedByUser`, `selectingSceneId`, and aborts the `imageReviewRefreshAbortController`. |

Already-correct behaviours preserved:
- `workflow_id` is regenerated per run (`storybook-demo-${Date.now()}`)
- `run_id` is generated server-side via `uuid4()` (uniqueness guaranteed)
- Backend writes outputs to `assets/mock/{workflow_id}/outputs.json` (per-run dir)
- Image generator writes to `assets/mock/image/{run_id}/` (per-run dir)

## Scope

- **Touched**: `frontend/src/views/StudioView.vue` only
- **Not touched**: `StudioView` template / business handlers / API surface / image provider / TTS / render / cancel endpoint / `RunnerSessionStore` schema / on-disk assets / router / Landing page / theme system / database / new dependencies

No on-disk files are deleted; only in-memory + localStorage state.

## Test plan

- [ ] `npm --prefix frontend run check` passes
- [ ] Enter topic A → 开始创作 → wait for images to start → 取消生成 → 放弃当前生成 → verify all panels (story / storyboard / image review / final video / step summaries) are empty
- [ ] After the above, verify `localStorage.getItem('jinsie_session_id')` returns `null`
- [ ] Enter new topic B → 开始创作 → outputs are entirely for B, no A residue in image review or storyboard
- [ ] Cancel mid-run without discarding → partial outputs remain visible (regression check: cancel must NOT wipe text fields)
- [ ] Reload the page during an in-flight run → reattaches to the same workflow_id (regression check)
- [ ] Recent-videos sidebar still shows previously completed videos (regression check: history is user-level state and must persist)
