### PR TITLE
fix: tune 120s/180s char counts to land on target (follow-up to #114)

### DIFF
--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -283,9 +283,9 @@ class RunnerAudioRenderSupport:
             shot_id = line.get("shot_id")
 
             char_count = max(1, len(text))
-            # Chinese children's story TTS narrates at ~4.7 chars/sec (slower,
-            # clearer pronunciation). The story plan calibrates all durations to
-            # this rate: 280 chars/60s, 560/120s, 840/180s.
+            # Chinese children's story TTS narrates at ~5.1 chars/sec
+            # (measured empirically). The story plan targets:
+            # 280/60s, 610/120s, 920/180s.
             # Using 5.0 as the estimate so the ±30% speed-retry threshold is
             # not triggered on normal narration segments and speed adjustment
             # stays a fine-tune.

--- a/app/services/runner_story_text.py
+++ b/app/services/runner_story_text.py
@@ -25,10 +25,12 @@ class RunnerStoryTextSupport:
         return 18
 
     def duration_story_plan(self, duration_sec: int) -> Dict[str, int]:
-        # Char counts are scaled to ~4.67 chars/sec (the calibrated rate
-        # that produces ~60s audio for the 60s preset). Previously 120s
-        # and 180s used a higher implicit rate (~5.4 chars/sec), which
-        # consistently overshot their targets by ~20-30s.
+        # Char counts are calibrated against real TTS output. Round 1 (#111)
+        # rescaled 120s/180s assuming 4.67 chars/sec, which produced
+        # 120s ≈ 110s / 180s ≈ 165s (undershoot ~10s) because actual TTS
+        # speed measured ≈ 5.1 chars/sec. This round bumps 120s/180s to
+        # land on target while leaving 60s alone — it was already
+        # acceptable in production.
         supported = [
             {
                 "duration_sec": 60,
@@ -40,16 +42,16 @@ class RunnerStoryTextSupport:
             {
                 "duration_sec": 120,
                 "scene_count": 12,
-                "target_min_chars": 500,
-                "target_max_chars": 620,
-                "target_chars": 560,
+                "target_min_chars": 550,
+                "target_max_chars": 670,
+                "target_chars": 610,
             },
             {
                 "duration_sec": 180,
                 "scene_count": 18,
-                "target_min_chars": 770,
-                "target_max_chars": 910,
-                "target_chars": 840,
+                "target_min_chars": 830,
+                "target_max_chars": 1010,
+                "target_chars": 920,
             },
         ]
         for item in supported:


### PR DESCRIPTION
Follow-up to #111 / PR #114.

## Summary

- Round 1 (PR #114) rescaled 120s/180s assuming TTS rate of 4.67 chars/sec — derived from the 60s preset's working numbers. Empirical test showed actual SiliconFlow TTS rate is ≈5.1 chars/sec.
- After round 1: 120s produced 1:50 (-10s undershoot).
- This PR bumps 120s/180s `target_chars` and ranges to land on target at the measured 5.1 chars/sec rate. 60s is left unchanged because it was already acceptable.

| duration | round 1 chars | round 2 chars | expected audio |
|---|---|---|---|
| 60s  | 280 | 280 (unchanged) | ~55s |
| 120s | 560 | **610** | ~120s |
| 180s | 840 | **920** | ~180s |

## Test plan

- [ ] Run a 120s story → confirm final video within ±5s of 2:00
- [ ] Run a 180s story → confirm final video within ±5s of 3:00
- [ ] 60s still within ±5s of 1:00