### PR TITLE
fix: audio duration overshoot on 120s/180s presets

### DIFF
--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -283,11 +283,12 @@ class RunnerAudioRenderSupport:
             shot_id = line.get("shot_id")
 
             char_count = max(1, len(text))
-            # Chinese children's story TTS narrates at ~5 chars/sec (slower,
-            # clearer pronunciation). The story plan calibrates: 280 chars/60s,
-            # 650/120s, 960/180s → 4.7–5.4 chars/sec. Using 5.0 as the
-            # estimate so the ±30% speed-retry threshold is not triggered on
-            # normal narration segments and speed adjustment stays a fine-tune.
+            # Chinese children's story TTS narrates at ~4.7 chars/sec (slower,
+            # clearer pronunciation). The story plan calibrates all durations to
+            # this rate: 280 chars/60s, 560/120s, 840/180s.
+            # Using 5.0 as the estimate so the ±30% speed-retry threshold is
+            # not triggered on normal narration segments and speed adjustment
+            # stays a fine-tune.
             duration_estimate_sec = max(2, min(20, round(char_count / 5)))
             duration_sec = float(duration_estimate_sec)
             duration_source = "estimate"

--- a/app/services/runner_story_text.py
+++ b/app/services/runner_story_text.py
@@ -25,6 +25,10 @@ class RunnerStoryTextSupport:
         return 18
 
     def duration_story_plan(self, duration_sec: int) -> Dict[str, int]:
+        # Char counts are scaled to ~4.67 chars/sec (the calibrated rate
+        # that produces ~60s audio for the 60s preset). Previously 120s
+        # and 180s used a higher implicit rate (~5.4 chars/sec), which
+        # consistently overshot their targets by ~20-30s.
         supported = [
             {
                 "duration_sec": 60,
@@ -36,16 +40,16 @@ class RunnerStoryTextSupport:
             {
                 "duration_sec": 120,
                 "scene_count": 12,
-                "target_min_chars": 560,
-                "target_max_chars": 700,
-                "target_chars": 650,
+                "target_min_chars": 500,
+                "target_max_chars": 620,
+                "target_chars": 560,
             },
             {
                 "duration_sec": 180,
                 "scene_count": 18,
-                "target_min_chars": 840,
-                "target_max_chars": 1050,
-                "target_chars": 960,
+                "target_min_chars": 770,
+                "target_max_chars": 910,
+                "target_chars": 840,
             },
         ]
         for item in supported:


### PR DESCRIPTION
Fixes #111

## Summary

- After lowering the 60s preset's TTS rate to 4.67 chars/sec, the 120s/180s rows in `duration_story_plan()` were left at the old higher rate (~5.4 chars/sec), so those videos consistently overshot target by ~20–30s.
- Rescale `target_min_chars` / `target_max_chars` / `target_chars` on both rows so all three presets sit at exactly 4.67 chars/sec.
- Updated the corresponding comment in `runner_audio_render_support.py`.

| duration | before (chars / rate) | after (chars / rate) |
|---|---|---|
| 60s  | 280 / 4.67 ✓ | 280 / 4.67 (unchanged) |
| 120s | 650 / 5.42 ✗ | 560 / 4.67 |
| 180s | 960 / 5.33 ✗ | 840 / 4.67 |

## Test plan

- [ ] Run a 60s video — confirm length stays within ±5s of 60s
- [ ] Run a 120s video — confirm length within ±10s of 120s
- [ ] Run a 180s video — confirm length within ±15s of 180s
