### PR TITLE
fix: observe cancel between LLM retry attempts so cancel responds in ≤60s

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -58,6 +58,53 @@ if ASSETS_DIR.exists():
     app.mount("/assets", StaticFiles(directory=str(ASSETS_DIR)), name="assets")
 
 
+@app.on_event("startup")
+def _abandon_orphaned_workflows() -> None:
+    """Clean up status files that survived a previous server crash / restart.
+
+    When uvicorn dies in the middle of a workflow run, the per-workflow
+    status.json is left at "processing" or "cancel_requested" forever.
+    A subsequent client reattach reads that stale status, enters the
+    cancelling-UI state, and polls forever because no process is going
+    to advance the status to a terminal value. Mark these as
+    "abandoned" on startup so the frontend can treat them as a clean
+    terminal state and recover.
+    """
+    mock_dir = ASSETS_DIR / "mock"
+    if not mock_dir.exists():
+        return
+
+    transient_states = {"processing", "cancel_requested"}
+    rewritten = 0
+    for status_path in mock_dir.glob("*/status.json"):
+        try:
+            with open(status_path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+            if not content:
+                continue
+            data = json.loads(content)
+            existing = str(data.get("status") or "").strip().lower()
+            if existing not in transient_states:
+                continue
+            data["status"] = "abandoned"
+            data["abandoned_at"] = int(time.time())
+            data["abandoned_reason"] = (
+                f"server restarted while workflow status was '{existing}'"
+            )
+            with open(status_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            rewritten += 1
+        except (OSError, json.JSONDecodeError):
+            # Corrupt or unreadable status file — leave it; the frontend
+            # 404 path / polling timeout will eventually handle it.
+            continue
+
+    if rewritten:
+        print(
+            f"[startup] marked {rewritten} orphaned workflow(s) as 'abandoned'"
+        )
+
+
 @app.get("/health")
 def health():
     return {"status": "ok"}

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -373,12 +373,19 @@ class WorkflowRunner:
         api_key: str,
         payload: Dict[str, Any],
         timeout: int,
+        workflow_id: Optional[str] = None,
     ) -> str:
         """Send one OpenAI-compatible chat/completions request; return raw content string.
 
         Retries up to 3 times on transient network errors (RemoteDisconnected,
         connection resets, timeouts, HTTP 5xx). 4xx errors and empty responses
         are not retried — they indicate a real problem, not a transient blip.
+
+        If ``workflow_id`` is provided, the retry loop checks the cancellation
+        registry between attempts and raises ``WorkflowCancelledError`` as soon
+        as the user has requested cancel. This shortens worst-case cancel
+        latency from ~3×timeout to ~1×timeout for any step that hits this
+        method.
         """
         url = f"{api_base_url.rstrip('/')}/chat/completions"
         body = json.dumps(payload).encode("utf-8")
@@ -387,11 +394,27 @@ class WorkflowRunner:
             "Content-Type": "application/json",
         }
 
+        def _raise_if_cancelled() -> None:
+            if workflow_id and _is_cancelled(workflow_id):
+                raise WorkflowCancelledError(workflow_id, partial_outputs={})
+
         last_err: Optional[BaseException] = None
         # The first attempt has zero wait; subsequent attempts back off.
+        # Cancellation is observed before every attempt (including the first,
+        # for the case where cancel arrived between step boundary and the
+        # call site) and during the backoff sleep so the user doesn't wait
+        # for a full timeout when they've already asked to stop.
         for attempt_index in range(len(self._LLM_RETRY_BACKOFF_SECONDS) + 1):
+            _raise_if_cancelled()
             if attempt_index > 0:
-                time.sleep(self._LLM_RETRY_BACKOFF_SECONDS[attempt_index - 1])
+                # Sleep in small slices so cancel responds within ~0.2s
+                # rather than the full backoff duration.
+                backoff = self._LLM_RETRY_BACKOFF_SECONDS[attempt_index - 1]
+                slept = 0.0
+                while slept < backoff:
+                    time.sleep(min(0.2, backoff - slept))
+                    slept += 0.2
+                    _raise_if_cancelled()
             try:
                 req = urllib_request.Request(
                     url=url,
@@ -416,10 +439,12 @@ class WorkflowRunner:
                 # won't change the outcome.
                 if 500 <= e.code < 600:
                     last_err = e
+                    _raise_if_cancelled()
                     continue
                 raise
             except self._LLM_RETRYABLE_ERRORS as e:
                 last_err = e
+                _raise_if_cancelled()
                 continue
             except urllib_error.URLError as e:
                 # URLError wraps lower-level network errors. Most are
@@ -428,6 +453,7 @@ class WorkflowRunner:
                 # (e.g. unknown URL scheme) are rare and still safe to
                 # retry because they'd reproduce, not hang.
                 last_err = e
+                _raise_if_cancelled()
                 continue
 
         # All attempts exhausted — surface the last exception so callers
@@ -544,7 +570,12 @@ class WorkflowRunner:
                 api_key=api_key,
                 payload=payload,
                 timeout=timeout,
+                workflow_id=ctx.workflow_id,
             )
+        except WorkflowCancelledError:
+            # User-requested cancel must propagate, not fall back to the
+            # secondary provider. The runner's step boundary will catch it.
+            raise
         except Exception as primary_err:
             fallback_url = self._llm_fallback_api_base_url()
             fallback_key = self._llm_fallback_api_key()
@@ -560,6 +591,7 @@ class WorkflowRunner:
                 api_key=fallback_key,
                 payload=fallback_payload,
                 timeout=timeout,
+                workflow_id=ctx.workflow_id,
             )
             provider_used = "fallback"
             fallback_reason = f"{type(primary_err).__name__}: {primary_err}"

--- a/app/services/runner_storyboard.py
+++ b/app/services/runner_storyboard.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional
 
+from app.services.runner_errors import WorkflowCancelledError
+
 
 class RunnerStoryboardSupport:
     """Storyboard and sentence-shot helpers extracted from WorkflowRunner.
@@ -212,13 +214,18 @@ class RunnerStoryboardSupport:
 
         try:
             timeout = runner._story_timeout_seconds()
+            workflow_id = str(getattr(ctx, "workflow_id", "") or "")
             try:
                 content = runner._call_llm_chat(
                     api_base_url=runner._llm_api_base_url(),
                     api_key=api_key,
                     payload=payload,
                     timeout=timeout,
+                    workflow_id=workflow_id,
                 )
+            except WorkflowCancelledError:
+                # Propagate cancel — the runner's step boundary handles it.
+                raise
             except Exception:
                 fallback_url = runner._llm_fallback_api_base_url()
                 fallback_key = runner._llm_fallback_api_key()
@@ -231,9 +238,12 @@ class RunnerStoryboardSupport:
                     api_key=fallback_key,
                     payload=fallback_payload,
                     timeout=timeout,
+                    workflow_id=workflow_id,
                 )
             return _parse_descriptions(content)
 
+        except WorkflowCancelledError:
+            raise
         except Exception:
             return {}
 

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -851,7 +851,22 @@ onMounted(() => {
           // Outputs not on disk yet — the run may still be in flight.
           return fetch(`${base}/v1/workflow/status/${savedWorkflowId}`)
             .then(r => r.ok ? r.json() : null)
-            .then(statusData => { reconnectInFlight(statusData) })
+            .then(statusData => {
+              // If the previous server crashed mid-run, the backend marks
+              // status as 'abandoned' on startup. Wipe the stale
+              // workflow_id from localStorage so we don't keep re-attaching
+              // to a dead run on every reload.
+              const stale = String(statusData?.status || '').trim().toLowerCase()
+              if (stale === 'abandoned' || stale === 'cancelled' || stale === 'failed') {
+                try {
+                  localStorage.removeItem(STORAGE_KEY_WORKFLOW)
+                  localStorage.removeItem(STORAGE_KEY_PAYLOAD)
+                  localStorage.removeItem(STORAGE_KEY_REFRESH_CANCELLED)
+                } catch { /* ignore */ }
+                return
+              }
+              reconnectInFlight(statusData)
+            })
             .catch(() => {})
         }
         if (data.outputs || data.steps) {
@@ -2404,11 +2419,14 @@ async function waitForAsyncWorkflowOutputs(
       continue
     }
 
-    if (status === 'cancelled') {
-      // Soft-terminate: don't throw (cancel isn't an error). Unify the UI
-      // back to idle here so every running surface — top progress bar,
-      // CTA, timeline, video preview, image review — drops "生成中"
-      // without waiting for a page refresh.
+    if (status === 'cancelled' || status === 'abandoned') {
+      // Soft-terminate: don't throw (cancel/server-restart isn't an error).
+      // Unify the UI back to idle here so every running surface — top
+      // progress bar, CTA, timeline, video preview, image review — drops
+      // "生成中" without waiting for a page refresh.
+      // 'abandoned' is written by the backend on startup for status files
+      // left orphaned by a previous server crash; treat it identically
+      // so stale workflow_ids in localStorage don't lock the UI forever.
       resetWorkflowRuntimeState()
       return null
     }


### PR DESCRIPTION
Fixes #118

PR now covers two halves of the cancel-stuck symptom — the live-run path AND the leftover-stale-state path.

## Half 1: cancel responds within ≤60s during a live run (commit b854008)

### Root cause

The runner only checked the cancellation flag at step boundaries (\`runner.py:977\` and \`:996\`). When the user clicked cancel during a long step — e.g. story generation, which can now take up to ~183s due to the 3-attempt retry layer added in #115 — the cancel was observed only after the entire step finished. UI showed "正在取消生成，等待当前步骤结束..." for minutes.

### Fix

- Added optional \`workflow_id\` param to \`_call_llm_chat\`. When provided, the retry loop polls \`is_cancelled()\` between attempts and during backoff sleep (in 0.2s slices).
- Story + storyboard call sites pass \`workflow_id\` from their context.
- Backwards-compatible: callers that don't pass \`workflow_id\` get the existing 3-retry behavior.

## Half 2: stale status files don't lock the UI across server restarts (commit 69e13c0)

### Problem

When uvicorn dies mid-run (crash, restart, Ctrl+C), the per-workflow \`status.json\` is left at \`"processing"\` or \`"cancel_requested"\` forever. Frontend reattach on next reload reads that stale status and locks the UI in the cancelling state, polling forever.

### Fix

- **Backend startup hook** (\`@app.on_event("startup")\`): scan \`assets/mock/*/status.json\` and rewrite any \`processing\` / \`cancel_requested\` entries to \`"abandoned"\` with a reason. The newly-booted process obviously isn't running those workflows, so it's safe to declare them terminal.
- **Frontend polling loop**: treat \`"abandoned"\` identically to \`"cancelled"\` (soft terminal — reset UI to idle).
- **Frontend reattach**: when the reattach \`/status/\` call returns \`abandoned\` / \`cancelled\` / \`failed\`, wipe the stale workflow_id from localStorage so the same dead workflow doesn't re-attach on every reload.

## Cancel response time table

| scenario | before | after |
|---|---|---|
| cancel between retries during live run | up to ~3 × timeout | **~0s** |
| cancel during backoff sleep | full 0.8s or 2.0s | **~0.2s slice** |
| cancel during in-flight urllib | up to timeout (60s) | unchanged |
| stale 'cancel_requested' after server restart | **stuck forever** | auto-marked 'abandoned' on next boot |

## Test plan

- [x] Backend: cancel between retries → \`WorkflowCancelledError\` raised after 1 attempt
- [x] Backend: cancel during backoff → raised within ~0.4s
- [x] Backend: omit \`workflow_id\` → original 3-retry behavior preserved
- [x] Backend: startup hook correctly rewrites only \`processing\` / \`cancel_requested\` to \`abandoned\` (other statuses untouched)
- [ ] Real run: start a 180s generation, click cancel mid-story-step, confirm UI returns to idle within ~60s
- [ ] Real run: kill uvicorn mid-run, restart, reload page, confirm UI lands on idle (not stuck on "正在取消生成")