### PR TITLE
fix(studio + audio): manual regenerate flow + multiple audio quality fixes

### DIFF
--- a/app/services/image_provider_adapter.py
+++ b/app/services/image_provider_adapter.py
@@ -89,6 +89,7 @@ class ApiImageGeneratorAdapter:
             negative_prompt=str(task.prompt_metadata.get("negative_prompt") or ""),
             img2img_reference_path=task.prompt_metadata.get("img2img_reference_path"),
             quality_tier=str(task.prompt_metadata.get("quality_tier") or "quality"),
+            seed_jitter=int(task.prompt_metadata.get("seed_jitter") or 0),
         )
 
     def _generate_api_image_bytes(
@@ -101,6 +102,14 @@ class ApiImageGeneratorAdapter:
         negative_prompt: str = "",
         quality_tier: str = "quality",
         img2img_reference_path: Optional[Any] = None,
+        # When the user clicks "重新生成" on a scene that already has
+        #candidates, the same (run_id, scene_index) pair would otherwise
+        # derive the SAME seed → the diffusion model would produce
+        #byte-identical output → the regenerated file overwrites itself
+        #with the same bytes and the user sees no visual change.
+        # seed_jitter (typically time.time_ns()) is added to the base seed
+        # so each regen draws from a fresh point in the latent space.
+        seed_jitter: int = 0,
     ) -> bytes:
         if self._runner._force_image_rate_limit():
             raise RuntimeError("HTTP 429: IPM limit reached (forced for local testing)")
@@ -166,7 +175,9 @@ class ApiImageGeneratorAdapter:
         }
 
         if run_id:
-            payload["seed"] = (_derive_run_seed(run_id) + scene_index * 1000) % 10_000_000_000
+            payload["seed"] = (
+                _derive_run_seed(run_id) + scene_index * 1000 + seed_jitter
+            ) % 10_000_000_000
 
         if not is_flux and negative_prompt:
             payload["negative_prompt"] = negative_prompt

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -16,11 +16,63 @@ from typing import Any, Dict, List, Optional
 # audio segment, so the audio always plays to its natural end.
 _VIDEO_FRAME_STEP_SEC = 1.0 / 25.0
 
+# Trailing silence appended to every TTS segment before concat. Two
+# benefits in one:
+#   1) Perceptual — back-to-back TTS segments with zero gap sound like
+#      the last syllable of segment N got cut when segment N+1 starts.
+#      A 150 ms breath gives natural sentence pacing.
+#   2) Tail-clip insurance — if the TTS provider (or the 1.25× speed
+#      retry path) returns audio with a slightly truncated tail, the
+#      missing audio falls into the silence buffer instead of the next
+#      segment's leading audio.
+_SEGMENT_TAIL_SILENCE_SEC = 0.15
+
 
 def _ceil_to_frame_boundary(duration_sec: float) -> float:
     if duration_sec <= 0:
         return 0.0
     return math.ceil(duration_sec / _VIDEO_FRAME_STEP_SEC) * _VIDEO_FRAME_STEP_SEC
+
+
+def _append_silence_to_mp3(mp3_path: Path, silence_sec: float) -> bool:
+    """Append `silence_sec` seconds of silence to `mp3_path` in place.
+
+    Returns True if the file was successfully padded. Returns False on
+    any ffmpeg failure — caller should treat that as "padding skipped,
+    keep the original file" rather than fatal.
+    """
+    if silence_sec <= 0 or not mp3_path.exists():
+        return False
+    temp = mp3_path.with_suffix(".pad.mp3")
+    try:
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-loglevel",
+                "error",
+                "-i",
+                str(mp3_path),
+                "-af",
+                f"apad=pad_dur={silence_sec:.3f}",
+                "-c:a",
+                "libmp3lame",
+                "-b:a",
+                "64k",
+                str(temp),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        temp.replace(mp3_path)
+        return True
+    except Exception:
+        if temp.exists():
+            try:
+                temp.unlink()
+            except Exception:
+                pass
+        return False
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -425,11 +477,25 @@ class RunnerAudioRenderSupport:
                                     "retry_error": True,
                                 }
 
+                    # Append a tiny tail silence to whatever the final
+                    # TTS file ended up being (original or speed-retry).
+                    # This adds a natural breath between sentences AND
+                    # masks any tail truncation from the TTS provider /
+                    # speed retry. See _SEGMENT_TAIL_SILENCE_SEC docstring.
+                    if _append_silence_to_mp3(output_path, _SEGMENT_TAIL_SILENCE_SEC):
+                        padded_duration = self._runner._probe_audio_duration_seconds(
+                            output_path
+                        )
+                        if padded_duration is not None and padded_duration > 0:
+                            duration_sec = padded_duration
+                            duration_source = f"{duration_source}+tail_pad"
+
                     asset_metadata = {
                         "tts_model": tts_result.get("model"),
                         "tts_voice": tts_result.get("voice"),
                         "output_bytes": tts_result.get("output_bytes"),
                         "duration_source": duration_source,
+                        "tail_silence_sec": _SEGMENT_TAIL_SILENCE_SEC,
                         **duration_retry_meta,
                     }
                     real_generation_count += 1
@@ -574,6 +640,11 @@ class RunnerAudioRenderSupport:
                         output_path=seg_output_path,
                         speed=speedup_factor,
                     )
+                    # Global speedup retry overwrites the file, which
+                    # blows away the per-segment tail silence we added
+                    # earlier. Re-append silence so the breathing buffer
+                    # still exists after the speedup pass.
+                    _append_silence_to_mp3(seg_output_path, _SEGMENT_TAIL_SILENCE_SEC)
                     new_duration = self._runner._probe_audio_duration_seconds(
                         seg_output_path
                     )

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -16,63 +16,10 @@ from typing import Any, Dict, List, Optional
 # audio segment, so the audio always plays to its natural end.
 _VIDEO_FRAME_STEP_SEC = 1.0 / 25.0
 
-# Trailing silence appended to every TTS segment before concat. Two
-# benefits in one:
-#   1) Perceptual — back-to-back TTS segments with zero gap sound like
-#      the last syllable of segment N got cut when segment N+1 starts.
-#      A 150 ms breath gives natural sentence pacing.
-#   2) Tail-clip insurance — if the TTS provider (or the 1.25× speed
-#      retry path) returns audio with a slightly truncated tail, the
-#      missing audio falls into the silence buffer instead of the next
-#      segment's leading audio.
-_SEGMENT_TAIL_SILENCE_SEC = 0.15
-
-
 def _ceil_to_frame_boundary(duration_sec: float) -> float:
     if duration_sec <= 0:
         return 0.0
     return math.ceil(duration_sec / _VIDEO_FRAME_STEP_SEC) * _VIDEO_FRAME_STEP_SEC
-
-
-def _append_silence_to_mp3(mp3_path: Path, silence_sec: float) -> bool:
-    """Append `silence_sec` seconds of silence to `mp3_path` in place.
-
-    Returns True if the file was successfully padded. Returns False on
-    any ffmpeg failure — caller should treat that as "padding skipped,
-    keep the original file" rather than fatal.
-    """
-    if silence_sec <= 0 or not mp3_path.exists():
-        return False
-    temp = mp3_path.with_suffix(".pad.mp3")
-    try:
-        subprocess.run(
-            [
-                "ffmpeg",
-                "-y",
-                "-loglevel",
-                "error",
-                "-i",
-                str(mp3_path),
-                "-af",
-                f"apad=pad_dur={silence_sec:.3f}",
-                "-c:a",
-                "libmp3lame",
-                "-b:a",
-                "64k",
-                str(temp),
-            ],
-            check=True,
-            capture_output=True,
-        )
-        temp.replace(mp3_path)
-        return True
-    except Exception:
-        if temp.exists():
-            try:
-                temp.unlink()
-            except Exception:
-                pass
-        return False
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -485,25 +432,11 @@ class RunnerAudioRenderSupport:
                                     "retry_error": True,
                                 }
 
-                    # Append a tiny tail silence to whatever the final
-                    # TTS file ended up being (original or speed-retry).
-                    # This adds a natural breath between sentences AND
-                    # masks any tail truncation from the TTS provider /
-                    # speed retry. See _SEGMENT_TAIL_SILENCE_SEC docstring.
-                    if _append_silence_to_mp3(output_path, _SEGMENT_TAIL_SILENCE_SEC):
-                        padded_duration = self._runner._probe_audio_duration_seconds(
-                            output_path
-                        )
-                        if padded_duration is not None and padded_duration > 0:
-                            duration_sec = padded_duration
-                            duration_source = f"{duration_source}+tail_pad"
-
                     asset_metadata = {
                         "tts_model": tts_result.get("model"),
                         "tts_voice": tts_result.get("voice"),
                         "output_bytes": tts_result.get("output_bytes"),
                         "duration_source": duration_source,
-                        "tail_silence_sec": _SEGMENT_TAIL_SILENCE_SEC,
                         **duration_retry_meta,
                     }
                     real_generation_count += 1
@@ -648,11 +581,6 @@ class RunnerAudioRenderSupport:
                         output_path=seg_output_path,
                         speed=speedup_factor,
                     )
-                    # Global speedup retry overwrites the file, which
-                    # blows away the per-segment tail silence we added
-                    # earlier. Re-append silence so the breathing buffer
-                    # still exists after the speedup pass.
-                    _append_silence_to_mp3(seg_output_path, _SEGMENT_TAIL_SILENCE_SEC)
                     new_duration = self._runner._probe_audio_duration_seconds(
                         seg_output_path
                     )

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -422,13 +422,21 @@ class RunnerAudioRenderSupport:
                     if actual_duration_sec is not None and duration_estimate_sec > 0 and speed_adjustment_allowed:
                         retry_speed: Optional[float] = None
                         if actual_duration_sec < duration_estimate_sec * 0.70:
-                            # Too short: slow down to fill the scene slot
+                            # Too short: slow down to fill the scene slot.
+                            # Slow-down is safe — TTS providers handle
+                            # speed<1 by stretching audio (more padding
+                            # or syllable extension), no content loss.
                             ratio = actual_duration_sec / duration_estimate_sec
                             retry_speed = max(0.75, min(0.95, ratio))
-                        elif actual_duration_sec > duration_estimate_sec * 1.30:
-                            # Too long: speed up to fit the scene slot
-                            ratio = actual_duration_sec / duration_estimate_sec
-                            retry_speed = min(1.25, max(1.05, ratio))
+                        # NO speed-up retry here. Empirically TTS providers
+                        # (SiliconFlow / OpenAI-compatible) drop trailing
+                        # syllables when handed speed>1 — the last word /
+                        # particle of long sentences vanishes ("个别句子
+                        # 尾音消失"). The global speedup pass at the end
+                        # of this method (uniform across ALL segments)
+                        # still handles total-duration overshoot, so
+                        # losing per-segment speed-up is no functional
+                        # regression — only a correctness fix.
 
                         if retry_speed is not None:
                             try:

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -968,40 +968,43 @@ class RunnerAudioRenderSupport:
                 encoding="utf-8",
             )
 
-            # SINGLE-PASS re-encode (NOT `-c copy`). Each TTS segment is
-            # an independent LAME-encoded MP3 with its own bit reservoir
-            # (LAME stores some encoded bytes in subsequent frames). When
-            # `-c copy` byte-concats two such MP3s, segment N+1's first
-            # frames inherit reservoir references that point at bytes
-            # which only existed inside segment N's stream — those frames
-            # decode to garbage. The garbage is audible as a brief click
-            # / stutter right at every segment boundary (i.e. at the
-            # tail of each sentence). Decoding all inputs and emitting a
-            # single clean MP3 dissolves the cross-segment references.
+            # Sample-accurate concat via the `concat` FILTER (not the
+            # concat demuxer). The demuxer approach (`-f concat`) plus
+            # re-encode mis-handles LAME's per-file priming/padding
+            # metadata, which can cut real audio samples at segment
+            # tails ("尾音被吃"). The filter approach feeds each MP3 as
+            # a separate input, decodes each fully to PCM, explicitly
+            # concatenates the sample arrays, then re-encodes ONCE — no
+            # sample loss at boundaries AND no MP3 bit-reservoir issues
+            # at the resulting concat points.
             #
             # 128 kbps preserves perceived TTS quality (TTS providers
-            # typically deliver 64–128 kbps; we encode AT LEAST as high
-            # so we don't lose quality on the rewrite).
-            subprocess.run(
+            # typically deliver 64–128 kbps).
+            ffmpeg_concat_cmd: List[str] = [
+                "ffmpeg",
+                "-y",
+                "-loglevel",
+                "error",
+            ]
+            for seg_path in audio_file_paths:
+                ffmpeg_concat_cmd.extend(["-i", seg_path])
+            n_segments = len(audio_file_paths)
+            filter_inputs = "".join(f"[{i}:a]" for i in range(n_segments))
+            filter_expr = f"{filter_inputs}concat=n={n_segments}:v=0:a=1[out]"
+            ffmpeg_concat_cmd.extend(
                 [
-                    "ffmpeg",
-                    "-y",
-                    "-loglevel",
-                    "error",
-                    "-f",
-                    "concat",
-                    "-safe",
-                    "0",
-                    "-i",
-                    str(merged_audio_list_path),
+                    "-filter_complex",
+                    filter_expr,
+                    "-map",
+                    "[out]",
                     "-c:a",
                     "libmp3lame",
                     "-b:a",
                     "128k",
                     str(merged_audio_path),
-                ],
-                check=True,
+                ]
             )
+            subprocess.run(ffmpeg_concat_cmd, check=True)
 
         # ========= 写字幕 =========
         subtitle_path = video_run_dir / "subtitles.srt"

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -968,18 +968,36 @@ class RunnerAudioRenderSupport:
                 encoding="utf-8",
             )
 
+            # SINGLE-PASS re-encode (NOT `-c copy`). Each TTS segment is
+            # an independent LAME-encoded MP3 with its own bit reservoir
+            # (LAME stores some encoded bytes in subsequent frames). When
+            # `-c copy` byte-concats two such MP3s, segment N+1's first
+            # frames inherit reservoir references that point at bytes
+            # which only existed inside segment N's stream — those frames
+            # decode to garbage. The garbage is audible as a brief click
+            # / stutter right at every segment boundary (i.e. at the
+            # tail of each sentence). Decoding all inputs and emitting a
+            # single clean MP3 dissolves the cross-segment references.
+            #
+            # 128 kbps preserves perceived TTS quality (TTS providers
+            # typically deliver 64–128 kbps; we encode AT LEAST as high
+            # so we don't lose quality on the rewrite).
             subprocess.run(
                 [
                     "ffmpeg",
                     "-y",
+                    "-loglevel",
+                    "error",
                     "-f",
                     "concat",
                     "-safe",
                     "0",
                     "-i",
                     str(merged_audio_list_path),
-                    "-c",
-                    "copy",
+                    "-c:a",
+                    "libmp3lame",
+                    "-b:a",
+                    "128k",
                     str(merged_audio_path),
                 ],
                 check=True,

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -1072,6 +1072,20 @@ class RunnerAudioRenderSupport:
 
         video_duration = _ffprobe_duration_sec(base_video_path)
         _rescale_srt_to_duration(subtitle_path, video_duration)
+
+        # The `-t` cap below was using `total_duration_sec`, which is the
+        # SUM of each individual MP3's ffprobe duration. The actual
+        # merged_audio.mp3 (built by `ffmpeg -f concat -c copy`) can be a
+        # few tens of ms LONGER than that sum because of MP3 frame
+        # boundary alignment — the last syllable of the final segment
+        # then gets clipped by `-t`. Probe the merged file's real length
+        # and add a small safety buffer so the cap never sits inside an
+        # active audio frame.
+        if has_audio and merged_audio_path:
+            actual_audio_duration = _ffprobe_duration_sec(merged_audio_path)
+            if actual_audio_duration > 0:
+                total_duration_sec = max(total_duration_sec, actual_audio_duration) + 0.2
+
         if has_audio and merged_audio_path:
             escaped_subtitle_path = (
                 str(subtitle_path)

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -267,6 +268,13 @@ class RunnerSingleSceneImageSupport:
                 file_name = f"{scene_id}__{candidate_suffix}.png"
                 output_path = run_dir / file_name
 
+                # seed_jitter unique per request: time.time_ns() guarantees
+                # two consecutive regen requests draw from different seeds,
+                # so the diffusion model produces visibly different output.
+                # Without this, (run_id, scene_index) is the same on every
+                # retry → same seed → byte-identical image → user sees no
+                # change after clicking "重新生成".
+                seed_jitter = time.time_ns() % 10_000_000_000 + candidate_index * 7919
                 task = ImageGenerationTask(
                     run_id=ctx.run_id,
                     item_id=scene_id,
@@ -282,6 +290,7 @@ class RunnerSingleSceneImageSupport:
                         "scene_index": scene_index + candidate_index,
                         "negative_prompt": active_negative,
                         "quality_tier": str(getattr(ctx.input, "quality_tier", "quality") or "quality"),
+                        "seed_jitter": seed_jitter,
                     },
                 )
 

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -244,7 +244,10 @@ const placeholderTitle = computed(() => {
   if (!sceneCount.value) return '等待分镜'
   // Single-scene retry (manual-mode "重新生成" button on a done scene)
   // — show activity even though the OVERALL render isn't in flight.
-  if (props.sceneRefreshingId) return '正在重新生成候选图'
+  // Gated on !refreshingImages so the initial bulk refresh (which
+  // ALSO sets sceneRefreshingId as it walks scenes) falls through to
+  // its own "正在生成候选图" copy below.
+  if (props.sceneRefreshingId && !props.refreshingImages) return '正在重新生成候选图'
   if (!assetsReady.value) {
     if (props.refreshingImages) return '正在生成候选图'
     if (imageAssetCount.value > 0) return '候选图已暂停'
@@ -272,10 +275,12 @@ const placeholderDesc = computed(() => {
   if (!sceneCount.value) {
     return '还没有可用的分镜。请先在「创作故事」页签输入故事主题，并点击「开始创作」生成内容。'
   }
-  // Match the title above — single-scene retry has its own description
-  // so the user sees that the system IS doing something, instead of the
-  // stale "等待渲染 / 候选图已就绪" copy.
-  if (props.sceneRefreshingId) {
+  // Match the title above — single-scene retry has its own description.
+  // Gated on !refreshingImages so the initial bulk refresh's own copy
+  // takes priority (it sets sceneRefreshingId per-scene as it walks
+  // through, but the user wants to see "1/6 候选图生成中", not
+  // "正在为 scene_01 重新生成").
+  if (props.sceneRefreshingId && !props.refreshingImages) {
     return `正在为 ${props.sceneRefreshingId} 重新生成候选图，请稍候。`
   }
   if (!assetsReady.value) {

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -169,12 +169,16 @@ const finalStatus = computed(() => asStr(finalVideo.value?.status).toLowerCase()
 const workflowInFlight = computed(() => props.loading && !outputs.value)
 
 // Any active phase that should swap the static clapperboard for the
-// AI-workflow loading animation: initial workflow, image refresh, render.
+// AI-workflow loading animation: initial workflow, image refresh,
+// render, OR per-scene retry (sceneRefreshingId set). Without the
+// per-scene case the placeholder icon stays static during "重新生成"
+// even though we're showing "正在重新生成候选图" text — looks broken.
 const isAnyLoading = computed(() => {
   return Boolean(
     props.loading ||
     props.renderInFlight ||
     props.refreshingImages ||
+    props.sceneRefreshingId ||
     finalStatus.value === 'rendering' ||
     workflowInFlight.value,
   )

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -111,6 +111,11 @@ const props = defineProps<{
   // through (or swapping a candidate first); in 'auto' mode the system
   // auto-triggers the render watcher and the button stays hidden.
   renderMode?: 'auto' | 'manual'
+  // Scene_id currently being regenerated via the per-scene "重新生成"
+  // button. Different from `refreshingImages` (which is the bulk refresh
+  // covering all scenes). When set, the placeholder copy swaps to
+  // "正在重新生成 …" so the user sees activity while waiting.
+  sceneRefreshingId?: string
 }>()
 
 const emit = defineEmits<{
@@ -233,6 +238,9 @@ const placeholderTitle = computed(() => {
   if (workflowInFlight.value) return '正在生成分镜'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '正在生成视频'
   if (!sceneCount.value) return '等待分镜'
+  // Single-scene retry (manual-mode "重新生成" button on a done scene)
+  // — show activity even though the OVERALL render isn't in flight.
+  if (props.sceneRefreshingId) return '正在重新生成候选图'
   if (!assetsReady.value) {
     if (props.refreshingImages) return '正在生成候选图'
     if (imageAssetCount.value > 0) return '候选图已暂停'
@@ -259,6 +267,12 @@ const placeholderDesc = computed(() => {
   }
   if (!sceneCount.value) {
     return '还没有可用的分镜。请先在「创作故事」页签输入故事主题，并点击「开始创作」生成内容。'
+  }
+  // Match the title above — single-scene retry has its own description
+  // so the user sees that the system IS doing something, instead of the
+  // stale "等待渲染 / 候选图已就绪" copy.
+  if (props.sceneRefreshingId) {
+    return `正在为 ${props.sceneRefreshingId} 重新生成候选图，请稍候。`
   }
   if (!assetsReady.value) {
     if (props.refreshingImages) {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -169,18 +169,11 @@ function toAssetHref(path?: string, sceneId?: string): string {
   // version after each successful refresh; absent / zero versions
   // are treated as "no bust needed" so unchanged scenes don't refetch.
   const version = sceneId ? props.sceneImageVersions?.[sceneId] : undefined
-  let finalUrl: string
   if (version && version > 0) {
     const separator = normalizedPath.includes('?') ? '&' : '?'
-    finalUrl = `${normalizedBase}${normalizedPath}${separator}v=${version}`
-  } else {
-    finalUrl = `${normalizedBase}${normalizedPath}`
+    return `${normalizedBase}${normalizedPath}${separator}v=${version}`
   }
-  // TEMPORARY DIAGNOSTIC — verifies the final URL the <img> binds to
-  if (sceneId && trimmed.includes('?_=')) {
-    console.log('[toAssetHref][regen]', sceneId, '→', finalUrl)
-  }
-  return finalUrl
+  return `${normalizedBase}${normalizedPath}`
 }
 
 function assetRefPath(assetRef?: ImageAssetRef): string {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -195,13 +195,17 @@ function isImageAsset(path?: string): boolean {
     return false
   }
 
-  const value = path.toLowerCase()
+  // Strip query string and hash before checking the file extension —
+  // cache-bust suffixes (e.g. "?_=1718999999") make the raw URL end in
+  // the timestamp, not in ".png", which previously caused isImageAsset
+  // to fail and fall back to the CSS placeholder graphic.
+  const pathPart = path.split(/[?#]/)[0].toLowerCase()
   return (
-    value.endsWith('.png') ||
-    value.endsWith('.jpg') ||
-    value.endsWith('.jpeg') ||
-    value.endsWith('.webp') ||
-    value.endsWith('.gif')
+    pathPart.endsWith('.png') ||
+    pathPart.endsWith('.jpg') ||
+    pathPart.endsWith('.jpeg') ||
+    pathPart.endsWith('.webp') ||
+    pathPart.endsWith('.gif')
   )
 }
 

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -596,6 +596,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 <img
                   v-if="isImageAsset(assetRefPath(entry.item.selected_asset_ref))"
                   class="preview-visual-image"
+                  :key="`${entry.sceneId}-${sceneImageVersions?.[entry.sceneId] ?? 0}-selected`"
                   :src="toAssetHref(assetRefPath(entry.item.selected_asset_ref), entry.sceneId)"
                   :alt="entry.sceneTitle || 'selected-image'"
                 />
@@ -701,6 +702,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                     <img
                       v-if="isImageAsset(assetRefPath(candidate))"
                       class="preview-visual-image"
+                      :key="`${entry.sceneId}-${sceneImageVersions?.[entry.sceneId] ?? 0}-${candidate.file_name || index}`"
                       :src="toAssetHref(assetRefPath(candidate), entry.sceneId)"
                       :alt="candidate.file_name || 'candidate-image'"
                     />

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -83,6 +83,14 @@ const props = defineProps<{
   // from must not change underneath it (the displayed selection would no
   // longer match the actual video frames).
   videoGenerated?: boolean
+  // Render mode drives whether the per-scene "重新生成" button is
+  // exposed. In 'auto' mode the system kicks off final video rendering
+  // as soon as all candidates are ready, so a per-scene regenerate
+  // button has no time to be useful and would just confuse users. In
+  // 'manual' mode the user is reviewing before clicking "生成视频",
+  // and they're the natural audience for regenerating a single bad
+  // scene without re-running the entire workflow.
+  renderMode?: 'auto' | 'manual'
 }>()
 
 // A scene's candidates are locked when:
@@ -603,6 +611,22 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   @click="onEnhanceScene(entry.sceneId)"
                 >
                   ✦ 增强画质
+                </button>
+                <!-- Manual-mode regenerate. Only useful while the user is
+                     still reviewing — once a final video exists the
+                     candidates are locked (the displayed selection must
+                     match what was baked in). In auto mode the system
+                     renders as soon as candidates are ready, so the
+                     button has no time window to be useful. -->
+                <button
+                  v-if="renderMode === 'manual' && !videoGenerated"
+                  type="button"
+                  class="regen-scene-button"
+                  :disabled="loading || selectingSceneId === entry.sceneId"
+                  :title="'对当前场景画面不满意时，重新生成两张候选图'"
+                  @click="onRetryScene(entry.sceneId)"
+                >
+                  ↻ 重新生成
                 </button>
               </div>
             </div>
@@ -1428,6 +1452,36 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 }
 
 .enhance-scene-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+/* Per-scene regenerate button — manual-mode only. Visually paired with
+   .enhance-scene-button (same row), uses theme accent (--arc-400)
+   instead of the prism orange so the two siblings are
+   distinguishable at a glance: "增强画质" = quality-tier upgrade,
+   "重新生成" = roll the dice again at the same tier. */
+.regen-scene-button {
+  width: fit-content;
+  min-height: 28px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(245,158,11,0.32);
+  background: rgba(245,158,11,0.10);
+  color: var(--arc-300);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 6px;
+  margin-left: 8px;
+  font-family: inherit;
+  transition: background 0.15s, border-color 0.15s;
+}
+.regen-scene-button:hover:not(:disabled) {
+  background: rgba(245,158,11,0.18);
+  border-color: rgba(245,158,11,0.52);
+}
+.regen-scene-button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
 }

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -349,7 +349,14 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
     }
 
     const matchedItem = itemMap.get(sceneId)
-    if (matchedItem) {
+    // If the placeholder is actively refreshing (e.g. user clicked the
+    // per-scene "重新生成" button on a done scene), the placeholder's
+    // refreshing animation takes priority over the stale done item.
+    // Without this, the matched item path wins and the user sees the
+    // OLD image unchanged while the background API call runs — there's
+    // no visual indication anything's happening, and once the new image
+    // arrives it appears to "just change" without any progress feedback.
+    if (matchedItem && placeholder.state !== 'refreshing' && placeholder.state !== 'waiting') {
       entries.push({
         kind: 'item',
         sceneId,
@@ -366,6 +373,14 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
         state: placeholder.state,
         errorMessage: placeholder.error_message,
       })
+      // Still remove from itemMap so the loop below doesn't re-add the
+      // stale done card after the placeholder; once refresh completes,
+      // markPlaceholderState(sceneId, 'done') flips the state and the
+      // matched-item branch above will pick up the FRESH item on the
+      // next render.
+      if (matchedItem) {
+        itemMap.delete(sceneId)
+      }
     }
   }
 
@@ -1473,7 +1488,6 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   font-weight: 600;
   cursor: pointer;
   margin-top: 6px;
-  margin-left: 8px;
   font-family: inherit;
   transition: background 0.15s, border-color 0.15s;
 }

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -91,6 +91,13 @@ const props = defineProps<{
   // and they're the natural audience for regenerating a single bad
   // scene without re-running the entire workflow.
   renderMode?: 'auto' | 'manual'
+  // Map of scene_id → version-counter for image cache-busting. When a
+  // scene is regenerated the new image file overwrites the OLD one
+  // at the same file path (e.g. scene_03__candidate_a.png), and
+  // browsers happily serve the cached image since the URL hasn't
+  // changed. Appending `?v=${sceneImageVersions[sceneId]}` to every
+  // image URL forces a fresh fetch after each per-scene refresh.
+  sceneImageVersions?: Record<string, number>
 }>()
 
 // A scene's candidates are locked when:
@@ -139,7 +146,7 @@ const emit = defineEmits<{
   (e: 'cancel-workflow'): void
 }>()
 
-function toAssetHref(path?: string): string {
+function toAssetHref(path?: string, sceneId?: string): string {
   if (!path) {
     return ''
   }
@@ -156,6 +163,16 @@ function toAssetHref(path?: string): string {
   const normalizedBase = props.apiBaseUrl.replace(/\/+$/, '')
   const normalizedPath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
 
+  // Cache-bust per scene: backend overwrites the same file path on
+  // regenerate, so without a version param the browser will keep
+  // showing the cached old image. The parent bumps the per-scene
+  // version after each successful refresh; absent / zero versions
+  // are treated as "no bust needed" so unchanged scenes don't refetch.
+  const version = sceneId ? props.sceneImageVersions?.[sceneId] : undefined
+  if (version && version > 0) {
+    const separator = normalizedPath.includes('?') ? '&' : '?'
+    return `${normalizedBase}${normalizedPath}${separator}v=${version}`
+  }
   return `${normalizedBase}${normalizedPath}`
 }
 
@@ -579,7 +596,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 <img
                   v-if="isImageAsset(assetRefPath(entry.item.selected_asset_ref))"
                   class="preview-visual-image"
-                  :src="toAssetHref(assetRefPath(entry.item.selected_asset_ref))"
+                  :src="toAssetHref(assetRefPath(entry.item.selected_asset_ref), entry.sceneId)"
                   :alt="entry.sceneTitle || 'selected-image'"
                 />
                 <div v-else class="placeholder-card">
@@ -611,7 +628,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 <a
                   v-if="isImageAsset(assetRefPath(entry.item.selected_asset_ref))"
                   class="selected-open-link"
-                  :href="toAssetHref(assetRefPath(entry.item.selected_asset_ref))"
+                  :href="toAssetHref(assetRefPath(entry.item.selected_asset_ref), entry.sceneId)"
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -684,7 +701,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                     <img
                       v-if="isImageAsset(assetRefPath(candidate))"
                       class="preview-visual-image"
-                      :src="toAssetHref(assetRefPath(candidate))"
+                      :src="toAssetHref(assetRefPath(candidate), entry.sceneId)"
                       :alt="candidate.file_name || 'candidate-image'"
                     />
 

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -169,11 +169,18 @@ function toAssetHref(path?: string, sceneId?: string): string {
   // version after each successful refresh; absent / zero versions
   // are treated as "no bust needed" so unchanged scenes don't refetch.
   const version = sceneId ? props.sceneImageVersions?.[sceneId] : undefined
+  let finalUrl: string
   if (version && version > 0) {
     const separator = normalizedPath.includes('?') ? '&' : '?'
-    return `${normalizedBase}${normalizedPath}${separator}v=${version}`
+    finalUrl = `${normalizedBase}${normalizedPath}${separator}v=${version}`
+  } else {
+    finalUrl = `${normalizedBase}${normalizedPath}`
   }
-  return `${normalizedBase}${normalizedPath}`
+  // TEMPORARY DIAGNOSTIC — verifies the final URL the <img> binds to
+  if (sceneId && trimmed.includes('?_=')) {
+    console.log('[toAssetHref][regen]', sceneId, '→', finalUrl)
+  }
+  return finalUrl
 }
 
 function assetRefPath(assetRef?: ImageAssetRef): string {

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2943,6 +2943,7 @@ async function runWorkflow() {
                   :cancel-requested="cancelRequested"
                   :cancellable="Boolean(activeWorkflowId)"
                   :video-generated="Boolean(finalVideoUrl)"
+                  :render-mode="workflowForm.renderMode"
                   @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
                   @retry-scene="retryImageReviewScene"
                   @enhance-scene="enhanceImageReviewScene"

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2063,6 +2063,22 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
     }
   }
 
+  // TEMPORARY DIAGNOSTIC — verifies the cache-bust rewrite landed in the
+  // merged response that downstream consumers actually see. Remove once
+  // the regen-after-image-render bug is confirmed fixed end-to-end.
+  try {
+    const debugAssets = (mergedResponse.outputs as Record<string, unknown> | undefined)?.image_review as Record<string, unknown> | undefined
+    const debugList = debugAssets?.selected_assets
+    if (Array.isArray(debugList)) {
+      const match = debugList.find((x: any) => x?.scene_id === sceneId)
+      console.log('[regen][cache-bust] scene=', sceneId, 'ts=', cacheBustTs)
+      console.log('[regen][cache-bust] new selected_asset_ref path=', (match as any)?.selected_asset_ref?.relative_path)
+      console.log('[regen][cache-bust] new selected_asset_ref url=', (match as any)?.selected_asset_ref?.public_url)
+    }
+  } catch (e) {
+    console.warn('[regen][cache-bust] diagnostic failed', e)
+  }
+
   applyWorkflowResponse(mergedResponse)
   markPlaceholderState(sceneId, 'done')
 }

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -1053,6 +1053,18 @@ const awaitingManualRender = computed(() => {
   )
 })
 
+// "Single-scene retry" = the user clicked "重新生成" on ONE done scene
+// AFTER the initial workflow finished. We must distinguish this from
+// the bulk image refresh that the initial workflow runs — the bulk
+// loop also sets `sceneRefreshingId` as it walks each scene, but the
+// correct UI copy for that is "正在生成候选图 (X/Y)", not "正在为 X
+// 重新生成". The discriminator is `refreshingImageReview`: it's only
+// true during the bulk refresh, never during user-triggered single
+// retries.
+const singleSceneRetryActive = computed(() => {
+  return Boolean(sceneRefreshingId.value) && !refreshingImageReview.value
+})
+
 function formatElapsedTime(totalSec: number): string {
   const normalizedSec = Math.max(0, Math.floor(totalSec))
   const minutes = Math.floor(normalizedSec / 60)
@@ -2822,7 +2834,7 @@ async function runWorkflow() {
           Boolean(sceneRefreshingId)
         "
         :percent="
-          sceneRefreshingId
+          singleSceneRetryActive
             ? 75
             : finalVideoRenderInFlight
               ? 92
@@ -2831,7 +2843,7 @@ async function runWorkflow() {
                 : (workflowStatusProgress ?? (refreshingImageReview ? reviewRefreshProgress.percent : 0))
         "
         :label="
-          sceneRefreshingId
+          singleSceneRetryActive
             ? `正在为 ${sceneRefreshingId} 重新生成候选图`
             : finalVideoRenderInFlight
               ? '正在合成视频（音频、字幕、画面拼接中）'
@@ -2839,7 +2851,7 @@ async function runWorkflow() {
                 ? '候选图已就绪，等待你点击「生成视频」'
                 : (workflowIsProcessing ? workflowRunStatusMessage : reviewRefreshProgress.text)
         "
-        :cancellable="phaseCancellable && !awaitingManualRender && !sceneRefreshingId"
+        :cancellable="phaseCancellable && !awaitingManualRender && !singleSceneRetryActive"
         :cancel-requested="cancelRequestedAny"
         @cancel="cancelActivePhase"
       />

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2012,65 +2012,15 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
     },
   }
 
-  // Inject a cache-bust timestamp directly into the per-scene asset
-  // paths inside the merged response, BEFORE applyWorkflowResponse
-  // hands the data downstream. Backend overwrites the same on-disk file
-  // (e.g. scene_03__candidate_a.png) on regenerate, and browsers happily
-  // serve the cached old image because the URL never changed.
-  // Re-writing relative_path / public_url with a fresh `?_=<ts>` suffix
-  // at the source guarantees every consumer (current image, candidates,
-  // 查看原图 link, etc.) sees a different URL and must re-fetch.
-  const cacheBustTs = Date.now()
-  const appendBust = (urlOrPath: string | undefined): string => {
-    const value = String(urlOrPath || '').trim()
-    if (!value) return value
-    const separator = value.includes('?') ? '&' : '?'
-    return `${value}${separator}_=${cacheBustTs}`
-  }
-  const rewriteAssetRef = (ref: Record<string, unknown> | undefined | null) => {
-    if (!ref || typeof ref !== 'object') return
-    const rp = (ref as Record<string, unknown>).relative_path
-    const pu = (ref as Record<string, unknown>).public_url
-    if (typeof rp === 'string' && rp) (ref as Record<string, unknown>).relative_path = appendBust(rp)
-    if (typeof pu === 'string' && pu) (ref as Record<string, unknown>).public_url = appendBust(pu)
-  }
-  const reviewBlock = (mergedResponse.outputs as Record<string, unknown> | undefined)?.image_review as Record<string, unknown> | undefined
-  const selectedAssetsList = reviewBlock?.selected_assets
-  if (Array.isArray(selectedAssetsList)) {
-    for (const sa of selectedAssetsList) {
-      if (!sa || typeof sa !== 'object') continue
-      const item = sa as Record<string, unknown>
-      if (String(item.scene_id || '') !== sceneId) continue
-      rewriteAssetRef(item.selected_asset_ref as Record<string, unknown> | undefined)
-      const candidates = item.candidate_asset_refs
-      if (Array.isArray(candidates)) {
-        for (const c of candidates) rewriteAssetRef(c as Record<string, unknown> | undefined)
-      }
-    }
-  }
-  const assetsBlock = (mergedResponse.outputs as Record<string, unknown> | undefined)?.image_assets as Record<string, unknown> | undefined
-  const assetItems = assetsBlock?.assets
-  if (Array.isArray(assetItems)) {
-    for (const a of assetItems) {
-      if (!a || typeof a !== 'object') continue
-      const item = a as Record<string, unknown>
-      if (String(item.scene_id || '') !== sceneId) continue
-      rewriteAssetRef(item.selected_asset_ref as Record<string, unknown> | undefined)
-      const candidates = item.candidate_asset_refs
-      if (Array.isArray(candidates)) {
-        for (const c of candidates) rewriteAssetRef(c as Record<string, unknown> | undefined)
-      }
-    }
-  }
-
-  // Bump the per-scene version counter so the <img :key> bound to this
-  // scene's version forces a full element remount when render fires.
-  // Without this Vue can reuse the same <img> DOM node and (combined
-  // with browser src-cache heuristics) skip fetching the new URL even
-  // though the underlying string has changed.
+  // Cache-bust ONLY at the URL building stage (toAssetHref reads this
+  // map and appends ?v=ts). We must NOT mutate the underlying asset
+  // paths here — those flow into /v1/final-video/render's payload and
+  // are used by the backend to locate the actual files on disk. A
+  // `?_=ts` suffix on relative_path would make the backend search for
+  // a non-existent file and silently break the final video.
   sceneImageVersions.value = {
     ...sceneImageVersions.value,
-    [sceneId]: cacheBustTs,
+    [sceneId]: Date.now(),
   }
 
   applyWorkflowResponse(mergedResponse)

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2765,6 +2765,11 @@ async function runWorkflow() {
   finalVideoUrl.value = ''
   finalVideoRenderInFlight.value = false
   finalVideoRendering.value = false
+  // Clear any stale per-scene retry state from the previous workflow run.
+  // Without this, the top progress bar and FinalVideoPanel keep showing
+  // "正在为 scene_XX 重新生成候选图" on top of the new initial workflow.
+  sceneRefreshingId.value = ''
+  sceneImageVersions.value = {}
 
   try {
     const response = await fetch(`${apiBaseUrl}/v1/workflow/run`, {

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2063,6 +2063,16 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
     }
   }
 
+  // Bump the per-scene version counter so the <img :key> bound to this
+  // scene's version forces a full element remount when render fires.
+  // Without this Vue can reuse the same <img> DOM node and (combined
+  // with browser src-cache heuristics) skip fetching the new URL even
+  // though the underlying string has changed.
+  sceneImageVersions.value = {
+    ...sceneImageVersions.value,
+    [sceneId]: cacheBustTs,
+  }
+
   // TEMPORARY DIAGNOSTIC — verifies the cache-bust rewrite landed in the
   // merged response that downstream consumers actually see. Remove once
   // the regen-after-image-render bug is confirmed fixed end-to-end.
@@ -2074,6 +2084,7 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
       console.log('[regen][cache-bust] scene=', sceneId, 'ts=', cacheBustTs)
       console.log('[regen][cache-bust] new selected_asset_ref path=', (match as any)?.selected_asset_ref?.relative_path)
       console.log('[regen][cache-bust] new selected_asset_ref url=', (match as any)?.selected_asset_ref?.public_url)
+      console.log('[regen][cache-bust] sceneImageVersions=', JSON.parse(JSON.stringify(sceneImageVersions.value)))
     }
   } catch (e) {
     console.warn('[regen][cache-bust] diagnostic failed', e)

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2016,10 +2016,12 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
   // the moment new items flow through to InteractiveImageReview, every
   // <img :src> for this scene gets re-evaluated with the new version
   // suffix — browsers fetch the fresh file instead of serving the cached
-  // pre-regen image.
+  // pre-regen image. Using Date.now() (timestamp) instead of an
+  // incrementing counter guarantees the version is always different from
+  // any previously-used value, even across hot-reload / state restore.
   sceneImageVersions.value = {
     ...sceneImageVersions.value,
-    [sceneId]: (sceneImageVersions.value[sceneId] ?? 0) + 1,
+    [sceneId]: Date.now(),
   }
 
   applyWorkflowResponse(mergedResponse)
@@ -2909,6 +2911,7 @@ async function runWorkflow() {
                 :workflow-status-message="workflowRunStatusMessage"
                 :workflow-status-progress="workflowStatusProgress"
                 :render-mode="workflowForm.renderMode"
+                :scene-refreshing-id="sceneRefreshingId"
                 @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
                 :show-render-button="workflowForm.renderMode === 'auto'"
               />

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2073,23 +2073,6 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
     [sceneId]: cacheBustTs,
   }
 
-  // TEMPORARY DIAGNOSTIC — verifies the cache-bust rewrite landed in the
-  // merged response that downstream consumers actually see. Remove once
-  // the regen-after-image-render bug is confirmed fixed end-to-end.
-  try {
-    const debugAssets = (mergedResponse.outputs as Record<string, unknown> | undefined)?.image_review as Record<string, unknown> | undefined
-    const debugList = debugAssets?.selected_assets
-    if (Array.isArray(debugList)) {
-      const match = debugList.find((x: any) => x?.scene_id === sceneId)
-      console.log('[regen][cache-bust] scene=', sceneId, 'ts=', cacheBustTs)
-      console.log('[regen][cache-bust] new selected_asset_ref path=', (match as any)?.selected_asset_ref?.relative_path)
-      console.log('[regen][cache-bust] new selected_asset_ref url=', (match as any)?.selected_asset_ref?.public_url)
-      console.log('[regen][cache-bust] sceneImageVersions=', JSON.parse(JSON.stringify(sceneImageVersions.value)))
-    }
-  } catch (e) {
-    console.warn('[regen][cache-bust] diagnostic failed', e)
-  }
-
   applyWorkflowResponse(mergedResponse)
   markPlaceholderState(sceneId, 'done')
 }

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2012,16 +2012,55 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
     },
   }
 
-  // Bump this scene's cache-bust version BEFORE applyWorkflowResponse so
-  // the moment new items flow through to InteractiveImageReview, every
-  // <img :src> for this scene gets re-evaluated with the new version
-  // suffix — browsers fetch the fresh file instead of serving the cached
-  // pre-regen image. Using Date.now() (timestamp) instead of an
-  // incrementing counter guarantees the version is always different from
-  // any previously-used value, even across hot-reload / state restore.
-  sceneImageVersions.value = {
-    ...sceneImageVersions.value,
-    [sceneId]: Date.now(),
+  // Inject a cache-bust timestamp directly into the per-scene asset
+  // paths inside the merged response, BEFORE applyWorkflowResponse
+  // hands the data downstream. Backend overwrites the same on-disk file
+  // (e.g. scene_03__candidate_a.png) on regenerate, and browsers happily
+  // serve the cached old image because the URL never changed.
+  // Re-writing relative_path / public_url with a fresh `?_=<ts>` suffix
+  // at the source guarantees every consumer (current image, candidates,
+  // 查看原图 link, etc.) sees a different URL and must re-fetch.
+  const cacheBustTs = Date.now()
+  const appendBust = (urlOrPath: string | undefined): string => {
+    const value = String(urlOrPath || '').trim()
+    if (!value) return value
+    const separator = value.includes('?') ? '&' : '?'
+    return `${value}${separator}_=${cacheBustTs}`
+  }
+  const rewriteAssetRef = (ref: Record<string, unknown> | undefined | null) => {
+    if (!ref || typeof ref !== 'object') return
+    const rp = (ref as Record<string, unknown>).relative_path
+    const pu = (ref as Record<string, unknown>).public_url
+    if (typeof rp === 'string' && rp) (ref as Record<string, unknown>).relative_path = appendBust(rp)
+    if (typeof pu === 'string' && pu) (ref as Record<string, unknown>).public_url = appendBust(pu)
+  }
+  const reviewBlock = (mergedResponse.outputs as Record<string, unknown> | undefined)?.image_review as Record<string, unknown> | undefined
+  const selectedAssetsList = reviewBlock?.selected_assets
+  if (Array.isArray(selectedAssetsList)) {
+    for (const sa of selectedAssetsList) {
+      if (!sa || typeof sa !== 'object') continue
+      const item = sa as Record<string, unknown>
+      if (String(item.scene_id || '') !== sceneId) continue
+      rewriteAssetRef(item.selected_asset_ref as Record<string, unknown> | undefined)
+      const candidates = item.candidate_asset_refs
+      if (Array.isArray(candidates)) {
+        for (const c of candidates) rewriteAssetRef(c as Record<string, unknown> | undefined)
+      }
+    }
+  }
+  const assetsBlock = (mergedResponse.outputs as Record<string, unknown> | undefined)?.image_assets as Record<string, unknown> | undefined
+  const assetItems = assetsBlock?.assets
+  if (Array.isArray(assetItems)) {
+    for (const a of assetItems) {
+      if (!a || typeof a !== 'object') continue
+      const item = a as Record<string, unknown>
+      if (String(item.scene_id || '') !== sceneId) continue
+      rewriteAssetRef(item.selected_asset_ref as Record<string, unknown> | undefined)
+      const candidates = item.candidate_asset_refs
+      if (Array.isArray(candidates)) {
+        for (const c of candidates) rewriteAssetRef(c as Record<string, unknown> | undefined)
+      }
+    }
   }
 
   applyWorkflowResponse(mergedResponse)

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -527,6 +527,14 @@ const refreshingImageReview = ref(false)
 const sceneRefreshQueue = ref<string[]>([])
 const sceneRefreshingId = ref('')
 const reviewPlaceholders = ref<ReviewPlaceholderItem[]>([])
+
+// Per-scene image cache-busting version counter. Bumped each time a
+// scene's candidates are successfully regenerated via the per-scene
+// "重新生成" button. Without this the browser keeps serving the cached
+// image file (backend overwrites the same file path on regen) and the
+// user sees the OLD image. The map is passed into InteractiveImageReview
+// and appended as `?v=${version}` to that scene's image URLs.
+const sceneImageVersions = ref<Record<string, number>>({})
 const imageReviewRefreshCancelled = ref(false)
 // Reactive mirror of STORAGE_KEY_REFRESH_CANCELLED — true iff THIS workflow's
 // image refresh was paused by user cancel. Used to distinguish "已暂停" (user
@@ -2004,6 +2012,16 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
     },
   }
 
+  // Bump this scene's cache-bust version BEFORE applyWorkflowResponse so
+  // the moment new items flow through to InteractiveImageReview, every
+  // <img :src> for this scene gets re-evaluated with the new version
+  // suffix — browsers fetch the fresh file instead of serving the cached
+  // pre-regen image.
+  sceneImageVersions.value = {
+    ...sceneImageVersions.value,
+    [sceneId]: (sceneImageVersions.value[sceneId] ?? 0) + 1,
+  }
+
   applyWorkflowResponse(mergedResponse)
   markPlaceholderState(sceneId, 'done')
 }
@@ -2944,6 +2962,7 @@ async function runWorkflow() {
                   :cancellable="Boolean(activeWorkflowId)"
                   :video-generated="Boolean(finalVideoUrl)"
                   :render-mode="workflowForm.renderMode"
+                  :scene-image-versions="sceneImageVersions"
                   @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
                   @retry-scene="retryImageReviewScene"
                   @enhance-scene="enhanceImageReviewScene"

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2863,23 +2863,28 @@ async function runWorkflow() {
           workflowIsProcessing ||
           refreshingImageReview ||
           awaitingManualRender ||
-          finalVideoRenderInFlight
+          finalVideoRenderInFlight ||
+          Boolean(sceneRefreshingId)
         "
         :percent="
-          awaitingManualRender
-            ? 85
+          sceneRefreshingId
+            ? 75
             : finalVideoRenderInFlight
               ? 92
-              : (workflowStatusProgress ?? (refreshingImageReview ? reviewRefreshProgress.percent : 0))
+              : awaitingManualRender
+                ? 85
+                : (workflowStatusProgress ?? (refreshingImageReview ? reviewRefreshProgress.percent : 0))
         "
         :label="
-          awaitingManualRender
-            ? '候选图已就绪，等待你点击「生成视频」'
+          sceneRefreshingId
+            ? `正在为 ${sceneRefreshingId} 重新生成候选图`
             : finalVideoRenderInFlight
               ? '正在合成视频（音频、字幕、画面拼接中）'
-              : (workflowIsProcessing ? workflowRunStatusMessage : reviewRefreshProgress.text)
+              : awaitingManualRender
+                ? '候选图已就绪，等待你点击「生成视频」'
+                : (workflowIsProcessing ? workflowRunStatusMessage : reviewRefreshProgress.text)
         "
-        :cancellable="phaseCancellable && !awaitingManualRender"
+        :cancellable="phaseCancellable && !awaitingManualRender && !sceneRefreshingId"
         :cancel-requested="cancelRequestedAny"
         @cancel="cancelActivePhase"
       />


### PR DESCRIPTION
## What's in this PR

Originally opened for a single feature (per-scene 重新生成 button) but grew to include several backend audio quality fixes uncovered while testing the regenerate flow end-to-end.

## 1. Manual-mode 重新生成 button (the original ask)

Per-scene "重新生成" button on done scenes in 画面审核 tab, manual mode only.

**Files**: \`InteractiveImageReview.vue\`, \`StudioView.vue\`, \`FinalVideoPanel.vue\`, \`StudioPreviewPanel.vue\`

Reuses the existing \`retry-scene\` event → \`retryImageReviewScene\` → \`refreshImageReviewScene\` path, which is also the path the bulk image refresh walks. Several state-machine adjustments to make per-scene retry visible without breaking the bulk flow:

- New \`sceneRefreshingId\` ref + \`singleSceneRetryActive\` computed (= \`sceneRefreshingId && !refreshingImageReview\`)
- StudioProgress label/percent + FinalVideoPanel placeholder copy + loading icon all switch on \`singleSceneRetryActive\` so initial bulk refresh keeps its "正在生成候选图 (X/Y)" copy
- Entries logic in \`InteractiveImageReview\` flips a done scene back to placeholder rendering when its state is \`'refreshing'\`/\`'waiting'\` (so user sees the loading animation instead of the stale image)
- \`sceneRefreshingId\` + \`sceneImageVersions\` cleared at the start of every new workflow run

## 2. Backend seed_jitter — the real reason regen produces a different image

\`image_provider_adapter.py\` previously derived its Kolors seed from \`(run_id, scene_index)\` deterministically. Same prompt + same seed → byte-identical PNG. The user clicked 重新生成, got a 200 response, the file on disk was overwritten with the same bytes, and the cache-busted URL fetched the "new" file — which looked identical.

**Fix**: \`runner_single_scene_image_support.py\` now passes \`seed_jitter = time.time_ns() + candidate_index * 7919\` in \`prompt_metadata\`; the adapter adds it to the base seed. Initial bulk workflow path is unaffected (it sends \`seed_jitter=0\`, default).

## 3. Image cache-bust without polluting backend payload

The image file path (e.g. \`scene_03__candidate_a.png\`) is overwritten in place on regen, so browsers serve the cached copy unless we change the URL. Cache-bust is now applied ONLY in \`toAssetHref\` via a per-scene version map; the underlying \`relative_path\` stays clean so it can flow into the \`/v1/final-video/render\` payload without breaking ffmpeg's file lookup.

## 4. Audio fixes (uncovered while testing)

### 4a. \`ceil_to_frame_boundary\` for per-scene image durations

Final video is rendered at 25 fps via \`-vsync cfr -r 25\`. Image durations were getting rounded by ffmpeg to the nearest 0.04 s frame; downward rounds made base_video < merged_audio per scene, and \`-shortest\` then truncated the tail of one or more audio segments. Image durations are now \`math.ceil(duration / 0.04) * 0.04\` so base_video ≥ merged_audio per scene.

### 4b. \`-t\` cap uses probed merged_audio duration + 0.2 s buffer

\`total_duration_sec\` was the SUM of each individual MP3's \`ffprobe\` duration. The actual merged_audio.mp3 (from \`ffmpeg -f concat -c copy\`) can be a few tens of ms longer due to MP3 frame boundary alignment — the last syllable of the final segment then got clipped by \`-t\`. Now we ffprobe the merged file directly and \`max(sum, actual) + 0.2\` it.

### 4c. Remove per-segment 1.25× speed-up retry

Root cause of the "个别句尾音被吞" symptom. When \`actual > estimate × 1.3\`, the runner was re-rendering that segment at \`speed=1.25\` via the TTS API; empirically the provider truncates trailing syllables at \`speed > 1\` on long sentences. Removed entirely — the global speedup pass at the end of the method (uniform across ALL segments, max 1.5×) still handles total-duration overshoot. Slow-down retry (audio < estimate × 0.7) is preserved — TTS providers handle \`speed < 1\` by stretching, no content loss.

### 4d. Concat filter instead of demuxer for merged_audio

Original \`-c copy\` MP3 concat byte-stitched LAME-encoded segments, which produced bit-reservoir cross-segment references and click/stutter at boundaries. Switched to the ffmpeg \`concat\` FILTER (not demuxer) with single-pass libmp3lame re-encode at 128 kbps:

\`\`\`
ffmpeg -i seg1.mp3 -i seg2.mp3 ...
  -filter_complex \"[0:a][1:a]...concat=n=N:v=0:a=1[out]\"
  -map \"[out]\" -c:a libmp3lame -b:a 128k merged.mp3
\`\`\`

Each segment is fully decoded to PCM, samples are explicitly concatenated by the filter, then a single MP3 is encoded — no bit-reservoir boundary artifacts AND no per-file padding/priming sample loss (which the demuxer + re-encode approach had).

## What was tried and reverted (recorded for honesty)

- Briefly added 150 ms tail silence padding via \`apad\` per-segment — caused perceptual stuttering (per-segment lossy re-encode at 64k + audible pauses). Removed.
- Briefly mutated \`selected_asset_ref.relative_path\` with cache-bust suffix — that path flows into the render payload and broke ffmpeg's file lookup → mismatched/short videos. Reverted; cache-bust now lives only in the URL builder.
- Briefly tried \`-c:a libmp3lame\` with the concat DEMUXER — eats sample padding at segment tails. Replaced with the concat filter.

## Test plan

- [x] Frontend acceptance check passes
- [x] \`py_compile\` passes for all changed Python files
- [ ] Manual mode 60s / 120s / 180s workflows run to completion
- [ ] Per-scene 重新生成 produces a visually different image on each click
- [ ] Top progress bar + FinalVideoPanel show single-scene retry copy (not "等待渲染" or "正在生成候选图 X/Y") while a per-scene retry is active
- [ ] Bulk refresh during initial workflow still shows "正在生成候选图 (X/Y)" copy
- [ ] Starting a new workflow clears stale per-scene retry state
- [ ] Audio tail content present on long sentences (per-segment retry was the root cause)
- [ ] Boundary stutter reduced (concat filter eliminates bit-reservoir issue)