### PR TITLE
fix: stop workflow chain from regressing 6/6 → 画面生成 during deferred image refresh

### DIFF
--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -462,12 +462,30 @@ const progressSteps = computed(() => {
 // Workflow chain for the current-work card — stage-aware:
 //   • renderInFlight     → all earlier steps done, video step active
 //   • refreshingImages   → story+storyboard done, image step active
-//   • isProcessing       → initial workflow run; derive from completedSteps
+//   • isProcessing       → initial workflow run; CAPPED at image step.
+//     See INITIAL_PHASE_MAX_IDX below for the no-regress contract.
 //   • finalVideoUrl set  → fully done
 //   • otherwise          → derive from completedSteps / totalSteps
 // Stage indices into STEP_DEFS:
 //   0 story · 1 storyboard · 2 images · 3 voice · 4 subtitles · 5 video
 type FlowState = 'done' | 'active' | 'pending'
+
+// During the initial workflow run, the backend's `completed_steps` walks
+// through ~11 internal stages including audio/subtitle/video — but those
+// stages run against PLACEHOLDER images, not real ones. Real image
+// generation only happens in the deferred-refresh phase that follows
+// (props.refreshingImages = true). So if we let the visualization advance
+// to "video done" during the initial run, the user sees "6/6 已完成"
+// momentarily — then refresh starts and the chain visually REGRESSES
+// back to "画面生成". That regression reads as a UI bug.
+//
+// Cap initial-phase advance at index 2 (image step). Story/storyboard
+// can show as "done"; image step stays "active" through the rest of the
+// initial run; audio/subtitle/video stay "pending" until the deferred
+// refresh actually completes and (eventually) the final-video re-render
+// fires. This keeps the chain MONOTONICALLY non-regressing across the
+// phase 1 → phase 2 boundary.
+const INITIAL_PHASE_MAX_IDX = 2  // image step
 
 function buildChainWithActive(activeIdx: number) {
   return STEP_DEFS.map((step, idx) => ({
@@ -484,16 +502,18 @@ const workflowChain = computed<{ id: string; label: string; flowLabel: string; s
   // therefore already done; the image step is the live one.
   if (props.refreshingImages) return buildChainWithActive(2)
 
-  // Initial workflow run — completedSteps drives the active index.
+  // Initial workflow run — completedSteps drives the active index, but
+  // never advance past the image step (see INITIAL_PHASE_MAX_IDX above).
   if (props.isProcessing) {
     const completed = props.completedSteps ?? 0
     const total = props.totalSteps ?? STEP_DEFS.length
     const ratio = total > 0 ? completed / total : 0
-    const activeIdx = Math.min(
+    const naiveIdx = Math.min(
       Math.floor(ratio * STEP_DEFS.length),
       STEP_DEFS.length - 1,
     )
-    return buildChainWithActive(activeIdx)
+    const cappedIdx = Math.min(naiveIdx, INITIAL_PHASE_MAX_IDX)
+    return buildChainWithActive(cappedIdx)
   }
 
   // Settled state with a finished video → mark everything done.


### PR DESCRIPTION
Fixes #112 (Part A — the remaining open part; Part B was fixed in #123).

## Problem

User runs a 60s/120s/180s topic. They observe:

1. Initial workflow runs and the pipeline visualization walks through all 6 steps (故事生成 → 分镜设计 → 画面生成 → 配音生成 → 字幕生成 → 视频合成). Top text shows "已完成 6/6 步骤" momentarily.
2. Then the deferred image-refresh phase kicks in and the visualization **REGRESSES** back to "画面生成", showing 0-3/6 again.

This reads as a UI bug — progress shouldn't visually move backward.

## Root cause

\`StudioPreviewPanel.vue\` shares a single 6-step pipeline visualization (\`workflowChain\` computed) across BOTH:

- Phase 1: initial workflow run with PLACEHOLDER images. Backend's \`completed_steps\` walks through ~11 internal stages including audio/subtitle/video against placeholders.
- Phase 2: deferred image refresh that generates REAL images, then the final video re-renders.

During Phase 1 the chain advances all the way to "视频合成 done" because backend's \`completed_steps\` / \`total_steps\` ratio reaches 1.0. Phase 2 then forcibly resets the visualization to "image step active" (\`buildChainWithActive(2)\`). The user sees this as a regression.

## Fix

Add an \`INITIAL_PHASE_MAX_IDX = 2\` (image step) cap inside the \`isProcessing\` branch. The phase-1 chain stops advancing past image step regardless of how far the backend has progressed through audio/subtitle/video sub-steps. Story/storyboard show as \`done\`; image stays \`active\` through phase 1 and seamlessly continues as \`active\` through phase 2.

\`doneCount\` is derived from \`workflowChain\` so the "已完成 X/6 步骤" text updates automatically — it now caps at \`已完成 2/6 步骤\` until refresh actually completes.

The chain is now **monotonically non-regressing** across phase 1 → phase 2 → render → final.

## What was NOT changed

- Top progress percent (\`progress_percent\` from backend) — unchanged, still shows backend's view of the full workflow
- \`progressSteps\` computed (different state machine for the top horizontal stepper) — unchanged
- Backend status broadcast — unchanged
- Phase-2 / render-in-flight / settled-state branches of \`workflowChain\` — unchanged

## Test plan

- [x] Frontend acceptance checks pass
- [ ] Real run 60s — confirm chain caps at "画面生成 active" through phase 1, smoothly transitions when refresh starts, no visual regression
- [ ] Real run 180s — same expectation
- [ ] Confirm no regression on the manual-render mode path (final video re-render after deferred refresh)