### PR TITLE
fix: studio review-tab UX consistency — lock candidate selection + align workflow step counter

### DIFF
--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -226,14 +226,14 @@ const placeholderDesc = computed(() => {
     return '还没有可用的分镜。请先在「创作故事」页签输入故事主题，并点击「开始创作」生成内容。'
   }
   if (!assetsReady.value) {
-    if (props.refreshingImages) return '系统正在准备每个场景的候选图，默认图生成后即可直接渲染，也可以手动改选。'
+    if (props.refreshingImages) return '系统正在为每个场景自动挑选最佳候选图，生成完成后即可直接渲染。'
     if (imageAssetCount.value > 0) return '剩余候选图尚未生成。点击下方「继续生成候选图」可恢复。'
     return '候选图尚未生成。点击下方「立即生成候选图」开始。'
   }
   if (audioItemCount.value === 0) {
     return '当前缺少音频片段，请先完成音频生成。'
   }
-  return '候选图已就绪。你可以直接使用默认图，也可以手动改选，然后点击按钮开始渲染。'
+  return '候选图已就绪，系统已自动为每个场景挑选最佳画面。点击按钮即可开始渲染。'
 })
 </script>
 

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -233,7 +233,7 @@ const placeholderDesc = computed(() => {
   if (audioItemCount.value === 0) {
     return '当前缺少音频片段，请先完成音频生成。'
   }
-  return '候选图已就绪，系统已自动为每个场景挑选最佳画面。点击按钮即可开始渲染。'
+  return '候选图已就绪，系统已自动为每个场景挑选最佳画面。'
 })
 </script>
 

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -78,7 +78,28 @@ const props = defineProps<{
   // the lightweight "取消生成" entry inside this panel so the user can
   // cancel the whole workflow without leaving the review tab.
   cancellable?: boolean
+  // True once the final video has been rendered. Locks every candidate
+  // selection — once a video exists, the image roster the video was built
+  // from must not change underneath it (the displayed selection would no
+  // longer match the actual video frames).
+  videoGenerated?: boolean
 }>()
+
+// A scene's candidates are locked when:
+//   • the final video already exists for this run (any swap would let
+//     the displayed selection diverge from the rendered video), OR
+//   • the scene was auto-selected by the system (auto means auto —
+//     a manual override would defeat the "auto" guarantee in the UI).
+// Locked candidates still RENDER, but the click handler / focus state /
+// "可切换" label all switch to a read-only treatment so the user
+// understands the choice is final for this run.
+function isSelectionLocked(item: ImageReviewSelectedAsset): boolean {
+  if (props.videoGenerated) {
+    return true
+  }
+  const source = String(item?.selection_source || '').trim().toLowerCase()
+  return source === 'auto' || source === 'auto_selected'
+}
 
 const storyExpanded = ref(false)
 const normalizedStoryText = computed(() => String(props.storyText || '').trim())
@@ -603,8 +624,20 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 class="asset-select-card"
                 :class="{
                   active: isSameAssetRef(candidate, entry.item.selected_asset_ref),
+                  'asset-select-card-locked': isSelectionLocked(entry.item),
                 }"
-                :disabled="loading || selectingSceneId === entry.sceneId"
+                :disabled="
+                  loading ||
+                  selectingSceneId === entry.sceneId ||
+                  isSelectionLocked(entry.item)
+                "
+                :title="
+                  isSelectionLocked(entry.item)
+                    ? (videoGenerated
+                        ? '视频已生成，候选图不可再切换'
+                        : '已自动选择，自动模式下不可手动切换')
+                    : undefined
+                "
                 @click="onSelect(entry.sceneId, candidate)"
               >
                 <div class="preview-card preview-card-candidate">
@@ -652,7 +685,9 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                         {{
                           isSameAssetRef(candidate, entry.item.selected_asset_ref)
                             ? '已选中'
-                            : '可切换'
+                            : (isSelectionLocked(entry.item)
+                                ? (videoGenerated ? '已锁定' : '自动模式')
+                                : '可切换')
                         }}
                       </span>
                     </div>
@@ -1446,6 +1481,18 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 
 .asset-select-card:disabled {
   cursor: not-allowed;
+  opacity: 0.55;
+}
+
+/* Locked candidates keep their image readable (so the user still sees
+   what was selected) but lose hover-affordance — the cursor becomes
+   not-allowed and the un-selected card visibly recedes so it doesn't
+   look like a live click target. The .active rule above still wins on
+   the selected card, so the chosen one stays highlighted. */
+.asset-select-card-locked {
+  cursor: not-allowed;
+}
+.asset-select-card-locked:not(.active) {
   opacity: 0.55;
 }
 

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -57,6 +57,13 @@ const props = defineProps<{
   cancelRequested?: boolean
   statusLabel?: string
   elapsedSec?: number
+  // `completedSteps` (preferred) is how many workflow steps have FINISHED.
+  // `currentStepIndex` (1-based "now running") is accepted for back-compat
+  // but the visual will use `completedSteps` when both are provided so the
+  // count here matches the "当前步骤：X（6/11）" text shown above.
+  // Showing two different numbers (current=7 vs completed=6) for the same
+  // run reads as a UI bug to users.
+  completedSteps?: number
   currentStepIndex?: number
   totalSteps?: number
 }>()
@@ -544,9 +551,9 @@ function getTopicManualMismatchWarning(): string {
             :text="statusLabel || '正在准备'"
           />
           <span
-            v-if="totalSteps && currentStepIndex"
+            v-if="totalSteps && (completedSteps !== undefined || currentStepIndex !== undefined)"
             class="runStateStep"
-          >{{ currentStepIndex }} / {{ totalSteps }}</span>
+          >{{ completedSteps !== undefined ? completedSteps : (currentStepIndex ?? 0) }} / {{ totalSteps }}</span>
           <span
             v-if="elapsedSec !== undefined && elapsedSec > 0"
             class="runStateElapsed"

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2907,6 +2907,7 @@ async function runWorkflow() {
                   :can-cancel="refreshingImageReview"
                   :cancel-requested="cancelRequested"
                   :cancellable="Boolean(activeWorkflowId)"
+                  :video-generated="Boolean(finalVideoUrl)"
                   @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
                   @retry-scene="retryImageReviewScene"
                   @enhance-scene="enhanceImageReviewScene"

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2798,6 +2798,7 @@ async function runWorkflow() {
           :cancel-requested="cancelRequestedAny"
           :status-label="workflowRunStatusMessage || (refreshingImageReview ? reviewRefreshProgress.text : '')"
           :elapsed-sec="workflowRunElapsedSec"
+          :completed-steps="workflowStatusData?.completed_steps ?? 0"
           :current-step-index="workflowStatusData?.current_step_index ?? 0"
           :total-steps="workflowStatusData?.total_steps ?? 0"
           @update:form-state="onUpdateFormState"


### PR DESCRIPTION
Two small studio-tab UX-consistency fixes bundled.

## Commit 1 — candidate selection lock (Fixes #113)

Auto-selected scenes and post-render scenes are no longer manually switchable.

\`InteractiveImageReview.vue\` gets a per-scene \`isSelectionLocked(item)\`:
- locked if \`videoGenerated\` prop is true (new — passed in from \`StudioView.vue\` as \`Boolean(finalVideoUrl)\`)
- locked if \`selection_source\` is \`auto\` / \`auto_selected\`

When locked:
- \`<button>\` becomes \`:disabled\`
- Card class \`asset-select-card-locked\` — un-selected card recedes (opacity 0.55); the selected one keeps its highlight
- "可切换" label switches to "已锁定" (video already rendered) or "自动模式" (auto-selected, no video yet)
- \`title\` attribute carries a tooltip explaining the lock reason

## Commit 2 — workflow step counter alignment

Same workflow showed two different counters:

- Top status text: \`当前步骤：音频片段（6/11）\` — uses \`completed_steps\`
- Bottom run-state pill: \`7 / 11\` — uses \`current_step_index\`

Both numbers are individually correct (6 done so far, currently on the 7th), but reads to the user as a UI bug. \`WorkflowRunPanel.vue\` now accepts an optional \`completedSteps\` prop and shows that when present — falling back to \`currentStepIndex\` for back-compat. \`StudioView.vue\` passes \`completedSteps\` so both top and bottom show the same X/N.

## What was NOT changed

- The selector logic itself, the refresh / retry paths, render trigger — unchanged
- Backend status broadcast — unchanged (still emits both \`completed_steps\` and \`current_step_index\`)
- Other consumers of \`currentStepIndex\` (if any) — back-compat preserved

## Test plan

- [x] Frontend acceptance checks pass
- [ ] After image refresh completes (auto mode): candidate cards visibly recede, can't be clicked
- [ ] After video render completes: all candidate cards lock with "已锁定" label
- [ ] During a workflow run on the create-story tab: top text and bottom pill show the same step counter