### PR TITLE
feat(studio): v1.0 polish — history delete + config trim

### DIFF
--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -132,6 +132,28 @@ const VIDEO_PROVIDER_OPTS: EnumOption[] = [
   { value: 'mock',      label: '绘本视频模式' },
   { value: 'storybook', label: '分镜播放模式' },
 ]
+
+/* ── V1.0 visible-option whitelists ──────────────────────────────────
+   The full _OPTS arrays above stay intact so the underlying types /
+   API payload / runtime constants are unchanged; the UI just renders
+   a subset for V1.0. Re-enable an option later by adding its `value`
+   back to the matching _V1_VALUES set.
+   - output mode  : 完整视频 only (分镜预览 / 仅生成素材 隐藏)
+   - language     : 中文 only (英文 隐藏)
+   - video provider: 绘本视频模式 only (分镜播放模式 隐藏)         */
+const OUTPUT_MODE_V1_VALUES = new Set(['full_video'])
+const LANGUAGE_V1_VALUES = new Set(['zh-CN'])
+const VIDEO_PROVIDER_V1_VALUES = new Set(['mock'])
+
+const OUTPUT_MODE_OPTS_VISIBLE: EnumOption[] = OUTPUT_MODE_OPTS.filter((o) =>
+  OUTPUT_MODE_V1_VALUES.has(o.value),
+)
+const LANGUAGE_OPTS_VISIBLE: EnumOption[] = LANGUAGE_OPTS.filter((o) =>
+  LANGUAGE_V1_VALUES.has(o.value),
+)
+const VIDEO_PROVIDER_OPTS_VISIBLE: EnumOption[] = VIDEO_PROVIDER_OPTS.filter((o) =>
+  VIDEO_PROVIDER_V1_VALUES.has(o.value),
+)
 const VOICE_MODE_OPTS: EnumOption[] = [
   { value: 'single',    label: '单人旁白' },
   { value: 'multi',     label: '亲子轮流' },
@@ -628,7 +650,7 @@ function getTopicManualMismatchWarning(): string {
           <span>视频模式</span>
           <ThemedSelect
             :model-value="formState.videoProvider"
-            :options="withFallback(VIDEO_PROVIDER_OPTS, formState.videoProvider)"
+            :options="VIDEO_PROVIDER_OPTS_VISIBLE"
             @update:model-value="(v: string) => updateFormState('videoProvider', v)"
           />
         </label>
@@ -637,7 +659,7 @@ function getTopicManualMismatchWarning(): string {
           <span>输出模式</span>
           <ThemedSelect
             :model-value="formState.outputMode"
-            :options="withFallback(OUTPUT_MODE_OPTS, formState.outputMode)"
+            :options="OUTPUT_MODE_OPTS_VISIBLE"
             @update:model-value="(v: string) => updateFormState('outputMode', v)"
           />
         </label>
@@ -837,7 +859,7 @@ function getTopicManualMismatchWarning(): string {
           <span>语言</span>
           <ThemedSelect
             :model-value="formState.language"
-            :options="withFallback(LANGUAGE_OPTS, formState.language)"
+            :options="LANGUAGE_OPTS_VISIBLE"
             @update:model-value="(v: string) => updateFormState('language', v)"
           />
         </label>

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -88,17 +88,31 @@
             <span class="pp-history-count">{{ allVideoUrls.length }} 个</span>
           </div>
           <div class="pp-history-list">
-            <button
+            <div
               v-for="(url, idx) in allVideoUrls"
               :key="url"
               :class="['pp-thumb', { 'pp-thumb--active': url === displayUrl }]"
-              @click="selectVideo(url)"
-              :title="`视频 ${idx + 1}`"
             >
-              <video class="pp-thumb-video" :src="url" preload="metadata" :muted="true"/>
-              <div class="pp-thumb-overlay"><span class="pp-thumb-play">▶</span></div>
-              <div class="pp-thumb-index">{{ idx + 1 }}</div>
-            </button>
+              <button
+                type="button"
+                class="pp-thumb-main"
+                :title="`视频 ${idx + 1}`"
+                @click="selectVideo(url)"
+              >
+                <video class="pp-thumb-video" :src="url" preload="metadata" :muted="true"/>
+                <div class="pp-thumb-overlay"><span class="pp-thumb-play">▶</span></div>
+                <div class="pp-thumb-index">{{ idx + 1 }}</div>
+              </button>
+              <button
+                type="button"
+                class="pp-thumb-delete"
+                aria-label="从历史记录中删除"
+                title="从历史记录中删除"
+                @click.stop="requestDeleteVideo(url)"
+              >
+                ×
+              </button>
+            </div>
           </div>
         </div>
       </template>
@@ -157,20 +171,34 @@
             <span class="pp-hist-main-count">{{ allVideoUrls.length }} 个</span>
           </div>
           <div class="pp-hist-main-grid">
-            <button
+            <div
               v-for="(url, idx) in allVideoUrls"
               :key="url"
               class="pp-hist-card"
-              @click="selectVideo(url)"
             >
-              <div class="pp-hist-card-frame">
-                <video class="pp-hist-card-video" :src="url" preload="metadata" :muted="true"/>
-                <div class="pp-hist-card-overlay">
-                  <span class="pp-hist-card-play">▶</span>
+              <button
+                type="button"
+                class="pp-hist-card-main"
+                @click="selectVideo(url)"
+              >
+                <div class="pp-hist-card-frame">
+                  <video class="pp-hist-card-video" :src="url" preload="metadata" :muted="true"/>
+                  <div class="pp-hist-card-overlay">
+                    <span class="pp-hist-card-play">▶</span>
+                  </div>
                 </div>
-              </div>
-              <div class="pp-hist-card-label">视频 {{ idx + 1 }}</div>
-            </button>
+                <div class="pp-hist-card-label">视频 {{ idx + 1 }}</div>
+              </button>
+              <button
+                type="button"
+                class="pp-hist-card-delete"
+                aria-label="从历史记录中删除"
+                title="从历史记录中删除"
+                @click.stop="requestDeleteVideo(url)"
+              >
+                ×
+              </button>
+            </div>
           </div>
         </div>
       </template>
@@ -334,10 +362,21 @@ const props = defineProps<{
   cancelRequested?: boolean
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'set-topic', topic: string): void
   (e: 'cancel'): void
+  (e: 'delete-video', url: string): void
 }>()
+
+/* Local-only history delete. Bubbles the URL up to the parent — the
+   parent shows a themed confirm dialog (matching the rest of the app)
+   and owns the localStorage persistence. stopPropagation is on the
+   button itself in the template so the parent thumbnail click (which
+   selects/plays the video) doesn't fire. */
+function requestDeleteVideo(url: string) {
+  if (!url) return
+  emit('delete-video', url)
+}
 
 // ── All unique video URLs (current first, then history) ──
 const allVideoUrls = computed(() => {
@@ -728,18 +767,59 @@ const doneCount = computed(
 }
 
 .pp-hist-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
+  padding: 0;
+  background: transparent;
+  text-align: left;
+  transition: transform 0.18s;
+}
+.pp-hist-card:hover { transform: translateY(-2px); }
+.pp-hist-card-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
   padding: 0;
   border: none;
   background: transparent;
   cursor: pointer;
   font-family: inherit;
   text-align: left;
-  transition: transform 0.18s;
 }
-.pp-hist-card:hover { transform: translateY(-2px); }
+.pp-hist-card-delete {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid rgba(245,158,11,0.24);
+  border-radius: 999px;
+  background: rgba(8,6,3,0.78);
+  color: rgba(255,245,220,0.82);
+  font-size: 15px;
+  line-height: 1;
+  font-family: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.16s ease, background 0.16s, border-color 0.16s, color 0.16s;
+  z-index: 2;
+}
+.pp-hist-card:hover .pp-hist-card-delete,
+.pp-hist-card:focus-within .pp-hist-card-delete {
+  opacity: 1;
+}
+.pp-hist-card-delete:hover {
+  background: rgba(180,60,40,0.74);
+  border-color: rgba(245,158,11,0.50);
+  color: #fff;
+}
 
 .pp-hist-card-frame {
   position: relative;
@@ -1268,7 +1348,8 @@ const doneCount = computed(
   color: rgba(111,106,95,0.76);
 }
 
-/* Thumbnail button */
+/* Thumbnail tile (was a button — now a div wrapping a main button +
+   delete button so the × doesn't trigger the play click). */
 .pp-thumb {
   position: relative;
   flex-shrink: 0;
@@ -1278,9 +1359,48 @@ const doneCount = computed(
   overflow: hidden;
   border: 1.5px solid rgba(255,255,255,0.08);
   background: #000;
-  cursor: pointer;
-  padding: 0;
   transition: border-color 0.18s, box-shadow 0.18s, transform 0.18s;
+}
+.pp-thumb-main {
+  position: absolute;
+  inset: 0;
+  display: block;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+.pp-thumb-delete {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid rgba(245,158,11,0.22);
+  border-radius: 999px;
+  background: rgba(8,6,3,0.72);
+  color: rgba(255,245,220,0.78);
+  font-size: 14px;
+  line-height: 1;
+  font-family: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.16s ease, background 0.16s, border-color 0.16s, color 0.16s;
+  z-index: 2;
+}
+.pp-thumb:hover .pp-thumb-delete,
+.pp-thumb:focus-within .pp-thumb-delete {
+  opacity: 1;
+}
+.pp-thumb-delete:hover {
+  background: rgba(180,60,40,0.72);
+  border-color: rgba(245,158,11,0.46);
+  color: #fff;
 }
 
 .pp-thumb:hover {

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -210,20 +210,34 @@
           <span class="pp-hist-main-count">{{ allVideoUrls.length }} 个</span>
         </div>
         <div class="pp-hist-main-grid">
-          <button
+          <div
             v-for="(url, idx) in allVideoUrls"
             :key="url"
             class="pp-hist-card"
-            @click="selectVideo(url)"
           >
-            <div class="pp-hist-card-frame">
-              <video class="pp-hist-card-video" :src="url" preload="metadata" :muted="true"/>
-              <div class="pp-hist-card-overlay">
-                <span class="pp-hist-card-play">▶</span>
+            <button
+              type="button"
+              class="pp-hist-card-main"
+              @click="selectVideo(url)"
+            >
+              <div class="pp-hist-card-frame">
+                <video class="pp-hist-card-video" :src="url" preload="metadata" :muted="true"/>
+                <div class="pp-hist-card-overlay">
+                  <span class="pp-hist-card-play">▶</span>
+                </div>
               </div>
-            </div>
-            <div class="pp-hist-card-label">视频 {{ idx + 1 }}</div>
-          </button>
+              <div class="pp-hist-card-label">视频 {{ idx + 1 }}</div>
+            </button>
+            <button
+              type="button"
+              class="pp-hist-card-delete"
+              aria-label="从历史记录中删除"
+              title="从历史记录中删除"
+              @click.stop="requestDeleteVideo(url)"
+            >
+              ×
+            </button>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -303,6 +303,9 @@ const recentFinalVideoUrls = ref<string[]>([])
 function pushRecentFinalVideoUrl(url: string) {
   const u = String(url || '').trim()
   if (!u) return
+  // Respect the user-driven deletion blacklist so a deleted URL stays
+  // gone after page reload / reattach.
+  if (deletedVideoUrlsSet.value.has(u)) return
 
   // 去重：最新的放最前
   recentFinalVideoUrls.value = [
@@ -320,6 +323,86 @@ function pushRecentFinalVideoUrl(url: string) {
   } catch {
     /* quota / serialisation failures are non-fatal */
   }
+}
+
+/* ── History video delete ───────────────────────────────────────────
+   The history list is just URLs persisted in localStorage; no backend
+   record exists, so removal here never touches `assets/mock/*`.
+
+   Two-step UX so the dialog matches the rest of the studio:
+     1. `requestDeleteRecentVideo(url)` opens a themed confirm dialog
+        (deleteVideoTarget holds the pending URL).
+     2. `performDeleteRecentVideo()` runs the actual deletion after the
+        user clicks 删除 in the dialog.
+
+   To make the deletion survive a page reload we maintain a SET of
+   deleted URLs in localStorage. Without that, applyWorkflowResponse
+   would re-read outputs.json on reattach and push the URL right back
+   into the recent list. The set is consulted by
+   `pushRecentFinalVideoUrl` and `applyWorkflowResponse` so the
+   blacklisted URL can't sneak back in. */
+const deleteVideoTarget = ref<string | null>(null)
+const deletedVideoUrlsSet = ref<Set<string>>(new Set())
+
+function persistDeletedVideoUrlsSet() {
+  try {
+    if (deletedVideoUrlsSet.value.size > 0) {
+      localStorage.setItem(
+        STORAGE_KEY_DELETED_VIDEOS,
+        JSON.stringify(Array.from(deletedVideoUrlsSet.value)),
+      )
+    } else {
+      localStorage.removeItem(STORAGE_KEY_DELETED_VIDEOS)
+    }
+  } catch {
+    /* localStorage quota / unavailability is non-fatal */
+  }
+}
+
+function requestDeleteRecentVideo(url: string) {
+  const target = String(url || '').trim()
+  if (!target) return
+  deleteVideoTarget.value = target
+}
+
+function cancelDeleteRecentVideo() {
+  deleteVideoTarget.value = null
+}
+
+function performDeleteRecentVideo() {
+  const target = deleteVideoTarget.value
+  deleteVideoTarget.value = null
+  if (!target) return
+
+  recentFinalVideoUrls.value = recentFinalVideoUrls.value.filter(
+    (item) => item !== target,
+  )
+
+  try {
+    if (recentFinalVideoUrls.value.length > 0) {
+      localStorage.setItem(
+        STORAGE_KEY_RECENT_VIDEOS,
+        JSON.stringify(recentFinalVideoUrls.value),
+      )
+    } else {
+      localStorage.removeItem(STORAGE_KEY_RECENT_VIDEOS)
+    }
+  } catch {
+    /* UI state still reflects the deletion */
+  }
+
+  if (finalVideoUrl.value === target) {
+    finalVideoUrl.value = ''
+    try {
+      localStorage.removeItem(STORAGE_KEY_VIDEO_URL)
+    } catch { /* ignore */ }
+  }
+
+  // Persist the deletion so a page reload that re-reads outputs.json
+  // (via applyWorkflowResponse) can't bring the URL back to life.
+  deletedVideoUrlsSet.value = new Set(deletedVideoUrlsSet.value)
+  deletedVideoUrlsSet.value.add(target)
+  persistDeletedVideoUrlsSet()
 }
 const finalVideoRendering = ref(false)
 const workflowForm = ref<any>({ ...DEFAULT_WORKFLOW_FORM })
@@ -438,6 +521,13 @@ const STORAGE_KEY_TAB = 'jinsie_active_tab'
 const STORAGE_KEY_SESSION = 'jinsie_session_id'
 const STORAGE_KEY_VIDEO_URL = 'jinsie_last_video_url'
 const STORAGE_KEY_RECENT_VIDEOS = 'jinsie_recent_video_urls'
+// Set of URLs the user has explicitly removed from history. Without this,
+// a page refresh would re-import the deleted URL because the workflow
+// outputs.json on disk still references it — applyWorkflowResponse would
+// extract finalVideoUrl and push it back into RECENT_VIDEOS. The blacklist
+// is consulted in pushRecentFinalVideoUrl + applyWorkflowResponse so the
+// deletion survives reload without touching backend files.
+const STORAGE_KEY_DELETED_VIDEOS = 'jinsie_deleted_video_urls'
 const STORAGE_KEY_DEV = 'jinsie_dev_mode'
 const STORAGE_KEY_WORKFLOW = 'jinsie_workflow_id'
 const STORAGE_KEY_PAYLOAD = 'jinsie_workflow_payload'
@@ -508,6 +598,20 @@ onMounted(() => {
       if (savedForm.visualStyle === 'cute chibi anime') {
         savedForm.visualStyle = 'cute_chibi_anime'
       }
+      // V1.0 visible-option coercion. WorkflowRunPanel hides
+      // storyboard_preview / assets_only / en-US / storybook from
+      // their respective selects; if a stored form carries one of
+      // those legacy values, snap it back to the supported default
+      // so the dropdown doesn't render with a blank current value.
+      if (savedForm.outputMode && savedForm.outputMode !== 'full_video') {
+        savedForm.outputMode = 'full_video'
+      }
+      if (savedForm.language && savedForm.language !== 'zh-CN') {
+        savedForm.language = 'zh-CN'
+      }
+      if (savedForm.videoProvider && savedForm.videoProvider !== 'mock') {
+        savedForm.videoProvider = 'mock'
+      }
       workflowForm.value = { ...DEFAULT_WORKFLOW_FORM, ...savedForm }
     } catch { /* ignore malformed */ }
   }
@@ -529,6 +633,26 @@ onMounted(() => {
     }
   }
 
+  // Restore the user's "deleted from history" set BEFORE rebuilding
+  // recentFinalVideoUrls / pushing savedVideoUrl, so a blacklisted URL
+  // can't re-enter the list during init.
+  const savedDeletedVideosStr = localStorage.getItem(STORAGE_KEY_DELETED_VIDEOS)
+  if (savedDeletedVideosStr) {
+    try {
+      const parsedDeleted = JSON.parse(savedDeletedVideosStr)
+      if (Array.isArray(parsedDeleted)) {
+        deletedVideoUrlsSet.value = new Set(
+          parsedDeleted.filter(
+            (item): item is string =>
+              typeof item === 'string' && item.length > 0,
+          ),
+        )
+      }
+    } catch {
+      /* corrupt JSON — treat as empty blacklist */
+    }
+  }
+
   // Restore the full recent-videos list first (so multi-session history
   // survives a refresh); then push the last video url for de-dup.
   const savedRecentVideosStr = localStorage.getItem(STORAGE_KEY_RECENT_VIDEOS)
@@ -538,6 +662,9 @@ onMounted(() => {
       if (Array.isArray(parsed)) {
         recentFinalVideoUrls.value = parsed
           .filter((item): item is string => typeof item === 'string' && item.length > 0)
+          // Strip any previously-deleted URL that might still linger in
+          // the recent list (e.g. older builds wrote it without checking).
+          .filter((item) => !deletedVideoUrlsSet.value.has(item))
           .slice(0, 10)
       }
     } catch {
@@ -1234,13 +1361,24 @@ function applyWorkflowResponse(data: WorkflowRunResponse) {
   renderPlanText.value = extractRenderPlanText(data)
   finalVideoText.value = extractFinalVideoText(data)
   finalVideoAudioEnabled.value = (data.outputs as any)?.final_video?.audio_enabled ?? true
-  finalVideoUrl.value = extractFinalVideoUrl(data)
-  if (finalVideoUrl.value) {
-    pushRecentFinalVideoUrl(finalVideoUrl.value)
-    localStorage.setItem(STORAGE_KEY_VIDEO_URL, finalVideoUrl.value)
-    // Pipeline is fully done — drop the "user cancelled refresh" marker
-    // so a brand-new workflow after this isn't accidentally blocked.
-    clearImageRefreshCancelledMarker()
+  {
+    const extractedVideoUrl = extractFinalVideoUrl(data)
+    // If the user has explicitly deleted this URL from history, do NOT
+    // resurrect it on reattach / outputs reload. Without this guard a
+    // page refresh after delete would re-import the URL via the
+    // workflow_id→outputs.json restore path.
+    if (extractedVideoUrl && deletedVideoUrlsSet.value.has(extractedVideoUrl)) {
+      finalVideoUrl.value = ''
+    } else {
+      finalVideoUrl.value = extractedVideoUrl
+      if (finalVideoUrl.value) {
+        pushRecentFinalVideoUrl(finalVideoUrl.value)
+        localStorage.setItem(STORAGE_KEY_VIDEO_URL, finalVideoUrl.value)
+        // Pipeline is fully done — drop the "user cancelled refresh"
+        // marker so a brand-new workflow after this isn't blocked.
+        clearImageRefreshCancelledMarker()
+      }
+    }
   }
   extractMockAudioState(data)
   stepSummaries.value = buildStepSummaries(data)
@@ -2534,6 +2672,7 @@ async function runWorkflow() {
         :example-topics="EXAMPLE_TOPICS"
         @set-topic="setExampleTopic"
         @cancel="cancelActivePhase"
+        @delete-video="requestDeleteRecentVideo"
       />
     </section>
       <section v-if="activeTab === 'review'" class="review-layout">
@@ -2814,6 +2953,27 @@ async function runWorkflow() {
           <div class="confirm-actions">
             <button class="confirm-btn confirm-btn-ghost" @click="cancelDiscardDialog">取消</button>
             <button class="confirm-btn confirm-btn-primary" @click="performDiscardCurrentDraft">放弃</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+
+  <Teleport to="body">
+    <Transition name="confirm-fade">
+      <div
+        v-if="deleteVideoTarget"
+        class="confirm-overlay"
+        role="dialog"
+        aria-modal="true"
+        @click.self="cancelDeleteRecentVideo"
+      >
+        <div class="confirm-dialog">
+          <h3 class="confirm-title">从历史记录中删除该视频？</h3>
+          <p class="confirm-message">这只会移除本地历史记录，不会删除已生成的文件。</p>
+          <div class="confirm-actions">
+            <button class="confirm-btn confirm-btn-ghost" @click="cancelDeleteRecentVideo">取消</button>
+            <button class="confirm-btn confirm-btn-primary" @click="performDeleteRecentVideo">删除</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

V1.0 cleanups on the studio. Two independent concerns, plus one follow-up
fix; front-end only, backend untouched.

### 1) Local history video delete

- Small × button on every history thumbnail — covers all three render
  paths (`.pp-thumb` compact strip + both `.pp-hist-card` grid variants).
  Visible on hover / focus-within, no layout shift otherwise.
- Click stops propagation so the underlying thumbnail (play / select)
  doesn't fire.
- Confirmation uses a **themed dialog** matching the existing 放弃当前生成
  pattern (same `confirm-overlay / confirm-dialog / confirm-btn-*`
  classes) instead of `window.confirm` — dark gold / blue / purple /
  pearl themes all stay consistent.
- Persistence: removes the URL from `recentFinalVideoUrls` and the
  `STORAGE_KEY_RECENT_VIDEOS` JSON; if it's the currently-playing URL,
  also clears `finalVideoUrl` + `STORAGE_KEY_VIDEO_URL`.
- **Adds a new user-level deletion blacklist `STORAGE_KEY_DELETED_VIDEOS`**
  so the deletion survives reload. Without it, reattaching to the same
  `workflow_id` would re-import the deleted URL via the
  `outputs.json → applyWorkflowResponse → pushRecentFinalVideoUrl`
  restoration path. The blacklist is consulted by both
  `pushRecentFinalVideoUrl` and `applyWorkflowResponse`.
- **Does not touch any backend / on-disk file** — `assets/mock/*` stays
  intact. No new API, no DB, no workflow / TTS / render changes.

### 2) V1.0 config option trim

`WorkflowRunPanel` hides options that aren't fully supported yet, while
keeping the underlying constants intact so the **value types and API
payload schema are unchanged**.

| Field | V1.0 keeps | Hidden |
|---|---|---|
| 视频模式 | 绘本视频模式 (`mock`) | 分镜播放模式 (`storybook`) |
| 输出类型 | 完整视频 (`full_video`) | 分镜预览 (`storyboard_preview`), 仅生成素材 (`assets_only`) |
| 语言 | 中文 (`zh-CN`) | 英文 (`en-US`) |

Implementation: new `_V1_VALUES` whitelists + `_OPTS_VISIBLE` filtered
arrays passed to `<ThemedSelect :options>`. `StudioView.onMounted`
coerces any legacy stored value back to the V1.0 default so the
dropdown never opens with an option that no longer renders. Defaults
in `DEFAULT_WORKFLOW_FORM` were already on the supported values.

### 3) Follow-up fix — missed grid variant

The first commit's `replace_all` matched the `.pp-hist-card` block in
the `workInProgress` template branch but missed the second instance in
the standalone "B" branch (has history, no current video) because the
two blocks have different indentation. The follow-up commit applies
the same `<div class="pp-hist-card">` + `.pp-hist-card-main` +
`.pp-hist-card-delete` structure to that missed block. CSS / dialog /
blacklist logic are unchanged. `grep -c 'pp-hist-card-delete'` now
returns 2, matching the two template instances.

## Scope

- **Touched**:
  - `frontend/src/views/StudioView.vue`
  - `frontend/src/components/studio/StudioPreviewPanel.vue`
  - `frontend/src/components/WorkflowRunPanel.vue`
- **Untouched**: Studio business handlers, router, `main.ts`, workflow /
  API / payload / cancel / 画面审核 / 素材库 / 视频生成, theme system,
  `ThemeSwitcher`, Landing page, backend, `RunnerSessionStore`,
  database. No new dependencies.

## Commits in this PR

- `433480d` — `feat(studio): v1.0 polish — history-video delete + config trim`
- *(this push)* — `fix(studio): add delete button to standalone history grid`

## Test plan

### History delete

- [ ] `npm --prefix frontend run check` passes
- [ ] Hover any history thumbnail in the **compact strip** (when a
      current video is playing) → × appears top-right
- [ ] Hover any history thumbnail in the **grid view** (no current
      video yet — the page state in the bug report screenshot) → × appears
- [ ] Hover any history thumbnail in the **in-progress grid** (workflow
      running, history still visible below) → × appears
- [ ] Click × → themed confirm dialog opens (dark gold / blue / purple /
      pearl all match their theme; NOT a browser-native window.confirm)
- [ ] Cancel → nothing changes
- [ ] Click outside the dialog → closes without deleting
- [ ] Confirm → thumbnail disappears, `localStorage.getItem(
      'jinsie_recent_video_urls')` reflects the removal
- [ ] Delete the **currently-playing** video → player clears, refresh
      the page → URL stays gone (does NOT come back)
- [ ] Delete a non-current video → refresh → it stays gone
- [ ] Start a brand-new workflow whose final video URL is NOT in the
      blacklist → it normally lands in the recent strip

### V1.0 config trim

- [ ] 渲染与输出 → 视频模式 shows only "绘本视频模式"; 输出类型 shows
      only "完整视频"
- [ ] 配音与字幕 → 语言 shows only "中文"
- [ ] Manually write a legacy value to localStorage
      (`jinsie_workflow_form` → `outputMode: 'storyboard_preview'`) and
      reload → it auto-snaps to `full_video`
- [ ] API payload sent to `/v1/workflow/run` still includes
      `output_mode / language / video_provider` (unchanged structure)

### Regression

- [ ] Discard / cancel flows behave as before (themed dialog, in-flight
      refresh aborted, recent-videos history preserved by 放弃)
- [ ] Recent-videos list still survives a normal reload when no
      deletions exist
- [ ] Theme switching works on every view
