### PR TITLE
fix: multi-character image prompts honor per-species counts + selector hard-fail

### DIFF
--- a/app/services/image_candidate_selector.py
+++ b/app/services/image_candidate_selector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -27,6 +28,20 @@ COLOR_KEYWORDS = {
 }
 
 MIN_PASS_SCORE = 45.0
+
+
+def _alias_matches(alias: str, haystack: str) -> bool:
+    # ASCII aliases match on word boundaries to avoid false positives like
+    # "long-eared" containing "red", "furred" containing "red", or
+    # "preview" containing "red". Non-ASCII aliases (Chinese) match as
+    # plain substrings since CJK has no whitespace boundaries.
+    alias_lc = alias.lower().strip()
+    if not alias_lc:
+        return False
+    if all(ord(ch) < 128 for ch in alias_lc):
+        pattern = r"(?<![a-z])" + re.escape(alias_lc) + r"(?![a-z])"
+        return re.search(pattern, haystack) is not None
+    return alias_lc in haystack
 
 # Vision-dominant scoring tunables. When the visual verifier returns a score:
 #  - metadata contribution is capped (no more drowning the signal in
@@ -128,7 +143,7 @@ def _extract_expected_colors(prompt: str, characters: List[Dict[str, Any]]) -> L
 
     found: List[str] = []
     for color_name, aliases in COLOR_KEYWORDS.items():
-        if any(alias.lower() in haystack for alias in aliases):
+        if any(_alias_matches(alias, haystack) for alias in aliases):
             found.append(color_name)
 
     # Only fall back to prompt text when no character profile is available.
@@ -137,7 +152,7 @@ def _extract_expected_colors(prompt: str, characters: List[Dict[str, Any]]) -> L
 
     prompt_haystack = str(prompt or "").lower()
     for color_name, aliases in COLOR_KEYWORDS.items():
-        if any(alias.lower() in prompt_haystack for alias in aliases):
+        if any(_alias_matches(alias, prompt_haystack) for alias in aliases):
             found.append(color_name)
 
     return found
@@ -158,7 +173,7 @@ def _extract_forbidden_colors(characters: List[Dict[str, Any]]) -> List[str]:
     haystack = " | ".join(texts).lower()
     found: List[str] = []
     for color_name, aliases in COLOR_KEYWORDS.items():
-        if any(alias.lower() in haystack for alias in aliases):
+        if any(_alias_matches(alias, haystack) for alias in aliases):
             found.append(color_name)
 
     return found
@@ -314,6 +329,7 @@ def _score_candidate(
     color_ratios: Dict[str, float] = {}
     forbidden_matched_colors: List[str] = []
     forbidden_color_ratios: Dict[str, float] = {}
+    metadata_hard_failures: List[str] = []
 
     if image is not None and expected_colors:
         matched_colors, color_ratios = _color_hits(
@@ -332,6 +348,47 @@ def _score_candidate(
             score -= 18.0
             reasons.append("matched_colors:none")
             reasons.append("expected_color_missing_penalty")
+
+        # Multi-character coverage penalty. Without this, a candidate
+        # that hits ONE of the two expected character colors (e.g.
+        # brown for the squirrel but no white for the rabbit — i.e.
+        # two squirrels) can outscore a candidate that hits BOTH
+        # because the matched single color contributed more saturated
+        # ratio. Penalise candidates that don't cover every expected
+        # color in a multi-character scene so the picker prefers
+        # candidates where ALL required characters are visible.
+        if (
+            quality_gates.get("multi_character_scene")
+            and len(expected_colors) >= 2
+        ):
+            missing_colors = [
+                c for c in expected_colors if c not in matched_colors
+            ]
+            if missing_colors:
+                # Per missing color, drop ~15 points so a candidate
+                # missing one required color drops well below one that
+                # covers both. Bounded so a single miss doesn't push
+                # the score into runaway-negative territory.
+                miss_penalty = min(15.0 * len(missing_colors), 30.0)
+                score -= miss_penalty
+                reasons.append(
+                    "multi_character_color_coverage_missing:"
+                    + ",".join(missing_colors)
+                )
+                reasons.append(
+                    f"multi_character_coverage_penalty:{miss_penalty:.1f}"
+                )
+                # Hard fail: in vision_dominant mode the metadata score
+                # is capped to <=25, so the penalty above is swallowed and
+                # the visual verifier alone decides. The verifier often
+                # gives a beautiful single-animal image a high score even
+                # though a required species is missing. Treat
+                # multi-character missing colors as a hard fail at the
+                # metadata layer so it survives into vision_dominant
+                # mode and caps the final score below MIN_PASS_SCORE.
+                metadata_hard_failures.append(
+                    "multi_character_missing_colors:" + ",".join(missing_colors)
+                )
 
     elif not expected_colors:
         score += 2.0
@@ -364,11 +421,32 @@ def _score_candidate(
     visual_hard_failures: List[str] = []
     if image is not None and visual_verifier is not None:
         try:
-            visual_review = visual_verifier(
-                image_path=path,
-                prompt=prompt,
-                characters=characters,
-            )
+            # Pass expected per-species counts so the verifier can flag
+            # candidates with extra same-species individuals (e.g. cast
+            # asks for 1 squirrel but image has 3). Same-species casts
+            # like "rabbit + rabbit mom" are correctly handled because
+            # the count for "rabbit" is 2, not 1.
+            try:
+                from app.services.runner_image_prompts_support import (
+                    species_count_map,
+                )
+                expected_counts = dict(species_count_map(characters))
+            except Exception:
+                expected_counts = {}
+            try:
+                visual_review = visual_verifier(
+                    image_path=path,
+                    prompt=prompt,
+                    characters=characters,
+                    expected_species_counts=expected_counts or None,
+                )
+            except TypeError:
+                # Legacy verifier signature without expected_species_counts.
+                visual_review = visual_verifier(
+                    image_path=path,
+                    prompt=prompt,
+                    characters=characters,
+                )
             raw_score = float(visual_review.get("score") or 0.0)
             visual_score_value = max(0.0, min(100.0, raw_score))
 
@@ -406,7 +484,9 @@ def _score_candidate(
         reasons.append(f"capped_metadata_floor:{capped_metadata:.1f}")
         for failure in visual_hard_failures:
             reasons.append(f"visual_hard_fail:{failure}")
-        if visual_hard_failures:
+        for failure in metadata_hard_failures:
+            reasons.append(f"metadata_hard_fail:{failure}")
+        if visual_hard_failures or metadata_hard_failures:
             score = min(score, MIN_PASS_SCORE - HARD_FAIL_MARGIN)
         if visual_review.get("passed") is False:
             reasons.append("visual_review_failed")
@@ -414,6 +494,10 @@ def _score_candidate(
     else:
         score_mode = "metadata_only"
         reasons.append("score_mode:metadata_only")
+        for failure in metadata_hard_failures:
+            reasons.append(f"metadata_hard_fail:{failure}")
+        if metadata_hard_failures:
+            score = min(score, MIN_PASS_SCORE - HARD_FAIL_MARGIN)
 
     passed = score >= MIN_PASS_SCORE
 
@@ -432,6 +516,7 @@ def _score_candidate(
         "quality_gates": quality_gates,
         "visual_review": visual_review,
         "visual_hard_failures": visual_hard_failures,
+        "metadata_hard_failures": metadata_hard_failures,
     }
 
 
@@ -477,12 +562,21 @@ def select_best_candidate(
     if not scored:
         raise ValueError("candidate_asset_refs is empty")
 
-    scored.sort(
-        key=lambda item: (
+    # Sort primarily by "no hard failure" (candidates that cleared all hard
+    # checks always rank above candidates with any hard failure, regardless
+    # of score), then by score. This guarantees a wrong-species image (e.g.
+    # one rabbit only) never wins over a correct one even if the visual
+    # verifier loved its composition.
+    def _sort_key(item: Dict[str, Any]) -> tuple:
+        has_hard_fail = bool(
+            item.get("visual_hard_failures") or item.get("metadata_hard_failures")
+        )
+        return (
+            0 if has_hard_fail else 1,
             float(item.get("score") or 0.0),
-        ),
-        reverse=True,
-    )
+        )
+
+    scored.sort(key=_sort_key, reverse=True)
 
     best = scored[0]
     best_score = float(best.get("score") or 0.0)

--- a/app/services/image_prompt_policy.py
+++ b/app/services/image_prompt_policy.py
@@ -161,6 +161,20 @@ def build_scene_action_binding_block(
     if story:
         parts.append(f"must match this story moment: {story}")
 
+    # Without any scene-specific text from the storyboard, the block above
+    # collapses into a generic instruction that's identical for every
+    # scene. The hint below forces a difference even in that degraded
+    # state. Caller (runner_image_prompts_support) also provides a
+    # scene-position anchor higher up in the prompt; this is a defense-in-
+    # depth so the block never reads "depict the current scene action"
+    # with no actual scene attached.
+    if not visual and not story:
+        parts.append(
+            "the storyboard's per-scene text was empty; rely on the scene "
+            "position anchor and required characters to make this scene "
+            "visibly different from any other scene of the same story"
+        )
+
     parts.append(
         "keep every required character visually consistent while changing only pose, framing, background, and action"
     )

--- a/app/services/image_provider_queue.py
+++ b/app/services/image_provider_queue.py
@@ -16,6 +16,10 @@ from app.services.image_provider_types import (
     QueueExecutionResult,
     QueuePolicy,
 )
+from app.services.runner_image_prompts_support import (
+    build_multi_character_negative_prompt,
+    ensure_multi_character_anchor,
+)
 
 
 class ImageProviderQueue:
@@ -128,6 +132,12 @@ class ImageProviderQueue:
                     prompt_item=prompt_item,
                     fallback_scene_title=scene_title,
                 )
+                # Last-mile multi-character guard for the queue batch path.
+                # See ensure_multi_character_anchor() for full context.
+                base_prompt = ensure_multi_character_anchor(
+                    base_prompt,
+                    asset_meta.get("characters") or [],
+                )
 
                 candidate_asset_refs = self._generate_shot_candidates(
                     provider=provider,
@@ -237,6 +247,13 @@ class ImageProviderQueue:
                     scene=scene,
                     prompt_item=prompt_item,
                     fallback_scene_title=str(scene.get("scene_title") or "").strip(),
+                )
+                # Last-mile multi-character guard for the queue scene-mode
+                # path. See ensure_multi_character_anchor() for full
+                # context.
+                base_prompt = ensure_multi_character_anchor(
+                    base_prompt,
+                    asset_meta.get("characters") or [],
                 )
 
                 candidate_asset_refs = self._generate_scene_candidates(
@@ -474,6 +491,15 @@ class ImageProviderQueue:
         img2img_reference_path: Optional[Path] = None,
     ) -> List[Dict[str, Any]]:
         candidate_asset_refs: List[Dict[str, Any]] = []
+        shot_characters = (
+            prompt_item.get("characters")
+            or parent_scene.get("characters")
+            or []
+        )
+        # Multi-character negative prompt — empty string for solo scenes
+        # so it never dilutes the per-character forbidden_traits / safety
+        # negatives already injected by the adapter.
+        multi_negative = build_multi_character_negative_prompt(shot_characters)
 
         for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
             candidate_prompt = base_prompt
@@ -532,6 +558,7 @@ class ImageProviderQueue:
                     "character_anchor": character_anchor,
                     "reference_images": reference_images,
                     "img2img_reference_path": img2img_reference_path,
+                    "negative_prompt": multi_negative,
                 },
             )
 
@@ -580,6 +607,12 @@ class ImageProviderQueue:
         img2img_reference_path: Optional[Path] = None,
     ) -> List[Dict[str, Any]]:
         candidate_asset_refs: List[Dict[str, Any]] = []
+        scene_characters = (
+            prompt_item.get("characters")
+            or scene.get("characters")
+            or []
+        )
+        multi_negative = build_multi_character_negative_prompt(scene_characters)
 
         for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
             candidate_scene = self._runner._scene_candidate_variant(
@@ -622,6 +655,7 @@ class ImageProviderQueue:
                     "character_anchor": character_anchor,
                     "reference_images": reference_images,
                     "img2img_reference_path": img2img_reference_path,
+                    "negative_prompt": multi_negative,
                 },
             )
 

--- a/app/services/image_visual_verifier.py
+++ b/app/services/image_visual_verifier.py
@@ -139,8 +139,25 @@ class OpenAICompatibleImageVisualVerifier:
         image_path: Path,
         prompt: str,
         characters: List[Dict[str, Any]],
+        expected_species_counts: Optional[Dict[str, int]] = None,
     ) -> Dict[str, Any]:
         character_summary = _character_summary(characters)
+        count_text = ""
+        if expected_species_counts:
+            count_text = (
+                "\n\nExpected cast counts (count individuals you see, "
+                "group by species; ignore tiny background creatures unless "
+                "they look like a duplicated main character):\n"
+                + "\n".join(
+                    f"- {species}: exactly {n}"
+                    for species, n in expected_species_counts.items()
+                )
+                + "\nIf you see MORE of any species than the expected count "
+                "(e.g. the cast calls for 1 squirrel but you see 3), include "
+                '"extra_same_species_subjects" in anatomy_leakage_issues and '
+                "lower the score significantly. Same-species duplicates are "
+                "only OK when the expected count itself is >= 2."
+            )
         instruction = (
             "You are a visual reviewer for children's story image candidates.\n"
             "Return ONLY compact JSON with these keys: score, passed, "
@@ -157,6 +174,7 @@ class OpenAICompatibleImageVisualVerifier:
             "Penalize: missing required characters, merged characters, "
             "traits explicitly listed in must_avoid appearing on a character.\n"
             f"Scene prompt:\n{prompt}\n\nRequired characters:\n{character_summary or '- none'}"
+            f"{count_text}"
         )
 
         payload = {

--- a/app/services/runner_image_prompts_support.py
+++ b/app/services/runner_image_prompts_support.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from app.services.character_visual_profile_llm import (
     build_llm_character_visual_profile,
@@ -81,6 +82,482 @@ def _scene_action_fallback(
     if title:
         return f"the scene depicting {title}"
     return ""
+
+
+def _english_label_for_character(character: Dict[str, Any]) -> str:
+    """Return a short English species noun for the diffusion prompt.
+
+    The auto-manifest copies the Chinese topic subject straight into the
+    `species` and `display_name` fields (e.g. species="小兔子" for a
+    Chinese topic "小兔子和小松鼠"). Diffusion providers like Kolors don't
+    reliably parse Chinese animal names mixed into an otherwise-English
+    prompt — they ignore the Chinese tokens and latch onto whatever
+    English animal word appears in the storyboard's visual_description,
+    so both required characters end up rendered as the LLM-mentioned
+    species (e.g. two squirrels).
+
+    This returns a SHORT noun ("rabbit", "squirrel") rather than the
+    whole descriptive phrase, so the downstream `not two <species>`
+    negatives stay clean and high-signal. Resolution chain — no
+    hardcoded animal table:
+
+      1. `species` if ASCII-only — already English
+      2. Trailing noun of the first clause of `visual_identity`
+         (LLM-generated English text), split on common connectors
+         like " with ", " who ", " that " — e.g. from
+         "white long-eared rabbit with pink twitching nose..." we
+         keep "white long-eared rabbit" then take the last word
+         "rabbit".
+      3. `display_name` if ASCII-only
+      4. `subject` if ASCII-only
+      5. Original Chinese species / display as a last resort so the
+         prompt isn't empty.
+    """
+    if not isinstance(character, dict):
+        return ""
+
+    def _ascii_only(s: str) -> bool:
+        return bool(s) and all(ord(c) < 128 for c in s)
+
+    species = str(character.get("species") or "").strip()
+    if _ascii_only(species):
+        return species
+
+    identity = str(character.get("visual_identity") or "").strip()
+    if identity:
+        # First sentence only — descriptions like "rabbit. The rabbit wears..."
+        # have all the info we need in the first clause.
+        first = identity.split(".")[0].strip()
+        # IMPORTANT: check for connectors BEFORE splitting on commas.
+        # Real visual_identity strings often start with stacked adjectives
+        # separated by commas before the species noun, e.g.
+        #   "A small, fluffy white rabbit with big eyes..."
+        # Splitting on the first comma here gives "A small" → last token
+        # "small" — wrong. Splitting on " with " first gives
+        # "A small, fluffy white rabbit" → last token "rabbit" — correct.
+        for connector in (
+            " with ",
+            " who ",
+            " that ",
+            " having ",
+            " wearing ",
+            " carrying ",
+        ):
+            if connector in first:
+                first = first.split(connector, 1)[0].strip()
+                break
+        else:
+            # Connector not found — fall back to first comma so we
+            # don't accidentally grab descriptors from later clauses.
+            first = first.split(",")[0].strip()
+        if first and any(ord(c) < 128 for c in first):
+            cleaned = "".join(c if ord(c) < 128 else " " for c in first).strip()
+            cleaned = " ".join(cleaned.split())
+            if cleaned:
+                # Skip leading articles before grabbing the head noun.
+                tokens = [t for t in cleaned.split() if t.lower() not in {"a", "an", "the"}]
+                # Strip trailing punctuation that may have stuck to the
+                # token (e.g. "rabbit," → "rabbit").
+                if tokens:
+                    last = tokens[-1].lower().strip(",;:.!?")
+                    if last:
+                        return last
+
+    display = str(character.get("display_name") or "").strip()
+    if _ascii_only(display):
+        return display
+
+    subject = str(character.get("subject") or "").strip()
+    if _ascii_only(subject):
+        return subject
+
+    return species or display or subject or ""
+
+
+_VOWELS = set("aeiou")
+
+
+def _pluralize(word: str) -> str:
+    """Tiny English pluralizer for species nouns. Not perfect — falls back
+    to suffix '+s' for unknown shapes — but covers rabbit/rabbits,
+    squirrel/squirrels, mouse/mice, fox/foxes, etc.
+
+    No hardcoded animal list: this only knows English suffix rules.
+    """
+    w = (word or "").strip().lower()
+    if not w:
+        return ""
+    # Common irregulars worth handling so the prompt reads naturally.
+    irregulars = {
+        "mouse": "mice",
+        "goose": "geese",
+        "child": "children",
+        "person": "people",
+        "tooth": "teeth",
+        "foot": "feet",
+    }
+    if w in irregulars:
+        return irregulars[w]
+    # Words ending in s, x, z, ch, sh → +es. Otherwise +s.
+    if w.endswith(("s", "x", "z")) or w.endswith(("ch", "sh")):
+        return w + "es"
+    # Word ending in consonant + y → -ies.
+    if w.endswith("y") and len(w) > 1 and w[-2].lower() not in _VOWELS:
+        return w[:-1] + "ies"
+    return w + "s"
+
+
+def species_count_map(
+    enriched_scene_characters: List[Dict[str, Any]],
+) -> "Counter[str]":
+    """Group required scene characters by their extracted English species
+    label and return a Counter of {species: count}.
+
+    This is the foundation for honoring same-species scenes ("rabbit and
+    rabbit mom" = {"rabbit": 2}) without falsely flagging them as
+    duplicates. All downstream multi-character prompt builders should
+    derive count language from this.
+
+    Characters with no extractable English label are skipped here — they
+    fall back to the existing Chinese-name path elsewhere in the prompt.
+    """
+    counts: "Counter[str]" = Counter()
+    if not enriched_scene_characters:
+        return counts
+    for character in enriched_scene_characters:
+        if not isinstance(character, dict):
+            continue
+        label = _english_label_for_character(character)
+        if not label:
+            continue
+        counts[label] += 1
+    return counts
+
+
+def _format_species_count_phrase(counts: "Counter[str]") -> str:
+    """Format a Counter into prompt-friendly text:
+      {"rabbit": 1, "squirrel": 1} → "1 rabbit and 1 squirrel"
+      {"rabbit": 2}                → "2 rabbits"
+      {"rabbit": 2, "squirrel": 1} → "2 rabbits and 1 squirrel"
+    """
+    if not counts:
+        return ""
+    parts: List[str] = []
+    for species, n in counts.items():
+        word = species if n == 1 else _pluralize(species)
+        parts.append(f"{n} {word}")
+    if len(parts) == 1:
+        return parts[0]
+    return ", ".join(parts[:-1]) + " and " + parts[-1]
+
+
+# A small, finite set of common animal body-part words. This is NOT a
+# species list — it's the anatomy vocabulary that applies to all
+# animals. Adding new body parts here is safe; it never enumerates
+# species.
+_BODY_PART_WORDS = (
+    "ears", "ear",
+    "tail", "tails",
+    "shell", "shells",
+    "horns", "horn", "antlers", "antler",
+    "beak", "beaks", "snout", "snouts",
+    "wings", "wing",
+    "fur", "fleece", "wool",
+    "scales", "scale",
+    "skin",
+    "paws", "paw", "hooves", "hoof", "claws", "claw",
+    "mane", "manes",
+    "whiskers", "whisker",
+    "fangs", "fang", "tusks", "tusk",
+    "fins", "fin", "flippers", "flipper",
+    "trunk", "trunks",
+)
+
+
+def _distinctive_anatomy_phrases(character: Dict[str, Any]) -> List[str]:
+    """Extract short "<adjective(s)> <body-part>" phrases from a
+    character's must_keep / visual_identity / signature_traits. These
+    become the cross-species anatomy rules — "only X may have <phrase>".
+
+    Heuristic-only — no species enumeration. We just scan for the
+    finite anatomy vocabulary above and grab a couple of leading
+    adjectives.
+    """
+    if not isinstance(character, dict):
+        return []
+    sources: List[str] = []
+    for key in ("must_keep", "signature_traits"):
+        value = character.get(key) or []
+        if isinstance(value, list):
+            sources.extend(str(v or "").strip() for v in value if v)
+        else:
+            sources.append(str(value or "").strip())
+    identity = str(character.get("visual_identity") or "").strip()
+    if identity:
+        # First clause only — descriptions like "rabbit. The rabbit
+        # wears..." don't add anatomy info in later sentences.
+        sources.append(identity.split(".")[0])
+
+    body_set = set(_BODY_PART_WORDS)
+    seen: set = set()
+    phrases: List[str] = []
+    for src in sources:
+        text = " ".join(src.lower().replace(",", " ").replace(";", " ").split())
+        tokens = text.split()
+        for i, token in enumerate(tokens):
+            if token not in body_set:
+                continue
+            # Walk back up to 3 adjectives until we hit a stopword.
+            start = i
+            stopwords = {
+                "a", "an", "the", "and", "with", "of", "that", "who",
+                "having", "wearing", "or", "also", "but", "to", "in",
+                "around", "on", "for", "by", "must", "should",
+                "same", "small", "tiny", "big", "large",
+            }
+            for j in range(1, 4):
+                if start - 1 < 0:
+                    break
+                prev = tokens[start - 1].strip(",.")
+                if not prev or prev in stopwords:
+                    break
+                if prev in body_set:
+                    break
+                start -= 1
+            phrase = " ".join(tokens[start : i + 1]).strip(",. ")
+            # Need at least one adjective for the rule to be useful —
+            # bare "tail" / "ears" alone is too generic to enforce.
+            if start == i:
+                continue
+            if phrase and phrase not in seen:
+                seen.add(phrase)
+                phrases.append(phrase)
+    return phrases
+
+
+def build_anatomy_separation_rules(
+    enriched_scene_characters: List[Dict[str, Any]],
+) -> str:
+    """Derive anatomy-separation rules from each character's profile.
+
+    For a rabbit-and-squirrel cast, produces something like:
+      "only the rabbit may have long upright ears, round fluffy tail;
+       only the squirrel may have brown fur, bushy tail;
+       do not transfer body parts between species"
+
+    For a same-species cast (rabbit + rabbit mom) returns empty string —
+    there's no cross-species body-part conflict to guard against.
+
+    No hardcoded species list. The anatomy vocabulary itself
+    (ears/tail/shell/...) is finite and applies to all animals.
+    """
+    if not isinstance(enriched_scene_characters, list) or len(enriched_scene_characters) < 2:
+        return ""
+
+    counts = species_count_map(enriched_scene_characters)
+    if len(counts) < 2:
+        # Same-species cast — no cross-species anatomy rules needed.
+        return ""
+
+    # Group anatomy phrases by extracted English species.
+    by_species: Dict[str, List[str]] = {}
+    for char in enriched_scene_characters:
+        if not isinstance(char, dict):
+            continue
+        species = _english_label_for_character(char)
+        if not species:
+            continue
+        phrases = _distinctive_anatomy_phrases(char)
+        if not phrases:
+            continue
+        bucket = by_species.setdefault(species, [])
+        for p in phrases:
+            if p not in bucket:
+                bucket.append(p)
+
+    if not by_species:
+        return ""
+
+    parts: List[str] = []
+    for species, phrases in by_species.items():
+        if not phrases:
+            continue
+        joined = ", ".join(phrases[:4])  # cap to keep prompt readable
+        parts.append(f"only the {species} may have {joined}")
+    if not parts:
+        return ""
+    parts.append("do not transfer body parts between different species")
+    return "; ".join(parts)
+
+
+def build_multi_character_negative_prompt(
+    enriched_scene_characters: List[Dict[str, Any]],
+) -> str:
+    """Build a negative prompt aimed at the most common multi-character
+    failure modes from diffusion models (Kolors and similar):
+
+    - Both characters rendered as the same species (e.g. two squirrels
+      instead of one rabbit + one squirrel)
+    - Mirrored / duplicated subjects
+    - One character missing entirely (solo portrait)
+
+    Returns empty string for single-character scenes so we don't dilute
+    the negative prompt for cases where this isn't a risk.
+    """
+    if not enriched_scene_characters or len(enriched_scene_characters) < 2:
+        return ""
+
+    counts = species_count_map(enriched_scene_characters)
+    if not counts:
+        return ""
+
+    # Universal negatives — always safe regardless of cast composition.
+    parts: List[str] = [
+        "duplicate characters beyond required count",
+        "missing one required character",
+        "only one character visible when multiple are required",
+    ]
+
+    # Mirror / identical-rendering negatives only when the cast contains
+    # multiple distinct species. For same-species casts (e.g. rabbit +
+    # rabbit mom) the model legitimately needs to render two of the same
+    # species, so we must not forbid mirroring or "same animal twice"
+    # phrasing — it would suppress correct output.
+    if len(counts) >= 2:
+        parts.extend(
+            [
+                "two different species merged into one body",
+                "characters swapped between species",
+            ]
+        )
+
+    # Per-species count guard: forbid counts ABOVE the expected count.
+    # For required=1 squirrel → forbid "two squirrels, three squirrels".
+    # For required=2 rabbits → forbid "three rabbits, four rabbits" but
+    # leave "two rabbits" untouched (that's the correct count).
+    count_words = {2: "two", 3: "three", 4: "four", 5: "five", 6: "six"}
+    for species, required in counts.items():
+        plural = _pluralize(species)
+        # Always forbid 1 more than required, plus a couple steps beyond.
+        for over in range(required + 1, required + 4):
+            word = count_words.get(over, str(over))
+            parts.append(f"{word} {plural}")
+        parts.append(f"more than {required} {plural if required > 1 else species}")
+
+    return ", ".join(parts)
+
+
+def ensure_multi_character_anchor(
+    prompt: str,
+    enriched_scene_characters: List[Dict[str, Any]],
+) -> str:
+    """Last-mile guard for any prompt that's about to hit the image
+    provider. If the scene has 2+ required characters and the prompt
+    text doesn't already contain the multi-character roster / anti-
+    mirror negatives, prepend the roster block.
+
+    Why this exists separately from the assembly-time injection: there
+    are several fallback paths that build a base_prompt directly from
+    `scene.visual_description` / `scene.narration` / a placeholder
+    string when `outputs["image_prompts"]` is empty or missing the
+    scene_id — runner_single_scene_image_support (API + pillow
+    branches), image_provider_queue (shot + scene branches). Without
+    a defense at this layer, a single missing image_prompts entry can
+    silently send a bare single-species prompt to the provider.
+    """
+    text = str(prompt or "")
+    if not isinstance(enriched_scene_characters, list) or len(enriched_scene_characters) < 2:
+        return text
+    lowered = text.lower()
+    if "not two " in lowered or "do not draw mirrored" in lowered:
+        return text
+    roster = _build_multi_character_roster_for_scene(enriched_scene_characters)
+    if not roster:
+        return text
+    return f"{roster}, {text}" if text else roster
+
+
+def _build_multi_character_roster_for_scene(
+    enriched_scene_characters: List[Dict[str, Any]],
+) -> str:
+    """Reinforcement block injected next to per-scene text fields when a
+    scene has 2+ required characters.
+
+    Why this exists: the multi-character color_prefix at PROMPT POSITION 0
+    declares "rabbit and squirrel". But the storyboard's per-scene
+    `visual_description` may name only ONE species (e.g. "the squirrel
+    jumps from rock to rock") because the storyboard LLM only sees the
+    narration and isn't forced to mention every character. Diffusion
+    models give heavy weight to the explicitly-named species in the
+    scene text and end up rendering BOTH characters as that species
+    (mirrored squirrels). The roster injected here re-asserts every
+    required species adjacent to the scene-specific text, so the
+    explicit single-species mention can't dominate.
+    """
+    if not isinstance(enriched_scene_characters, list) or len(enriched_scene_characters) < 2:
+        return ""
+
+    counts = species_count_map(enriched_scene_characters)
+    if not counts:
+        return ""
+
+    total = sum(counts.values())
+    species_set: List[str] = list(counts.keys())
+    count_phrase = _format_species_count_phrase(counts)  # "2 rabbits and 1 squirrel"
+
+    parts: List[str] = [
+        f"this scene contains exactly {count_phrase}",
+        f"render exactly {total} distinct animal subjects in total",
+        f"required species in this single image: {', '.join(species_set)}",
+    ]
+
+    # Per-species count guards. For required=1 squirrel → "not two squirrels".
+    # For required=2 rabbits → "not three rabbits" but NEVER "not two
+    # rabbits" — that would block the legitimate output for same-species
+    # casts (rabbit + rabbit mom).
+    count_words = {2: "two", 3: "three", 4: "four", 5: "five", 6: "six"}
+    for species, required in counts.items():
+        plural = _pluralize(species)
+        over = required + 1
+        word = count_words.get(over, str(over))
+        parts.append(f"not {word} {plural} in this image")
+        parts.append(f"do not render more than {required} {plural if required > 1 else species}")
+
+    # Cross-species "do not swap" rules only when there are 2+ distinct
+    # species in the cast. For same-species cast (all rabbits) there's
+    # nothing to swap with, so we skip these to avoid noise.
+    if len(species_set) >= 2:
+        for s in species_set:
+            parts.append(f"do not turn any other character into a {s}")
+        parts.append("do not duplicate a single character; do not mirror one character to fake another")
+
+    return ", ".join(parts)
+
+
+def _scene_text_mentions_all_species(
+    text: str,
+    enriched_scene_characters: List[Dict[str, Any]],
+) -> bool:
+    """Returns True if every required character's species (or display name)
+    appears in the given text. Used to decide whether the per-scene
+    visual_description / narration is already self-sufficient or whether
+    we need to surface the roster reinforcement block."""
+    if not text:
+        return False
+    if not isinstance(enriched_scene_characters, list) or len(enriched_scene_characters) < 2:
+        return True
+    lowered = text.lower()
+    for character in enriched_scene_characters:
+        if not isinstance(character, dict):
+            continue
+        species = str(character.get("species") or "").strip().lower()
+        display = str(character.get("display_name") or "").strip().lower()
+        candidates = [c for c in [species, display] if c]
+        if not candidates:
+            continue
+        if not any(c in lowered or c in text for c in candidates):
+            return False
+    return True
 
 
 def _write_image_prompts_debug(workflow_id: str, prompts: List[Dict[str, Any]]) -> None:
@@ -310,10 +787,25 @@ class RunnerImagePromptsSupport:
                 # adds explicit "not two <species>" negatives.
                 if is_multi_character_scene:
                     multi_prefix = self._build_multi_character_color_prefix(
-                        character_visual_profiles
+                        character_visual_profiles,
+                        enriched_scene_characters=enriched_scene_characters,
                     )
                     if multi_prefix:
                         color_prefix = multi_prefix
+
+                # Roster reinforcement block — inserted immediately AFTER
+                # the scene-specific text in multi-character scenes. The
+                # storyboard's visual_description may name only one species
+                # (e.g. "the squirrel jumps"), which then weights the
+                # diffusion model toward rendering both characters as that
+                # species. By following every scene-specific block with an
+                # explicit "BOTH X and Y appear here, not two X, not two Y"
+                # reinforcement, the single-species mention can't dominate.
+                scene_multi_roster = (
+                    _build_multi_character_roster_for_scene(enriched_scene_characters)
+                    if is_multi_character_scene
+                    else ""
+                )
                 # `scene_position_anchor` is placed right after color_prefix
                 # so the early-prompt weight (most important for diffusion)
                 # encodes THIS scene's identity before the shared
@@ -325,6 +817,7 @@ class RunnerImagePromptsSupport:
                     scene_position_anchor,
                     global_style_anchor,
                     shot_anchor,
+                    scene_multi_roster,
                     character_anchor,
                     policy_blocks.get("visual_profile_block"),
                     policy_blocks.get("character_visual_profiles_block"),
@@ -332,6 +825,7 @@ class RunnerImagePromptsSupport:
                     scene_required_presence_block,
                     policy_blocks.get("character_separation_block"),
                     policy_blocks.get("scene_action_block"),
+                    scene_multi_roster,
                     story_anchor,
                     policy_blocks.get("subject_negative_block"),
                     negative_block,
@@ -344,11 +838,13 @@ class RunnerImagePromptsSupport:
                         global_style_anchor,
                         compact_trait_block,
                         shot_anchor,
+                        scene_multi_roster,
                         scene_required_presence_block,
                         character_block,
                         policy_blocks.get("character_visual_profiles_block"),
                         policy_blocks.get("character_separation_block"),
                         policy_blocks.get("scene_action_block"),
+                        scene_multi_roster,
                         story_anchor,
                         negative_block,
                         anti_repeat_block,
@@ -474,6 +970,16 @@ class RunnerImagePromptsSupport:
                 )
                 if multi_prefix:
                     color_prefix = multi_prefix
+
+            # Roster reinforcement for multi-character scenes — placed
+            # adjacent to per-scene text so the storyboard's potentially
+            # single-species visual_description can't dominate. See
+            # the helper docstring for the full failure-mode rationale.
+            scene_multi_roster = (
+                _build_multi_character_roster_for_scene(enriched_scene_characters)
+                if is_multi_character_scene
+                else ""
+            )
             # scene_position_anchor goes early so this scene's identity
             # gets the most attention from the diffusion model; the
             # anti_repeat_block goes last so the negative-style demand
@@ -483,6 +989,7 @@ class RunnerImagePromptsSupport:
                 scene_position_anchor,
                 global_style_anchor,
                 scene_anchor,
+                scene_multi_roster,
                 character_anchor,
                 policy_blocks.get("visual_profile_block"),
                 policy_blocks.get("character_visual_profiles_block"),
@@ -490,6 +997,7 @@ class RunnerImagePromptsSupport:
                 scene_required_presence_block,
                 policy_blocks.get("character_separation_block"),
                 policy_blocks.get("scene_action_block"),
+                scene_multi_roster,
                 story_anchor,
                 policy_blocks.get("subject_negative_block"),
                 negative_block,
@@ -502,11 +1010,13 @@ class RunnerImagePromptsSupport:
                     global_style_anchor,
                     compact_trait_block,
                     scene_anchor,
+                    scene_multi_roster,
                     scene_required_presence_block,
                     character_block,
                     policy_blocks.get("character_visual_profiles_block"),
                     policy_blocks.get("character_separation_block"),
                     policy_blocks.get("scene_action_block"),
+                    scene_multi_roster,
                     story_anchor,
                     negative_block,
                     anti_repeat_block,
@@ -544,6 +1054,7 @@ class RunnerImagePromptsSupport:
     def _build_multi_character_color_prefix(
         self,
         character_visual_profiles: Dict[str, Any],
+        enriched_scene_characters: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
         """Position-0 prefix for multi-character scenes.
 
@@ -560,8 +1071,32 @@ class RunnerImagePromptsSupport:
         respond strongly to that pattern when it appears early.
         """
         profiles = (character_visual_profiles or {}).get("profiles") or []
+        # Defensive fallback: when the LLM-built character_visual_profiles
+        # didn't produce >=2 entries (LLM error, key missing, partial
+        # failure), fall back to the scene's enriched manifest bindings.
+        # Those are reliably populated from the auto-built / user-defined
+        # character_manifest and always have display_name + species when
+        # the scene is multi-character. Without this, a single LLM hiccup
+        # quietly drops us back to the singular color_prefix and the
+        # diffusion model renders mirrored same-species characters.
         if not isinstance(profiles, list) or len(profiles) < 2:
-            return ""
+            if (
+                isinstance(enriched_scene_characters, list)
+                and len(enriched_scene_characters) >= 2
+            ):
+                profiles = [
+                    {
+                        "species": str(c.get("species") or "").strip(),
+                        "display_name": str(c.get("display_name") or "").strip(),
+                        "subject": str(c.get("species") or c.get("display_name") or "").strip(),
+                        "visual_identity": str(c.get("visual_identity") or "").strip(),
+                        "must_keep": c.get("must_keep") or c.get("signature_traits") or [],
+                    }
+                    for c in enriched_scene_characters
+                    if isinstance(c, dict)
+                ]
+            else:
+                return ""
 
         COLOR_WORDS = {
             "red", "blue", "green", "yellow", "orange", "purple", "pink",
@@ -577,13 +1112,10 @@ class RunnerImagePromptsSupport:
             if not isinstance(profile, dict):
                 continue
 
-            species = str(profile.get("species") or "").strip()
-            display = str(profile.get("display_name") or "").strip()
-            subject = str(profile.get("subject") or "").strip()
-            identity = str(profile.get("visual_identity") or "").strip()
             must_keep = profile.get("must_keep") or []
             if not isinstance(must_keep, list):
                 must_keep = []
+            identity = str(profile.get("visual_identity") or "").strip()
 
             # Pick the first must_keep trait that carries a color word
             # so the label reads as "{color/trait} {species}" — e.g.
@@ -599,7 +1131,9 @@ class RunnerImagePromptsSupport:
             if not color_trait and identity:
                 color_trait = identity.split(".")[0].strip()
 
-            anchor_species = species or display or subject
+            # English-friendly species label — Chinese species/display
+            # from the auto-manifest gets ignored by Kolors etc.
+            anchor_species = _english_label_for_character(profile)
             if not anchor_species:
                 continue
             if anchor_species not in species_set:
@@ -616,16 +1150,44 @@ class RunnerImagePromptsSupport:
         if len(labels) < 2:
             return ""
 
+        # Build a species->count map from the same profile list so the
+        # prefix language matches the actual required cast (handles
+        # same-species casts like "rabbit + rabbit mom").
+        counts = species_count_map(profiles)
+        if not counts:
+            return ""
+        total = sum(counts.values())
+        species_set = list(counts.keys())
+        count_phrase = _format_species_count_phrase(counts)  # "2 rabbits and 1 squirrel"
+
         parts: List[str] = []
-        # "X and Y" — both characters named at the very start.
+        # Lead with each character's color+species label so diffusion
+        # weighs both at the front.
         parts.append(" and ".join(labels))
-        parts.append(f"two different animal species in one image: {', '.join(species_set)}")
-        # Explicit negatives by species — strongest known anti-mirror
-        # signal for diffusion models when placed early in the prompt.
-        for s in species_set:
-            parts.append(f"not two {s}")
-        parts.append("do not draw mirrored characters")
-        parts.append("do not draw both characters as the same species")
+        parts.append(f"this image contains exactly {count_phrase}")
+        parts.append(f"render exactly {total} animal subjects in total")
+
+        # Per-species over-count negatives only. For required=1 squirrel
+        # we forbid "two squirrels"; for required=2 rabbits we forbid
+        # "three rabbits" but NEVER "two rabbits" — that would block
+        # legitimate same-species output.
+        count_words = {2: "two", 3: "three", 4: "four", 5: "five", 6: "six"}
+        for species, required in counts.items():
+            plural = _pluralize(species)
+            over = required + 1
+            word = count_words.get(over, str(over))
+            parts.append(f"not {word} {plural}")
+            parts.append(f"no more than {required} {plural if required > 1 else species}")
+
+        # Cross-species "do not swap" language only when the cast has
+        # multiple distinct species.
+        if len(species_set) >= 2:
+            parts.append(
+                f"distinct species required: {', '.join(species_set)}"
+            )
+            parts.append("do not draw both characters as the same species")
+            parts.append("do not swap species between characters")
+
         return ", ".join(parts)
 
     def _build_color_prefix(self, profile: Dict[str, Any]) -> str:

--- a/app/services/runner_image_prompts_support.py
+++ b/app/services/runner_image_prompts_support.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any, Dict, List
 
 from app.services.character_visual_profile_llm import (
@@ -10,6 +12,109 @@ from app.services.image_prompt_policy import (
     build_image_prompt_policy_blocks,
     clean_image_prompt_text,
 )
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _scene_position_anchor(
+    scene_index: int,
+    total: int,
+    scene: Dict[str, Any],
+    narration_text: str,
+) -> str:
+    """Strong scene-unique anchor placed early in the prompt.
+
+    Diffusion models weight the beginning of the prompt most heavily. By
+    inserting the current scene's position + title + a slice of the actual
+    narration BEFORE the long character-identity lock blocks, the model
+    is forced to encode this scene's unique story moment instead of
+    settling on "a generic character portrait" shared with other scenes.
+    The clean_image_prompt_text() pass strips any "主角" labels that would
+    otherwise leak into the rendered image as Chinese characters.
+    """
+    pos = scene_index + 1
+    title = str(scene.get("scene_title") or "").strip()
+    moment = clean_image_prompt_text(narration_text)[:160] if narration_text else ""
+    parts: List[str] = [f"scene {pos} of {total}"]
+    if title:
+        parts.append(f"scene title: {title}")
+    if moment:
+        parts.append(f"current story moment: {moment}")
+    parts.append(
+        "this is a unique moment of the story, not a generic character portrait"
+    )
+    return ", ".join(parts)
+
+
+def _anti_repeat_block(scene_index: int, total: int) -> str:
+    """Anti-repetition tail block — explicitly demand visual variation
+    across scenes. Without this, when every scene's prompt shares the
+    same long character lock, the diffusion model tends to converge on
+    a single canonical pose for every scene."""
+    pos = scene_index + 1
+    return (
+        f"this is scene {pos} of {total}; "
+        "the composition, camera angle, environment, mood, and visible action "
+        "must visibly differ from the other scenes of this story; "
+        "do not reuse the composition, lighting, or background from any other scene"
+    )
+
+
+def _scene_action_fallback(
+    visual_description: str,
+    narration: str,
+    scene_title: str,
+) -> str:
+    """If visual_description is empty (storyboard LLM enrichment failed),
+    synthesize a scene-specific action hint from whatever IS available so
+    the scene_anchor and scene_action_block don't end up empty. Without
+    this, an LLM failure makes every scene's "visual focus" collapse to
+    the same string and the prompts become indistinguishable."""
+    visual = clean_image_prompt_text(visual_description)
+    if visual:
+        return visual
+    story = clean_image_prompt_text(narration)
+    if story:
+        # Trim long narration to a focused visual hint
+        return story[:200]
+    title = clean_image_prompt_text(scene_title)
+    if title:
+        return f"the scene depicting {title}"
+    return ""
+
+
+def _write_image_prompts_debug(workflow_id: str, prompts: List[Dict[str, Any]]) -> None:
+    """Write a per-run debug file with every scene's final prompt so the
+    output can be inspected after generation. Failures here are non-fatal
+    — debug logging must never break the actual image generation."""
+    wf = str(workflow_id or "").strip()
+    if not wf:
+        return
+    try:
+        out_dir = PROJECT_ROOT / "assets" / "mock" / wf
+        out_dir.mkdir(parents=True, exist_ok=True)
+        debug_path = out_dir / "image_prompts_debug.json"
+        debug_payload = {
+            "workflow_id": wf,
+            "scene_count": len(prompts),
+            "prompts": [
+                {
+                    "scene_id": str(p.get("scene_id") or "").strip(),
+                    "scene_title": str(p.get("scene_title") or "").strip(),
+                    "required_character_names": p.get("required_character_names") or [],
+                    "prompt": str(p.get("prompt") or ""),
+                    "prompt_char_count": len(str(p.get("prompt") or "")),
+                }
+                for p in prompts
+            ],
+        }
+        with open(debug_path, "w", encoding="utf-8") as f:
+            json.dump(debug_payload, f, ensure_ascii=False, indent=2)
+        print(
+            f"[RunnerImagePromptsSupport] wrote per-scene image prompts debug → {debug_path}"
+        )
+    except Exception as error:  # noqa: BLE001
+        print(f"[RunnerImagePromptsSupport] image prompts debug write failed: {error}")
 
 
 class RunnerImagePromptsSupport:
@@ -103,8 +208,9 @@ class RunnerImagePromptsSupport:
                 for scene in scenes
                 if isinstance(scene, dict)
             }
+            total_shots = len(shot_items)
 
-            for shot in shot_items:
+            for shot_index, shot in enumerate(shot_items):
                 shot_id = str(shot.get("shot_id") or "").strip()
                 scene_id = str(shot.get("scene_id") or "").strip()
                 scene_title = str(shot.get("scene_title") or "").strip()
@@ -114,6 +220,16 @@ class RunnerImagePromptsSupport:
                 text = str(shot.get("text") or "").strip()
 
                 scene_data = scene_map.get(scene_id) or {}
+
+                # Robust scene-specific focus: when visual_description is
+                # empty (LLM enrichment failed), synthesize from narration
+                # or scene_title so the scene anchor isn't reduced to a
+                # blank "visual focus: " that's identical across scenes.
+                scene_focus = _scene_action_fallback(
+                    visual_description=visual_description,
+                    narration=text,
+                    scene_title=scene_title,
+                )
                 enriched_scene_characters = (
                     runner._scene_characters.enriched_scene_characters_from_manifest(
                         outputs,
@@ -145,7 +261,7 @@ class RunnerImagePromptsSupport:
                     outputs, scene_data
                 )
 
-                clean_visual_description = clean_image_prompt_text(visual_description)
+                clean_visual_description = clean_image_prompt_text(visual_description) or scene_focus
 
                 shot_anchor = (
                     f"scene title: {scene_title}, "
@@ -155,12 +271,26 @@ class RunnerImagePromptsSupport:
                 )
 
                 story_anchor = f"story context: {text}"
+                # scene_focus replaces empty visual_description so the
+                # policy's scene_action_block always carries scene-specific
+                # content, even when the storyboard LLM enrichment failed.
                 policy_blocks = build_image_prompt_policy_blocks(
                     workflow_input=ctx.input,
                     outputs=profile_outputs,
-                    visual_description=visual_description,
+                    visual_description=visual_description or scene_focus,
                     narration=text,
                     subject_hint=character_anchor,
+                )
+
+                scene_position_anchor = _scene_position_anchor(
+                    scene_index=shot_index,
+                    total=total_shots,
+                    scene=scene_data or {"scene_title": scene_title},
+                    narration_text=text,
+                )
+                anti_repeat_block = _anti_repeat_block(
+                    scene_index=shot_index,
+                    total=total_shots,
                 )
                 if not character_visual_profile:
                     character_visual_profile = policy_blocks.get("profile") or {}
@@ -172,8 +302,27 @@ class RunnerImagePromptsSupport:
                 color_prefix = self._build_color_prefix(character_visual_profile)
 
                 is_multi_character_scene = len(required_character_names) >= 2
+                # In multi-character scenes the singular color_prefix puts only the
+                # PRIMARY character at position 0 (e.g. "white rabbit, white fur").
+                # The diffusion model then renders BOTH characters as the same
+                # species — "two mirrored rabbits" instead of "rabbit + squirrel".
+                # Override position 0 with a builder that names every species and
+                # adds explicit "not two <species>" negatives.
+                if is_multi_character_scene:
+                    multi_prefix = self._build_multi_character_color_prefix(
+                        character_visual_profiles
+                    )
+                    if multi_prefix:
+                        color_prefix = multi_prefix
+                # `scene_position_anchor` is placed right after color_prefix
+                # so the early-prompt weight (most important for diffusion)
+                # encodes THIS scene's identity before the shared
+                # character-lock blocks. `anti_repeat_block` is appended at
+                # the very end so the negative-style instruction caps the
+                # sequence with explicit "do not duplicate previous scene".
                 prompt_parts = [
                     color_prefix,
+                    scene_position_anchor,
                     global_style_anchor,
                     shot_anchor,
                     character_anchor,
@@ -186,10 +335,12 @@ class RunnerImagePromptsSupport:
                     story_anchor,
                     policy_blocks.get("subject_negative_block"),
                     negative_block,
+                    anti_repeat_block,
                 ]
                 if is_multi_character_scene:
                     prompt_parts = [
                         color_prefix,
+                        scene_position_anchor,
                         global_style_anchor,
                         compact_trait_block,
                         shot_anchor,
@@ -200,6 +351,7 @@ class RunnerImagePromptsSupport:
                         policy_blocks.get("scene_action_block"),
                         story_anchor,
                         negative_block,
+                        anti_repeat_block,
                     ]
 
                 prompt = ", ".join(
@@ -223,6 +375,7 @@ class RunnerImagePromptsSupport:
                     }
                 )
 
+            _write_image_prompts_debug(getattr(ctx, "workflow_id", ""), prompts)
             return {
                 "provider": "image_prompt_builder",
                 "character_visual_profile": character_visual_profile,
@@ -231,13 +384,22 @@ class RunnerImagePromptsSupport:
                 "prompts": prompts,
             }
 
-        for scene in scenes:
+        total_scenes = len(scenes)
+        for scene_index, scene in enumerate(scenes):
             scene_id = str(scene.get("scene_id") or "").strip()
             narration = str(scene.get("narration", "")).strip()
             visual_description = str(scene.get("visual_description", "")).strip()
             shot_type = str(scene.get("shot_type", "medium")).strip()
             transition = str(scene.get("transition", "fade")).strip()
             scene_title = str(scene.get("scene_title", "")).strip()
+
+            # Robust scene focus fallback so the per-scene visual content
+            # is never blank even when storyboard LLM enrichment fails.
+            scene_focus = _scene_action_fallback(
+                visual_description=visual_description,
+                narration=narration,
+                scene_title=scene_title,
+            )
             enriched_scene_characters = (
                 runner._scene_characters.enriched_scene_characters_from_manifest(
                     outputs,
@@ -268,7 +430,7 @@ class RunnerImagePromptsSupport:
                 outputs, scene
             )
 
-            clean_visual_description = clean_image_prompt_text(visual_description)
+            clean_visual_description = clean_image_prompt_text(visual_description) or scene_focus
 
             scene_anchor = (
                 f"scene title: {scene_title}, "
@@ -281,9 +443,20 @@ class RunnerImagePromptsSupport:
             policy_blocks = build_image_prompt_policy_blocks(
                 workflow_input=ctx.input,
                 outputs=profile_outputs,
-                visual_description=visual_description,
+                visual_description=visual_description or scene_focus,
                 narration=narration,
                 subject_hint=character_anchor,
+            )
+
+            scene_position_anchor = _scene_position_anchor(
+                scene_index=scene_index,
+                total=total_scenes,
+                scene=scene,
+                narration_text=narration,
+            )
+            anti_repeat_block = _anti_repeat_block(
+                scene_index=scene_index,
+                total=total_scenes,
             )
             if not character_visual_profile:
                 character_visual_profile = policy_blocks.get("profile") or {}
@@ -291,8 +464,23 @@ class RunnerImagePromptsSupport:
             color_prefix = self._build_color_prefix(character_visual_profile)
 
             is_multi_character_scene = len(required_character_names) >= 2
+            # Override position 0 with the multi-character species anchor when
+            # there are 2+ required characters — see commentary in the shot
+            # branch above. Without this, both characters render as the
+            # primary species (mirrored rabbits / mirrored squirrels).
+            if is_multi_character_scene:
+                multi_prefix = self._build_multi_character_color_prefix(
+                    character_visual_profiles
+                )
+                if multi_prefix:
+                    color_prefix = multi_prefix
+            # scene_position_anchor goes early so this scene's identity
+            # gets the most attention from the diffusion model; the
+            # anti_repeat_block goes last so the negative-style demand
+            # to differ from other scenes is the final instruction.
             prompt_parts = [
                 color_prefix,
+                scene_position_anchor,
                 global_style_anchor,
                 scene_anchor,
                 character_anchor,
@@ -305,10 +493,12 @@ class RunnerImagePromptsSupport:
                 story_anchor,
                 policy_blocks.get("subject_negative_block"),
                 negative_block,
+                anti_repeat_block,
             ]
             if is_multi_character_scene:
                 prompt_parts = [
                     color_prefix,
+                    scene_position_anchor,
                     global_style_anchor,
                     compact_trait_block,
                     scene_anchor,
@@ -319,6 +509,7 @@ class RunnerImagePromptsSupport:
                     policy_blocks.get("scene_action_block"),
                     story_anchor,
                     negative_block,
+                    anti_repeat_block,
                 ]
 
             prompt = ", ".join(
@@ -341,6 +532,7 @@ class RunnerImagePromptsSupport:
                 }
             )
 
+        _write_image_prompts_debug(getattr(ctx, "workflow_id", ""), prompts)
         return {
             "provider": "image_prompt_builder",
             "character_visual_profile": character_visual_profile,
@@ -348,6 +540,93 @@ class RunnerImagePromptsSupport:
             "character_anchor": character_anchor_metadata,
             "prompts": prompts,
         }
+
+    def _build_multi_character_color_prefix(
+        self,
+        character_visual_profiles: Dict[str, Any],
+    ) -> str:
+        """Position-0 prefix for multi-character scenes.
+
+        When a scene has 2+ required characters, the singular
+        `_build_color_prefix(profile)` (which only sees the PRIMARY
+        character) puts "white rabbit, white fur" at the start of the
+        prompt — diffusion weights this most heavily and the model
+        then renders BOTH characters as rabbits (or even mirrored
+        copies of one rabbit). This builder pulls every character's
+        species + the first color trait so the very first tokens of
+        the prompt are "white long-eared rabbit and brown bushy-tailed
+        squirrel, two different animal species". The explicit
+        "not two <species>" negatives are critical — diffusion models
+        respond strongly to that pattern when it appears early.
+        """
+        profiles = (character_visual_profiles or {}).get("profiles") or []
+        if not isinstance(profiles, list) or len(profiles) < 2:
+            return ""
+
+        COLOR_WORDS = {
+            "red", "blue", "green", "yellow", "orange", "purple", "pink",
+            "white", "black", "gray", "grey", "brown", "gold", "silver",
+            "cream", "teal", "cyan", "magenta", "violet", "indigo",
+            "红", "蓝", "绿", "黄", "橙", "紫", "粉", "白", "黑", "灰", "棕", "金",
+        }
+
+        labels: List[str] = []
+        species_set: List[str] = []
+
+        for profile in profiles:
+            if not isinstance(profile, dict):
+                continue
+
+            species = str(profile.get("species") or "").strip()
+            display = str(profile.get("display_name") or "").strip()
+            subject = str(profile.get("subject") or "").strip()
+            identity = str(profile.get("visual_identity") or "").strip()
+            must_keep = profile.get("must_keep") or []
+            if not isinstance(must_keep, list):
+                must_keep = []
+
+            # Pick the first must_keep trait that carries a color word
+            # so the label reads as "{color/trait} {species}" — e.g.
+            # "white long-eared rabbit" or "brown bushy-tailed squirrel".
+            color_trait = ""
+            for trait in must_keep:
+                t = str(trait or "").strip()
+                if not t:
+                    continue
+                if any(c in t.lower() for c in COLOR_WORDS):
+                    color_trait = t
+                    break
+            if not color_trait and identity:
+                color_trait = identity.split(".")[0].strip()
+
+            anchor_species = species or display or subject
+            if not anchor_species:
+                continue
+            if anchor_species not in species_set:
+                species_set.append(anchor_species)
+
+            label = (
+                f"{color_trait} {anchor_species}".strip()
+                if color_trait
+                else anchor_species
+            )
+            if label and label not in labels:
+                labels.append(label)
+
+        if len(labels) < 2:
+            return ""
+
+        parts: List[str] = []
+        # "X and Y" — both characters named at the very start.
+        parts.append(" and ".join(labels))
+        parts.append(f"two different animal species in one image: {', '.join(species_set)}")
+        # Explicit negatives by species — strongest known anti-mirror
+        # signal for diffusion models when placed early in the prompt.
+        for s in species_set:
+            parts.append(f"not two {s}")
+        parts.append("do not draw mirrored characters")
+        parts.append("do not draw both characters as the same species")
+        return ", ".join(parts)
 
     def _build_color_prefix(self, profile: Dict[str, Any]) -> str:
         """Return a tight color+identity anchor prepended to every scene prompt.

--- a/app/services/runner_scene_characters.py
+++ b/app/services/runner_scene_characters.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from app.services.runner_image_prompts_support import (
+    build_anatomy_separation_rules,
+    species_count_map,
+)
+
 
 class RunnerSceneCharactersSupport:
     """Scene-level character binding and prompt-contract helpers.
@@ -243,6 +248,7 @@ class RunnerSceneCharactersSupport:
         required_names: List[str] = []
         primary_names: List[str] = []
         secondary_names: List[str] = []
+        manifest_items: List[Dict[str, Any]] = []
 
         for binding in scene_characters:
             if not isinstance(binding, dict):
@@ -260,6 +266,8 @@ class RunnerSceneCharactersSupport:
             name = display_name or species
             if not name:
                 continue
+
+            manifest_items.append(manifest_item)
 
             if name not in required_names:
                 required_names.append(name)
@@ -291,9 +299,6 @@ class RunnerSceneCharactersSupport:
             "do not merge multiple characters into one body",
             "do not create a hybrid creature that combines traits from multiple required characters",
             "do not replace one character with another character",
-            "anatomy separation: only rabbit characters may have long upright ears; only turtle characters may have shells",
-            "turtle anatomy rule: turtles must have an earless rounded reptile head with no external ears",
-            "rabbit anatomy rule: rabbits must not have a shell or turtle body",
             "give every required character clear readable scale and enough visual space",
             f"{primary_text} may lead the action, but must not hide, replace, or visually erase the other required characters",
         ]
@@ -306,6 +311,24 @@ class RunnerSceneCharactersSupport:
         parts.append(
             "if any required scene character is missing, the image is invalid and should be regenerated"
         )
+
+        # Dynamic per-cast anatomy rules — derived from each character's
+        # profile, not hardcoded to any species. Same-species casts get
+        # empty string (no cross-species body-part conflict to guard).
+        anatomy_rules = build_anatomy_separation_rules(manifest_items)
+        if anatomy_rules:
+            parts.append(anatomy_rules)
+
+        # Expected per-species count callout. For "rabbit + rabbit mom"
+        # this becomes "expected cast count: 2 rabbits"; for
+        # "rabbit + squirrel" it becomes "expected cast count: 1 rabbit, 1 squirrel".
+        counts = species_count_map(manifest_items)
+        if counts:
+            count_text = ", ".join(
+                f"{n} {sp if n == 1 else sp + 's'}"
+                for sp, n in counts.items()
+            )
+            parts.append(f"expected cast count: {count_text}")
 
         return "; ".join(parts)
 

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -11,6 +11,7 @@ from app.services.image_quality_retry_policy import (
     quality_max_retries,
     summarize_selection_for_history,
 )
+from app.services.runner_image_prompts_support import ensure_multi_character_anchor
 
 
 class RunnerSingleSceneImageSupport:
@@ -142,6 +143,17 @@ class RunnerSingleSceneImageSupport:
             fallback_scene_title=str(scene.get("scene_title") or "").strip(),
         )
 
+        # Last-mile multi-character guard: if the scene has 2+ required
+        # characters but base_prompt lacks the anti-mirror anchor (most
+        # commonly because outputs["image_prompts"] was missing this
+        # scene_id and we fell back to bare visual_description), prepend
+        # the roster block so the diffusion model still gets the
+        # "two different species, not two X, not two Y" signal.
+        base_prompt = ensure_multi_character_anchor(
+            base_prompt,
+            asset_meta.get("characters") or [],
+        )
+
         candidate_asset_refs: List[Dict[str, Any]] = []
 
         for candidate_index, candidate_suffix in enumerate(["candidate_a", "candidate_b"]):
@@ -218,6 +230,13 @@ class RunnerSingleSceneImageSupport:
             scene=scene,
             prompt_item=prompt_item,
             fallback_scene_title=str(scene.get("scene_title") or "").strip(),
+        )
+        # Last-mile multi-character guard — same purpose as the pillow
+        # branch above. Critical here because the API path drives
+        # generation for the real image-provider integration.
+        base_prompt = ensure_multi_character_anchor(
+            base_prompt,
+            asset_meta.get("characters") or [],
         )
         negative_prompt = self.scene_negative_prompt_from_characters(
             asset_meta["characters"]

--- a/app/services/runner_storyboard.py
+++ b/app/services/runner_storyboard.py
@@ -130,6 +130,38 @@ class RunnerStoryboardSupport:
             "Each prompt must describe a vivid, distinct illustration scene."
         )
 
+        # When the manifest lists >=2 characters, every scene description
+        # must name every species — otherwise the downstream image
+        # prompt's per-scene text only mentions one species, and the
+        # diffusion model renders both required characters as that
+        # species (e.g. two mirrored squirrels for a "rabbit+squirrel"
+        # story).
+        try:
+            multi_character_mode = (
+                isinstance(manifest_items, list) and len([
+                    item for item in manifest_items
+                    if isinstance(item, dict)
+                    and (
+                        str(item.get("display_name") or "").strip()
+                        or str(item.get("species") or "").strip()
+                    )
+                ]) >= 2
+            )
+        except Exception:
+            multi_character_mode = False
+
+        character_naming_rule = ""
+        if multi_character_mode:
+            character_naming_rule = (
+                "5. EVERY scene description MUST explicitly name ALL of the "
+                "required characters listed above. If the narration mentions "
+                "only one character explicitly, you must still include the "
+                "other character(s) by their species or display name in the "
+                "description (e.g. 'while the squirrel watches from behind a "
+                "tree'). Do NOT write a scene that only names one species — "
+                "this is the most common failure mode.\n"
+            )
+
         user_prompt = (
             f"Story topic: {topic}\n"
             f"Art style: {visual_style} illustration, cute chibi anime, soft warm colors\n"
@@ -145,7 +177,9 @@ class RunnerStoryboardSupport:
             "   Example: 'The rabbit dashes forward with powerful leaps, ears streaming behind, while the turtle plods steadily on the dusty track.'\n"
             "2. Then describe the SPECIFIC environment/location matching the narration.\n"
             "3. End with the required lighting palette for that scene.\n"
-            "4. Each scene must be visually DISTINCT from all others — different action, location, and color.\n\n"
+            "4. Each scene must be visually DISTINCT from all others — different action, location, and color.\n"
+            + character_naming_rule +
+            "\n"
             "Return ONLY valid JSON, no markdown:\n"
             '{"scenes": [{"scene_id": "scene_01", "visual_description": "..."}, ...]}'
         )

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -374,6 +374,8 @@ function performDeleteRecentVideo() {
   deleteVideoTarget.value = null
   if (!target) return
 
+  // Strip from the recent list FIRST so any reactive consumer sees the
+  // post-delete state.
   recentFinalVideoUrls.value = recentFinalVideoUrls.value.filter(
     (item) => item !== target,
   )
@@ -391,15 +393,99 @@ function performDeleteRecentVideo() {
     /* UI state still reflects the deletion */
   }
 
-  if (finalVideoUrl.value === target) {
+  const wasCurrent = finalVideoUrl.value === target
+
+  if (wasCurrent) {
+    // CRITICAL: deleting the currently-playing video is treated as
+    // discarding the run that produced it. If we only clear
+    // `finalVideoUrl` and leave `currentWorkflowResponse` /
+    // `STORAGE_KEY_WORKFLOW` in place, two reactive paths immediately
+    // try to "finish" the run and restart generation:
+    //
+    //   · The watcher on `isWorkflowReadyForRender` (the auto-render
+    //     trigger) uses `if (finalVideoUrl.value) return` as its
+    //     "already done" guard. With finalVideoUrl emptied but the
+    //     completed response still present, the guard fails and the
+    //     watcher calls renderFinalVideoIfReady() → backend re-renders.
+    //
+    //   · `resumePendingSceneGenerationAfterRestore()` uses the same
+    //     finalVideoUrl guard. On any subsequent restore / nav back,
+    //     it sees pending placeholders + empty finalVideoUrl and fires
+    //     `refreshImageReview()` → backend regenerates candidate images.
+    //
+    // The only safe fix is to fully sever the workflow association the
+    // same way 放弃当前生成 does: wipe response / payload / status /
+    // placeholders / per-step text + drop the persisted workflow_id /
+    // payload / refresh-cancel marker. The blacklist below is kept as
+    // belt-and-suspenders in case any other code path still tries to
+    // restore the URL by string match.
     finalVideoUrl.value = ''
+    finalVideoText.value = ''
+    finalVideoAudioEnabled.value = true
+    finalVideoRenderInFlight.value = false
+    finalVideoRendering.value = false
+
+    currentWorkflowResponse.value = null
+    currentWorkflowPayload.value = null
+    workflowStatusData.value = null
+    activeWorkflowId.value = ''
+    loading.value = false
+    cancelRequested.value = false
+    workflowRunElapsedSec.value = 0
+
+    // Stop any in-flight image refresh so it can't resolve after this
+    // wipe and overwrite the cleaned state with stale data.
+    imageReviewRefreshAbortController?.abort()
+    imageReviewRefreshAbortController = null
+    refreshingImageReview.value = false
+    imageReviewRefreshCancelled.value = false
+    imageRefreshPausedByUser.value = false
+    sceneRefreshQueue.value = []
+    sceneRefreshingId.value = ''
+    clearImageReviewAutoRefreshTimer()
+    reviewAutoRefreshFiredOnce = false
+    restoreAutoRefreshFired = false
+
+    // Drop every per-run preview field so review tab doesn't keep
+    // showing the deleted run's story / images / audio.
+    storyText.value = ''
+    storyboardText.value = ''
+    imagePromptsText.value = ''
+    imageAssetsText.value = ''
+    imageReviewText.value = ''
+    videoPromptsText.value = ''
+    narrationText.value = ''
+    subtitlesText.value = ''
+    renderPlanText.value = ''
+    stepSummaries.value = []
+    characterCandidatesText.value = ''
+    characterManifestText.value = ''
+    resultText.value = ''
+    reviewPlaceholders.value = []
+    selectingSceneId.value = ''
+    userHasInteractedWithImages.value = false
+    mockAudioIndexUrl.value = ''
+    mockAudioSceneGroups.value = []
+    mockAudioDirectoryText.value = ''
+    errorMessage.value = ''
+
+    // Forget the workflow on disk too. Without these removals, a page
+    // refresh would re-read outputs.json via the reattach path and the
+    // blacklist would only intercept finalVideoUrl — currentWorkflow-
+    // Response would still be populated, re-triggering the watcher
+    // chain described above.
     try {
       localStorage.removeItem(STORAGE_KEY_VIDEO_URL)
+      localStorage.removeItem(STORAGE_KEY_WORKFLOW)
+      localStorage.removeItem(STORAGE_KEY_PAYLOAD)
+      localStorage.removeItem(STORAGE_KEY_REFRESH_CANCELLED)
     } catch { /* ignore */ }
   }
 
-  // Persist the deletion so a page reload that re-reads outputs.json
-  // (via applyWorkflowResponse) can't bring the URL back to life.
+  // Persist the deletion as a defensive backstop. Even after the full
+  // workflow wipe above, if any other code path (e.g. SPA nav from the
+  // Landing showcase that reads outputs by direct URL) tries to push
+  // the URL back into recent list, the blacklist will reject it.
   deletedVideoUrlsSet.value = new Set(deletedVideoUrlsSet.value)
   deletedVideoUrlsSet.value.add(target)
   persistDeletedVideoUrlsSet()
@@ -719,6 +805,20 @@ onMounted(() => {
       waitForAsyncWorkflowOutputs(savedWorkflowId)
         .then(asyncData => {
           if (asyncData) {
+            // Same blacklist guard as the direct-results path below —
+            // if the user already deleted this run's final video, don't
+            // resurrect it on async reattach either.
+            const restoredFinalUrl = extractFinalVideoUrl(asyncData)
+            if (restoredFinalUrl && deletedVideoUrlsSet.value.has(restoredFinalUrl)) {
+              try {
+                localStorage.removeItem(STORAGE_KEY_WORKFLOW)
+                localStorage.removeItem(STORAGE_KEY_PAYLOAD)
+                localStorage.removeItem(STORAGE_KEY_VIDEO_URL)
+                localStorage.removeItem(STORAGE_KEY_REFRESH_CANCELLED)
+              } catch { /* ignore */ }
+              currentWorkflowPayload.value = null
+              return
+            }
             applyWorkflowResponse(asyncData)
             // Match runWorkflow()'s post-completion path so the deferred
             // candidate-image refresh kicks in automatically (sets
@@ -755,6 +855,26 @@ onMounted(() => {
             .catch(() => {})
         }
         if (data.outputs || data.steps) {
+          // Defensive guard: if the fetched workflow's final-video URL is
+          // on the user's deletion blacklist, they've already discarded
+          // this run. Calling applyWorkflowResponse would populate
+          // currentWorkflowResponse with the deleted run's data, which
+          // then triggers the isWorkflowReadyForRender watcher and gets
+          // stuck on "等待用户触发渲染" because the URL is blocked from
+          // restoration but the rest of the response is live. Wipe the
+          // persisted workflow keys and bail so the new tab loads to a
+          // clean idle state instead of resurrecting the deleted run.
+          const restoredFinalUrl = extractFinalVideoUrl(data as WorkflowRunResponse)
+          if (restoredFinalUrl && deletedVideoUrlsSet.value.has(restoredFinalUrl)) {
+            try {
+              localStorage.removeItem(STORAGE_KEY_WORKFLOW)
+              localStorage.removeItem(STORAGE_KEY_PAYLOAD)
+              localStorage.removeItem(STORAGE_KEY_VIDEO_URL)
+              localStorage.removeItem(STORAGE_KEY_REFRESH_CANCELLED)
+            } catch { /* ignore */ }
+            currentWorkflowPayload.value = null
+            return
+          }
           applyWorkflowResponse(data)
           resumePendingSceneGenerationAfterRestore()
         }


### PR DESCRIPTION
## Summary

- Multi-character prompts and selector now reason about per-species counts (`{rabbit: 1, squirrel: 1}` vs `{rabbit: 2}`), so same-species casts like "小兔子和兔妈妈" are no longer falsely flagged as duplicates.
- Selector treats "missing required color" in multi-character scenes as a hard fail, so wrong-species candidates can no longer outrank correct ones in vision_dominant mode.
- Removed hardcoded rabbit/turtle anatomy lines in favor of dynamic per-cast anatomy rules derived from each character's `must_keep` / `visual_identity` body-part vocabulary.
- Multi-character `negative_prompt` is now plumbed through to the image provider; the existing smart-retry path is reactivated because hard-fail candidates now actually score below the pass threshold.
- Pre-existing color-keyword substring leak fixed (`"long-eared"` no longer false-matches `"red"`).

## Test plan

- [ ] Cross-species run ("小兔子和小松鼠") — verify selector rejects single-species candidates and retries
- [ ] Same-species run ("小兔子和兔妈妈") — verify prompts say "exactly 2 rabbits" and don't forbid "two rabbits"
- [ ] N≥3 same-species run ("三只小猪") — verify count phrasing scales
- [ ] Confirm no hardcoded species in newly added code (`grep -E 'rabbit|squirrel' app/services/runner_image_prompts_support.py` only shows docstring examples)
