### PR TITLE
refactor(studio): drop redundant :key cache-bust on candidate <img>

### DIFF
--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -600,7 +600,6 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 <img
                   v-if="isImageAsset(assetRefPath(entry.item.selected_asset_ref))"
                   class="preview-visual-image"
-                  :key="`${entry.sceneId}-${sceneImageVersions?.[entry.sceneId] ?? 0}-selected`"
                   :src="toAssetHref(assetRefPath(entry.item.selected_asset_ref), entry.sceneId)"
                   :alt="entry.sceneTitle || 'selected-image'"
                 />
@@ -706,7 +705,6 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                     <img
                       v-if="isImageAsset(assetRefPath(candidate))"
                       class="preview-visual-image"
-                      :key="`${entry.sceneId}-${sceneImageVersions?.[entry.sceneId] ?? 0}-${candidate.file_name || index}`"
                       :src="toAssetHref(assetRefPath(candidate), entry.sceneId)"
                       :alt="candidate.file_name || 'candidate-image'"
                     />


### PR DESCRIPTION
## What

Two \`<img :key>\` bindings in \`InteractiveImageReview.vue\` were keyed on \`\${sceneId}-\${sceneImageVersions[sceneId]}-...\` to force Vue to remount the element on regenerate. They duplicate the cache-bust already happening in \`:src\` via \`toAssetHref\`'s \`?v=\${version}\` suffix.

## Why drop

- A version bump produces a NEW URL on \`:src\` → browser treats as new resource → fetches fresh bytes. That's the actual cache-bust.
- \`:key\` remount on the same version bump only forced Vue to recreate the DOM node. Without it Vue patches the \`src\` attribute on the existing element, which fires the same fetch.
- Net: the \`:key\` was belt-and-suspenders defense that didn't change behavior, just made the template noisier.

## What still uses sceneImageVersions

\`toAssetHref(path, sceneId)\` reads it to append \`?v=\${version}\` — single, correct use. The map is still bumped on each successful per-scene regenerate.

## Risk

Very low. No behavior change intended; the URL-level cache-bust still kicks in identically.

## Test plan

- [x] Frontend acceptance check passes
- [ ] Per-scene 重新生成 still updates the displayed image (URL changes → browser fetches fresh)
- [ ] No visual artifacts on candidate switch in 画面审核 tab