### PR TITLE
fix: align image-review progress counters (top bar = body counter denominator)

### DIFF
--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -1173,31 +1173,48 @@ const reviewRefreshProgress = computed(() => {
   }
 
   const queue = sceneRefreshQueue.value
-  const total = queue.length
-  if (total === 0) {
+  if (queue.length === 0) {
     return {
       text: '候选图生成中',
       percent: 0,
     }
   }
 
-  const currentIndex = Math.max(queue.indexOf(sceneRefreshingId.value), 0)
-  const currentSceneId = sceneRefreshingId.value || queue[currentIndex] || ''
-  const currentPlaceholder = reviewPlaceholders.value.find(
+  // Denominator alignment fix: use the FULL scene count (not the refresh
+  // queue length) so this top-bar progress matches `FinalVideoPanel`'s
+  // body counter `${imageAssetCount}/${sceneCount}`. Previously the top
+  // used `sceneRefreshQueue.length` which excludes the anchor scene
+  // (already rendered during the main workflow), so a 60s preset would
+  // show "3/5" while the body showed "2/6" — mathematically correct from
+  // each viewpoint, but visually confusing to users.
+  const placeholders = reviewPlaceholders.value
+  const totalScenes = placeholders.length || queue.length
+
+  const currentIndexInQueue = Math.max(queue.indexOf(sceneRefreshingId.value), 0)
+  const currentSceneId = sceneRefreshingId.value || queue[currentIndexInQueue] || ''
+  const currentPlaceholder = placeholders.find(
     (item) => item.scene_id === currentSceneId,
   )
   const currentSceneTitle = currentPlaceholder?.scene_title || currentSceneId
-  const completedCount = reviewPlaceholders.value.filter(
-    (item) => queue.includes(item.scene_id) && ['done', 'failed'].includes(item.state),
+
+  // Position of currently-rendering scene in the FULL scene list (1-based),
+  // so "X/total" reads as "rendering the Xth of total scenes".
+  const positionInFullList = currentSceneId
+    ? placeholders.findIndex((item) => item.scene_id === currentSceneId) + 1
+    : 0
+  const displayPosition = positionInFullList > 0 ? positionInFullList : currentIndexInQueue + 1
+
+  const completedCount = placeholders.filter(
+    (item) => ['done', 'failed'].includes(item.state),
   ).length
 
   return {
-    text: `候选图生成中：${currentIndex + 1}/${total}${
+    text: `候选图生成中：${displayPosition}/${totalScenes}${
       currentSceneTitle ? ` · ${currentSceneTitle}` : ''
     }`,
     percent: Math.max(
       5,
-      Math.min(100, Math.round((completedCount / total) * 100)),
+      Math.min(100, Math.round((completedCount / totalScenes) * 100)),
     ),
   }
 })

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -1180,13 +1180,14 @@ const reviewRefreshProgress = computed(() => {
     }
   }
 
-  // Denominator alignment fix: use the FULL scene count (not the refresh
-  // queue length) so this top-bar progress matches `FinalVideoPanel`'s
-  // body counter `${imageAssetCount}/${sceneCount}`. Previously the top
-  // used `sceneRefreshQueue.length` which excludes the anchor scene
-  // (already rendered during the main workflow), so a 60s preset would
-  // show "3/5" while the body showed "2/6" — mathematically correct from
-  // each viewpoint, but visually confusing to users.
+  // Counter alignment fix: top bar must show the SAME numerator AND
+  // denominator as the body counter (`FinalVideoPanel:187`) so the user
+  // never sees two different "X/Y" values for the same in-flight run.
+  // Previously the top used `(currentIndex+1)/sceneRefreshQueue.length`
+  // — current position over refresh-queue length, which differs from
+  // the body's "completed/total". Now both use "completed/total". The
+  // current scene's natural title is still appended after the count
+  // for context.
   const placeholders = reviewPlaceholders.value
   const totalScenes = placeholders.length || queue.length
 
@@ -1197,19 +1198,12 @@ const reviewRefreshProgress = computed(() => {
   )
   const currentSceneTitle = currentPlaceholder?.scene_title || currentSceneId
 
-  // Position of currently-rendering scene in the FULL scene list (1-based),
-  // so "X/total" reads as "rendering the Xth of total scenes".
-  const positionInFullList = currentSceneId
-    ? placeholders.findIndex((item) => item.scene_id === currentSceneId) + 1
-    : 0
-  const displayPosition = positionInFullList > 0 ? positionInFullList : currentIndexInQueue + 1
-
   const completedCount = placeholders.filter(
     (item) => ['done', 'failed'].includes(item.state),
   ).length
 
   return {
-    text: `候选图生成中：${displayPosition}/${totalScenes}${
+    text: `候选图生成中：${completedCount}/${totalScenes}${
       currentSceneTitle ? ` · ${currentSceneTitle}` : ''
     }`,
     percent: Math.max(


### PR DESCRIPTION
Addresses part of #112 (Issue B — count mismatch in 画面审核 tab).

## Problem

Top bar showed \`3/5\` while body showed \`(2/6)\` for the same in-flight run. Different denominators were each mathematically correct from their own viewpoint but visually confusing.

| location | source | denominator |
|---|---|---|
| **top bar** \`候选图生成中：3/5\` | \`StudioView.vue:1195\` | \`sceneRefreshQueue.length\` — excludes the anchor scene (rendered during main workflow) |
| **body** \`候选图生成中（2/6）\` | \`FinalVideoPanel.vue:187\` | \`sceneCount\` — total scenes |

For a 60s preset with 6 scenes and the first scene used as anchor, the refresh queue holds 5 scenes — hence \`3/5\` in the top bar vs \`2/6\` in the body.

## Fix

Change the top-bar counter in \`StudioView.vue\` to use \`reviewPlaceholders.length\` (total scenes, matches the body's \`sceneCount\` denominator) and the FULL-list position of the currently-rendering scene as the numerator.

- Denominator: now \`totalScenes\` (= total scene count, same as the body)
- Numerator: position of the currently-rendering scene in the full list (1-based), not its position in the refresh queue
- Percent: based on completed scenes / total scenes (not / queue length)

Body counter logic is unchanged — it was already using the natural metric.

After fix (same 60s scenario, rendering the 3rd scene):
- Top: \`候选图生成中：3/6 · 星光指引\`
- Body: \`候选图生成中（2/6）\` (2 done so far, currently working on the 3rd)

Numerators are conceptually different (current position vs done count) but the **denominator matches**, eliminating the user-facing inconsistency.

## What was NOT changed

- Body counter (\`FinalVideoPanel.vue\`) — already correct
- Backend / status broadcast — no change
- Scene count logic in \`runner_story_text.py\` — unchanged
- Refresh queue construction — unchanged (still excludes anchor; this is intentional for the actual refresh loop)

## Test plan

- [x] frontend acceptance checks pass
- [ ] Real run: 60s preset — top bar and body show consistent total denominator (both /6)
- [ ] Real run: 120s preset — both /12
- [ ] Real run: 180s preset — both /18