### PR TITLE
feat(studio): scene narration in 画面审核 + unified action buttons + pearl theme polish

### DIFF
--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -665,6 +665,15 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                 >
                   ↻ 重新生成
                 </button>
+
+                <!-- Storyboard prompt — already in entry.item.prompt,
+                     just surfacing it inline so users understand what
+                     the candidate was generated from. Wrapped + scrollable
+                     so very long prompts don't blow up the card. -->
+                <div v-if="entry.item.prompt" class="prompt-display-block">
+                  <div class="prompt-display-label">分镜提示词</div>
+                  <p class="prompt-display-text">{{ entry.item.prompt }}</p>
+                </div>
               </div>
             </div>
           </div>
@@ -1521,6 +1530,38 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
 .regen-scene-button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
+}
+
+/* Scene prompt inline display. Sits below the action buttons in the
+   selected-image info panel — gives the user visibility into what
+   exactly the candidate was generated from. Capped height + scroll
+   so a multi-paragraph prompt doesn't push the card off the page. */
+.prompt-display-block {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.05);
+  border: 1px solid rgba(245, 158, 11, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.prompt-display-label {
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.prompt-display-text {
+  margin: 0;
+  color: var(--text-secondary, #c8c8c8);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  word-break: break-word;
+  white-space: pre-wrap;
 }
 
 .candidate-header {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -98,6 +98,12 @@ const props = defineProps<{
   // changed. Appending `?v=${sceneImageVersions[sceneId]}` to every
   // image URL forces a fresh fetch after each per-scene refresh.
   sceneImageVersions?: Record<string, number>
+  // Map of scene_id → narration text (the TTS script for this scene).
+  // Surfaced inline on each candidate's card so the user knows what
+  // each scene is ABOUT in plain language. This is the user-readable
+  // story moment — NOT the structural image-gen prompt, which is
+  // hundreds of lines of cast-lock boilerplate and not useful to show.
+  sceneNarrationMap?: Record<string, string>
 }>()
 
 // A scene's candidates are locked when:
@@ -666,13 +672,20 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   ↻ 重新生成
                 </button>
 
-                <!-- Storyboard prompt — already in entry.item.prompt,
-                     just surfacing it inline so users understand what
-                     the candidate was generated from. Wrapped + scrollable
-                     so very long prompts don't blow up the card. -->
-                <div v-if="entry.item.prompt" class="prompt-display-block">
-                  <div class="prompt-display-label">分镜提示词</div>
-                  <p class="prompt-display-text">{{ entry.item.prompt }}</p>
+                <!-- Scene narration (the TTS script for this scene) —
+                     reads in plain language what's happening in this
+                     candidate's moment of the story. Helps the user
+                     judge whether the rendered candidate matches the
+                     intended scene without expanding "开发者信息" or
+                     parsing the structural image-gen prompt. -->
+                <div
+                  v-if="sceneNarrationMap?.[entry.sceneId]"
+                  class="narration-display-block"
+                >
+                  <div class="narration-display-label">画面内容</div>
+                  <p class="narration-display-text">
+                    {{ sceneNarrationMap[entry.sceneId] }}
+                  </p>
                 </div>
               </div>
             </div>
@@ -1532,11 +1545,11 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   opacity: 0.55;
 }
 
-/* Scene prompt inline display. Sits below the action buttons in the
-   selected-image info panel — gives the user visibility into what
-   exactly the candidate was generated from. Capped height + scroll
-   so a multi-paragraph prompt doesn't push the card off the page. */
-.prompt-display-block {
+/* Scene narration inline display. Sits below the action buttons in
+   the selected-image info panel — gives the user a plain-language
+   summary of what this candidate's scene is about. Narration is
+   typically one to two sentences, so the block stays compact. */
+.narration-display-block {
   margin-top: 10px;
   padding: 10px 12px;
   border-radius: 8px;
@@ -1545,21 +1558,19 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  max-height: 200px;
-  overflow-y: auto;
 }
-.prompt-display-label {
+.narration-display-label {
   color: var(--text-muted);
   font-size: 0.6875rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-.prompt-display-text {
+.narration-display-text {
   margin: 0;
   color: var(--text-secondary, #c8c8c8);
-  font-size: 0.8125rem;
-  line-height: 1.5;
+  font-size: 0.875rem;
+  line-height: 1.6;
   word-break: break-word;
   white-space: pre-wrap;
 }

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -588,17 +588,6 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
             <strong class="scene-title-text">
               {{ sceneDisplayTitle(entry) }}
             </strong>
-            <!-- Inline narration summary under the scene title. Caps at
-                 ~one line via CSS truncation so the head row stays
-                 compact; full text is still accessible by hover (title
-                 attribute) and via 开发者信息. -->
-            <span
-              v-if="sceneNarrationMap?.[entry.sceneId]"
-              class="scene-narration-summary"
-              :title="sceneNarrationMap[entry.sceneId]"
-            >
-              {{ sceneNarrationMap[entry.sceneId] }}
-            </span>
           </div>
 
           <span class="summary-status">
@@ -683,6 +672,22 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   ↻ 重新生成
                 </button>
 
+              </div>
+              <!-- Scene narration spans the FULL card width below the
+                   image + info-panel row. Originally placed inside the
+                   info panel (column 2), it ended up sitting in the
+                   bottom-right with a lot of empty space — the card
+                   looked unbalanced. Spanning both grid columns gives
+                   the narration its own visual band and ties the image
+                   to its description as a single unit. -->
+              <div
+                v-if="sceneNarrationMap?.[entry.sceneId]"
+                class="narration-display-block"
+              >
+                <div class="narration-display-label">画面内容</div>
+                <p class="narration-display-text">
+                  {{ sceneNarrationMap[entry.sceneId] }}
+                </p>
               </div>
             </div>
           </div>
@@ -1541,20 +1546,38 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   opacity: 0.55;
 }
 
-/* Scene narration as a single-line subtitle under the scene title.
-   Truncates with ellipsis to keep the head row compact; the full
-   narration is available via `title` attribute on hover. */
-.scene-narration-summary {
-  display: block;
+/* Scene narration band — spans both grid columns of .preview-card
+   (image + info-panel), so it forms a full-width strip below the
+   image and buttons. This is what the TTS reads aloud for this
+   moment of the story. */
+.narration-display-block {
+  grid-column: 1 / -1;
   margin-top: 4px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.05);
+  border: 1px solid rgba(245, 158, 11, 0.12);
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 10px;
+}
+.narration-display-label {
+  flex-shrink: 0;
   color: var(--text-muted);
-  font-size: 0.8125rem;
-  line-height: 1.4;
-  font-weight: 400;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.narration-display-text {
+  margin: 0;
+  color: var(--text-secondary, #c8c8c8);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  word-break: break-word;
+  white-space: pre-wrap;
+  flex: 1 1 auto;
 }
 
 .candidate-header {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -588,6 +588,17 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
             <strong class="scene-title-text">
               {{ sceneDisplayTitle(entry) }}
             </strong>
+            <!-- Inline narration summary under the scene title. Caps at
+                 ~one line via CSS truncation so the head row stays
+                 compact; full text is still accessible by hover (title
+                 attribute) and via 开发者信息. -->
+            <span
+              v-if="sceneNarrationMap?.[entry.sceneId]"
+              class="scene-narration-summary"
+              :title="sceneNarrationMap[entry.sceneId]"
+            >
+              {{ sceneNarrationMap[entry.sceneId] }}
+            </span>
           </div>
 
           <span class="summary-status">
@@ -672,22 +683,6 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   ↻ 重新生成
                 </button>
 
-              </div>
-              <!-- Scene narration spans the FULL card width below the
-                   image + info-panel row. Originally placed inside the
-                   info panel (column 2), it ended up sitting in the
-                   bottom-right with a lot of empty space — the card
-                   looked unbalanced. Spanning both grid columns gives
-                   the narration its own visual band and ties the image
-                   to its description as a single unit. -->
-              <div
-                v-if="sceneNarrationMap?.[entry.sceneId]"
-                class="narration-display-block"
-              >
-                <div class="narration-display-label">画面内容</div>
-                <p class="narration-display-text">
-                  {{ sceneNarrationMap[entry.sceneId] }}
-                </p>
               </div>
             </div>
           </div>
@@ -1546,38 +1541,20 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   opacity: 0.55;
 }
 
-/* Scene narration band — spans both grid columns of .preview-card
-   (image + info-panel), so it forms a full-width strip below the
-   image and buttons. This is what the TTS reads aloud for this
-   moment of the story. */
-.narration-display-block {
-  grid-column: 1 / -1;
+/* Scene narration as a single-line subtitle under the scene title.
+   Truncates with ellipsis to keep the head row compact; the full
+   narration is available via `title` attribute on hover. */
+.scene-narration-summary {
+  display: block;
   margin-top: 4px;
-  padding: 10px 14px;
-  border-radius: 8px;
-  background: rgba(245, 158, 11, 0.05);
-  border: 1px solid rgba(245, 158, 11, 0.12);
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: 10px;
-}
-.narration-display-label {
-  flex-shrink: 0;
   color: var(--text-muted);
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-.narration-display-text {
-  margin: 0;
-  color: var(--text-secondary, #c8c8c8);
-  font-size: 0.875rem;
-  line-height: 1.6;
-  word-break: break-word;
-  white-space: pre-wrap;
-  flex: 1 1 auto;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .candidate-header {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -123,6 +123,17 @@ function isSelectionLocked(item: ImageReviewSelectedAsset): boolean {
 }
 
 const storyExpanded = ref(false)
+
+// scene_id whose narration is currently expanded in a modal. The modal
+// shows the full narration text without growing the underlying card
+// (the card itself stays a fixed height — only ~3 lines of clamped
+// narration sit inline). `null` = no modal open.
+const narrationModalSceneId = ref<string | null>(null)
+const narrationModalText = computed(() => {
+  const sceneId = narrationModalSceneId.value
+  if (!sceneId) return ''
+  return props.sceneNarrationMap?.[sceneId] || ''
+})
 const normalizedStoryText = computed(() => String(props.storyText || '').trim())
 const storyNeedsToggle = computed(() => normalizedStoryText.value.length > 260)
 const visibleStoryText = computed(() => {
@@ -636,58 +647,61 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   <span class="preview-state-tag preview-state-tag-done">已生成</span>
                 </div>
 
-                <a
-                  v-if="isImageAsset(assetRefPath(entry.item.selected_asset_ref))"
-                  class="selected-open-link"
-                  :href="toAssetHref(assetRefPath(entry.item.selected_asset_ref), entry.sceneId)"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  查看原图
-                </a>
+                <!-- Inline narration — sits in the right column next
+                     to the image. Capped at 2 lines via CSS line-clamp
+                     so the card height stays stable. Most narrations
+                     fit in 1-2 lines naturally; only truly long ones
+                     (> 100 chars, rare) show "详情" inline to open the
+                     full text in a modal. The eyebrow label gives the
+                     paragraph context so the floating sentence reads as
+                     "this scene's narration", not loose body text. -->
+                <p
+                  v-if="sceneNarrationMap?.[entry.sceneId]"
+                  class="narration-inline-text"
+                ><span class="narration-eyebrow">画面内容 ·</span>{{ sceneNarrationMap[entry.sceneId] }}<button
+                    v-if="(sceneNarrationMap[entry.sceneId] || '').length > 100"
+                    type="button"
+                    class="narration-detail-link"
+                    @click="narrationModalSceneId = entry.sceneId"
+                  >详情</button></p>
 
-                <button
-                  type="button"
-                  class="enhance-scene-button"
-                  :disabled="loading || selectingSceneId === entry.sceneId"
-                  :title="'用 Cinematic 档重新生成更高质量候选'"
-                  @click="onEnhanceScene(entry.sceneId)"
-                >
-                  ✦ 增强画质
-                </button>
-                <!-- Manual-mode regenerate. Only useful while the user is
-                     still reviewing — once a final video exists the
-                     candidates are locked (the displayed selection must
-                     match what was baked in). In auto mode the system
-                     renders as soon as candidates are ready, so the
-                     button has no time window to be useful. -->
-                <button
-                  v-if="renderMode === 'manual' && !videoGenerated"
-                  type="button"
-                  class="regen-scene-button"
-                  :disabled="loading || selectingSceneId === entry.sceneId"
-                  :title="'对当前场景画面不满意时，重新生成两张候选图'"
-                  @click="onRetryScene(entry.sceneId)"
-                >
-                  ↻ 重新生成
-                </button>
+                <div class="action-row">
+                  <a
+                    v-if="isImageAsset(assetRefPath(entry.item.selected_asset_ref))"
+                    class="selected-open-link"
+                    :href="toAssetHref(assetRefPath(entry.item.selected_asset_ref), entry.sceneId)"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    ↗ 查看原图
+                  </a>
 
-              </div>
-              <!-- Scene narration spans the FULL card width below the
-                   image + info-panel row. Originally placed inside the
-                   info panel (column 2), it ended up sitting in the
-                   bottom-right with a lot of empty space — the card
-                   looked unbalanced. Spanning both grid columns gives
-                   the narration its own visual band and ties the image
-                   to its description as a single unit. -->
-              <div
-                v-if="sceneNarrationMap?.[entry.sceneId]"
-                class="narration-display-block"
-              >
-                <div class="narration-display-label">画面内容</div>
-                <p class="narration-display-text">
-                  {{ sceneNarrationMap[entry.sceneId] }}
-                </p>
+                  <button
+                    type="button"
+                    class="enhance-scene-button"
+                    :disabled="loading || selectingSceneId === entry.sceneId"
+                    :title="'用 Cinematic 档重新生成更高质量候选'"
+                    @click="onEnhanceScene(entry.sceneId)"
+                  >
+                    ✦ 增强画质
+                  </button>
+                  <!-- Manual-mode regenerate. Only useful while the user is
+                       still reviewing — once a final video exists the
+                       candidates are locked (the displayed selection must
+                       match what was baked in). In auto mode the system
+                       renders as soon as candidates are ready, so the
+                       button has no time window to be useful. -->
+                  <button
+                    v-if="renderMode === 'manual' && !videoGenerated"
+                    type="button"
+                    class="regen-scene-button"
+                    :disabled="loading || selectingSceneId === entry.sceneId"
+                    :title="'对当前场景画面不满意时，重新生成两张候选图'"
+                    @click="onRetryScene(entry.sceneId)"
+                  >
+                    ↻ 重新生成
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -1112,6 +1126,37 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
         </details>
       </article>
     </div>
+
+    <!-- Narration "详情" modal — opens when the user clicks the
+         inline "详情" button on any scene card. Keeps the underlying
+         card height stable: long narrations live in this modal, not
+         in the card itself. Click backdrop or the close button to
+         dismiss; ESC also dismisses via the keyup handler on the
+         backdrop overlay (focus is moved there on open). -->
+    <div
+      v-if="narrationModalSceneId"
+      class="narration-modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      @click.self="narrationModalSceneId = null"
+      @keyup.esc="narrationModalSceneId = null"
+    >
+      <div class="narration-modal-card">
+        <div class="narration-modal-head">
+          <span class="narration-modal-title">画面内容</span>
+          <button
+            type="button"
+            class="narration-modal-close"
+            aria-label="关闭"
+            @click="narrationModalSceneId = null"
+          >
+            ×
+          </button>
+        </div>
+        <p class="narration-modal-body">{{ narrationModalText }}</p>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -1429,6 +1474,14 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   color: var(--text-muted);
 }
 
+/* Pearl (light) theme: the dark-theme `rgba(255,255,255,0.07)` bg is
+   white-at-7% which is invisible against pearl's white surface. Swap
+   to a soft champagne wash matching the page accent system. */
+:root[data-theme="pearl"] .preview-state-tag-waiting {
+  background: rgba(200, 154, 85, 0.08);
+  color: var(--text-muted);
+}
+
 .preview-state-tag-refreshing {
   background: rgba(245,158,11,0.15);
   color: var(--arc-300);
@@ -1439,17 +1492,43 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   color: #f87171;
 }
 
-.selected-open-link {
-  width: fit-content;
-  font-size: 0.75rem;
+/* Three actions on the same row share an explicit pill shape.
+   Using `height` (not `min-height`) + `inline-flex` + `align-items:
+   center` on all three guarantees they render at the EXACT same
+   pixel height regardless of <a> vs <button> intrinsic differences.
+   Individual `margin-top` is dropped — the parent .action-row
+   handles spacing via `gap`. */
+.selected-open-link,
+.enhance-scene-button,
+.regen-scene-button {
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--arc-300);
+  font-family: inherit;
+  line-height: 1;
+  box-sizing: border-box;
+  margin-top: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
   text-decoration: none;
 }
 
+.selected-open-link {
+  border: 1px solid rgba(245, 158, 11, 0.32);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--arc-300);
+}
 .selected-open-link:hover {
-  text-decoration: underline;
+  background: rgba(245, 158, 11, 0.14);
+  border-color: rgba(245, 158, 11, 0.52);
   color: var(--arc-200);
+  text-decoration: none;
 }
 
 .placeholder-status-copy {
@@ -1491,93 +1570,170 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   opacity: 0.55;
 }
 
-.enhance-scene-button {
-  width: fit-content;
-  min-height: 28px;
-  padding: 0 12px;
-  border-radius: 8px;
-  border: 1px solid rgba(249,115,22,0.32);
-  background: rgba(249,115,22,0.10);
-  color: var(--prism-400);
-  font-size: 0.8125rem;
-  font-weight: 600;
-  cursor: pointer;
-  margin-top: 6px;
-  font-family: inherit;
-  transition: background 0.15s, border-color 0.15s;
-}
-
-.enhance-scene-button:hover:not(:disabled) {
-  background: rgba(249,115,22,0.18);
-  border-color: rgba(249,115,22,0.52);
-}
-
-.enhance-scene-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-/* Per-scene regenerate button — manual-mode only. Visually paired with
-   .enhance-scene-button (same row), uses theme accent (--arc-400)
-   instead of the prism orange so the two siblings are
-   distinguishable at a glance: "增强画质" = quality-tier upgrade,
-   "重新生成" = roll the dice again at the same tier. */
+/* All three action buttons (查看原图 / 增强画质 / 重新生成) share the
+   same arc-accent palette. The icon prefix (↗ / ✦ / ↻) carries the
+   semantic difference; color difference would just create visual
+   imbalance — especially with 增强画质 sitting in the middle. */
+.enhance-scene-button,
 .regen-scene-button {
-  width: fit-content;
-  min-height: 28px;
-  padding: 0 12px;
-  border-radius: 8px;
   border: 1px solid rgba(245,158,11,0.32);
   background: rgba(245,158,11,0.10);
   color: var(--arc-300);
-  font-size: 0.8125rem;
-  font-weight: 600;
-  cursor: pointer;
-  margin-top: 6px;
-  font-family: inherit;
-  transition: background 0.15s, border-color 0.15s;
 }
+.enhance-scene-button:hover:not(:disabled),
 .regen-scene-button:hover:not(:disabled) {
   background: rgba(245,158,11,0.18);
   border-color: rgba(245,158,11,0.52);
 }
+.enhance-scene-button:disabled,
+.regen-scene-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+/* Pearl theme overrides — the dark-theme defaults use hardcoded orange
+   rgba backgrounds paired with theme-bound text colors. In pearl the
+   bg renders as pink on white and the prism text becomes ice blue,
+   creating a "warning pill" mismatch. Unify all three buttons to the
+   champagne-gold accent (arc-300) so they read as a single
+   horizontal action group — the icons (↗ / ✦ / ↻) already convey the
+   semantic difference between view / enhance / regenerate without
+   needing a different color for the middle button. */
+:root[data-theme="pearl"] .selected-open-link,
+:root[data-theme="pearl"] .enhance-scene-button,
+:root[data-theme="pearl"] .regen-scene-button {
+  border-color: rgba(200, 154, 85, 0.35);
+  background: rgba(200, 154, 85, 0.10);
+  color: var(--arc-300);
+}
+:root[data-theme="pearl"] .selected-open-link:hover,
+:root[data-theme="pearl"] .enhance-scene-button:hover:not(:disabled),
+:root[data-theme="pearl"] .regen-scene-button:hover:not(:disabled) {
+  background: rgba(200, 154, 85, 0.18);
+  border-color: rgba(200, 154, 85, 0.55);
+}
+
 .regen-scene-button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
 }
 
-/* Scene narration band — spans both grid columns of .preview-card
-   (image + info-panel), so it forms a full-width strip below the
-   image and buttons. This is what the TTS reads aloud for this
-   moment of the story. */
-.narration-display-block {
-  grid-column: 1 / -1;
-  margin-top: 4px;
-  padding: 10px 14px;
-  border-radius: 8px;
-  background: rgba(245, 158, 11, 0.05);
-  border: 1px solid rgba(245, 158, 11, 0.12);
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: 10px;
-}
-.narration-display-label {
-  flex-shrink: 0;
+/* Narration paragraph with inline label prefix. Putting the "画面内容"
+   label as a <span> INSIDE the <p> (not as a separate flex item) means
+   wrapped lines start at the paragraph's left edge — no awkward
+   indent on the second line. The eyebrow inherits the text baseline
+   naturally because it's part of the inline flow. */
+.narration-eyebrow {
+  margin-right: 8px;
   color: var(--text-muted);
   font-size: 0.6875rem;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  vertical-align: baseline;
 }
-.narration-display-text {
-  margin: 0;
+.narration-inline-text {
+  margin: 4px 0 8px;
   color: var(--text-secondary, #c8c8c8);
   font-size: 0.875rem;
-  line-height: 1.6;
+  line-height: 1.65;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
   word-break: break-word;
+}
+.narration-detail-link {
+  display: inline;
+  margin-left: 6px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--arc-300, #fbbf24);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  vertical-align: baseline;
+}
+.narration-detail-link:hover {
+  text-decoration: underline;
+}
+
+/* Buttons row — visually groups 查看原图 + ✦ 增强画质 + ↻ 重新生成
+   into one horizontal action band, separated from the narration above. */
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* Modal that holds the full narration. Independent of card height. */
+.narration-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.narration-modal-card {
+  width: min(560px, 100%);
+  max-height: 70vh;
+  background: var(--surface-elevated, #1a1410);
+  border: 1px solid rgba(245, 158, 11, 0.22);
+  border-radius: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.narration-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(245, 158, 11, 0.12);
+}
+.narration-modal-title {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.narration-modal-close {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-secondary, #c8c8c8);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.narration-modal-close:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+.narration-modal-body {
+  margin: 0;
+  padding: 18px;
+  color: var(--text-primary, #f0e6dc);
+  font-size: 0.9375rem;
+  line-height: 1.7;
   white-space: pre-wrap;
-  flex: 1 1 auto;
+  word-break: break-word;
+  overflow-y: auto;
 }
 
 .candidate-header {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -1557,19 +1557,11 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   max-width: 100%;
 }
 
-/* Section divider between the 当前图 card and the 候选图 grid.
-   Without this the user's eye reads three images in a row (selected
-   + A + B) as if they were three side-by-side candidates. A
-   horizontal hairline + an inline-block "候选图" label gives a
-   clear "section starts here" cue while staying compact. */
 .candidate-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  margin-top: 14px;
-  padding-top: 12px;
-  border-top: 1px dashed rgba(245, 158, 11, 0.18);
 }
 
 .candidate-count {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -672,21 +672,22 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
                   ↻ 重新生成
                 </button>
 
-                <!-- Scene narration (the TTS script for this scene) —
-                     reads in plain language what's happening in this
-                     candidate's moment of the story. Helps the user
-                     judge whether the rendered candidate matches the
-                     intended scene without expanding "开发者信息" or
-                     parsing the structural image-gen prompt. -->
-                <div
-                  v-if="sceneNarrationMap?.[entry.sceneId]"
-                  class="narration-display-block"
-                >
-                  <div class="narration-display-label">画面内容</div>
-                  <p class="narration-display-text">
-                    {{ sceneNarrationMap[entry.sceneId] }}
-                  </p>
-                </div>
+              </div>
+              <!-- Scene narration spans the FULL card width below the
+                   image + info-panel row. Originally placed inside the
+                   info panel (column 2), it ended up sitting in the
+                   bottom-right with a lot of empty space — the card
+                   looked unbalanced. Spanning both grid columns gives
+                   the narration its own visual band and ties the image
+                   to its description as a single unit. -->
+              <div
+                v-if="sceneNarrationMap?.[entry.sceneId]"
+                class="narration-display-block"
+              >
+                <div class="narration-display-label">画面内容</div>
+                <p class="narration-display-text">
+                  {{ sceneNarrationMap[entry.sceneId] }}
+                </p>
               </div>
             </div>
           </div>
@@ -1545,21 +1546,24 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   opacity: 0.55;
 }
 
-/* Scene narration inline display. Sits below the action buttons in
-   the selected-image info panel — gives the user a plain-language
-   summary of what this candidate's scene is about. Narration is
-   typically one to two sentences, so the block stays compact. */
+/* Scene narration band — spans both grid columns of .preview-card
+   (image + info-panel), so it forms a full-width strip below the
+   image and buttons. This is what the TTS reads aloud for this
+   moment of the story. */
 .narration-display-block {
-  margin-top: 10px;
-  padding: 10px 12px;
+  grid-column: 1 / -1;
+  margin-top: 4px;
+  padding: 10px 14px;
   border-radius: 8px;
   background: rgba(245, 158, 11, 0.05);
   border: 1px solid rgba(245, 158, 11, 0.12);
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 10px;
 }
 .narration-display-label {
+  flex-shrink: 0;
   color: var(--text-muted);
   font-size: 0.6875rem;
   font-weight: 700;
@@ -1573,6 +1577,7 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   line-height: 1.6;
   word-break: break-word;
   white-space: pre-wrap;
+  flex: 1 1 auto;
 }
 
 .candidate-header {

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -1557,11 +1557,19 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
   max-width: 100%;
 }
 
+/* Section divider between the 当前图 card and the 候选图 grid.
+   Without this the user's eye reads three images in a row (selected
+   + A + B) as if they were three side-by-side candidates. A
+   horizontal hairline + an inline-block "候选图" label gives a
+   clear "section starts here" cue while staying compact. */
 .candidate-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px dashed rgba(245, 158, 11, 0.18);
 }
 
 .candidate-count {

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -1549,7 +1549,14 @@ select.input {
 
 /* ===== Quick Start / Advanced ===== */
 .quickStart {
-  margin: 6px auto 0;
+  /* `margin: 6px auto 0` was making the block center horizontally,
+     which previously appeared full-width only because the inner grid
+     forced a 360px min-width. After loosening the grid to
+     `minmax(0, 1fr)` to fix the third-button overflow, that crutch
+     vanished and the block collapsed to a centered narrow column.
+     Explicit `width: 100%` makes it fill its parent regardless. */
+  width: 100%;
+  margin-top: 6px;
 }
 
 .quickStartTitle {
@@ -1562,15 +1569,21 @@ select.input {
   text-transform: uppercase;
 }
 
+/* `minmax(120px, 1fr)` forced columns to be AT LEAST 120 px wide.
+   When the panel's container shrinks (narrow side-pane, certain
+   theme padding), 3 × 120 px exceeds the available width and the
+   third column ("角色配音") overflows past the container edge.
+   `minmax(0, 1fr)` lets columns shrink with the container. */
 .quickStartRow {
   display: grid;
-  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
   margin: 0 0 10px;
 }
 
 .chipBtn {
   width: 100%;
+  min-width: 0;
   border: 1px solid var(--border-glass);
   border-radius: 999px;
   padding: 6px 12px;
@@ -1579,6 +1592,8 @@ select.input {
   background: var(--surface-overlay-soft);
   color: var(--text-secondary);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   text-align: center;
   font-family: inherit;
   transition: border-color 0.15s, background 0.15s, color 0.15s;

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -946,6 +946,30 @@ const imageReviewItems = computed(() => {
   return Array.isArray(selectedAssets) ? selectedAssets : []
 })
 
+// Map of scene_id → narration text (the human-readable script TTS reads
+// for this scene). Surfaced in InteractiveImageReview as a per-card
+// description so the user knows what each candidate's scene is ABOUT —
+// far more useful than the structural image-generation prompt, which
+// is hundreds of lines of cast-lock / consistency-rule prompt
+// engineering boilerplate.
+const sceneNarrationMap = computed<Record<string, string>>(() => {
+  const result: Record<string, string> = {}
+  const storyboard = currentWorkflowResponse.value?.outputs?.storyboard as
+    | Record<string, unknown>
+    | undefined
+  const scenes = storyboard?.scenes
+  if (!Array.isArray(scenes)) return result
+  for (const scene of scenes) {
+    if (!scene || typeof scene !== 'object') continue
+    const sceneObj = scene as Record<string, unknown>
+    const sceneId = String(sceneObj.scene_id || '').trim()
+    if (!sceneId) continue
+    const narration = String(sceneObj.narration || '').trim()
+    if (narration) result[sceneId] = narration
+  }
+  return result
+})
+
 
 const hasReviewContent = computed(() => {
   return Boolean(
@@ -2987,6 +3011,7 @@ async function runWorkflow() {
                   :video-generated="Boolean(finalVideoUrl)"
                   :render-mode="workflowForm.renderMode"
                   :scene-image-versions="sceneImageVersions"
+                  :scene-narration-map="sceneNarrationMap"
                   @select-asset="({ sceneId, assetRef }) => selectImageAsset(sceneId, assetRef)"
                   @retry-scene="retryImageReviewScene"
                   @enhance-scene="enhanceImageReviewScene"


### PR DESCRIPTION
## What

Originally opened to surface the per-scene **narration** (the human-readable story moment the TTS reads aloud) on each candidate's "当前图" card in 画面审核. Grew during iteration to include the surrounding UI affordances — unified action buttons, a "详情" modal for long narration, theme polish — so the candidate card finally reads as one cohesive panel.

## 1. Scene narration display

- New \`sceneNarrationMap\` computed in \`StudioView.vue\` — \`{ scene_id → narration }\` derived from \`outputs.storyboard.scenes\`. Passed into \`InteractiveImageReview\` as a new optional prop \`scene-narration-map\`.
- Each candidate card now shows the narration inline in the right info-panel column, prefixed by a "画面内容 ·" eyebrow label.
- The label is rendered as a \`<span>\` INSIDE the \`<p>\` (not a separate flex item) so wrapped lines naturally start at the paragraph's left edge — no indent on the second line.
- Capped at 2 lines via \`-webkit-line-clamp\` so the card height stays stable regardless of narration length.
- For very long narration (> 100 chars, rare), a "详情" button appears inline at the tail of the truncated text. Clicking opens a modal with the full narration — card height never grows.

## 2. Unified action buttons

Originally 增强画质 used the prism palette (orange in dark, ice blue in pearl) while 查看原图 / 重新生成 used arc. That created two issues:
- "Pink-on-white + blue text" looked like a warning pill in pearl theme.
- The middle button was visually emphasized over its neighbors, but it's not the primary action — color difference was over-engineered.

All three buttons are now unified to the same arc-accent pill (light champagne wash + arc-300 text), with the icon prefix carrying the semantic difference: \`↗\` view / \`✦\` enhance / \`↻\` regenerate. 查看原图 also gains the \`↗\` icon for icon-language parity.

A shared selector forces \`height: 32px\` on all three so the \`<a>\` renders at the exact same pixel height as the two \`<button>\`s.

## 3. Pearl theme polish

- \`.preview-state-tag-waiting\` previously used \`rgba(255, 255, 255, 0.07)\` — invisible against pearl's white surface (the "可切换" badge had no background). Added a pearl-only override using a soft champagne wash.
- Action button colors are overridden under \`[data-theme="pearl"]\` to use champagne-gold rather than the hardcoded orange rgba that would otherwise render pink.

## 4. WorkflowRunPanel grid fix

\`快捷模板\` row in 创作故事 used \`grid-template-columns: repeat(3, minmax(120px, 1fr))\`. On narrower containers \`3 × 120 = 360px\` exceeded the parent's width and the third \`角色配音\` button overflowed past the right edge.

- Grid loosened to \`minmax(0, 1fr)\` so columns shrink with the container.
- \`.quickStart\` was relying on the grid's old 360px min-width to fill its parent (it had \`margin: auto\` for centering); after loosening the grid this collapsed the block to a narrow centered column. Replaced with explicit \`width: 100%\` + \`margin-top: 6px\` so the block fills its parent unconditionally.
- \`.chipBtn\` gets \`min-width: 0\` + \`text-overflow: ellipsis\` for safe shrinking.

## What was NOT changed

- Backend: no changes
- Auto-mode flow, state machines, cache-bust: untouched
- The structural image-gen prompt is still accessible in collapsed "开发者信息" for power users
- Dark theme retains its original visual identity (unified arc-only buttons are a small consistency improvement, not a redesign)
- \`.retry-scene-button\` (red, failed-state retry) intentionally KEPT distinct — its color is a genuine semantic warning, not noise

## What was tried and reverted (recorded for honesty)

- Briefly showed \`entry.item.prompt\` (the structural image-gen prompt) — 4000+ chars of cast-lock / consistency-rule boilerplate, useless to end users. Switched to \`narration\`.
- Briefly displayed narration as a full-width band UNDER the image+buttons row — visually heavier than needed once the inline-in-right-column layout was right.
- Briefly tried D-layout (narration as single-line subtitle under scene title with a dashed divider above the candidates) — the dashed line was too subtle, candidates still blended visually with the selected card.
- Briefly differentiated 增强画质 with a blue pearl-theme override — too much per-button color logic for what icons already convey.

## Test plan

- [x] Frontend acceptance check passes
- [ ] Each "当前图" card shows the matching scene's narration prefixed by "画面内容 ·"
- [ ] Narrations > 100 chars show "详情" inline and open the modal on click; card height does not change
- [ ] Three action buttons render at identical pixel height in both dark and pearl themes
- [ ] In pearl theme: no "pink background + blue text" mismatch on action buttons
- [ ] In pearl theme: "可切换" badge has a visible background
- [ ] 创作故事 page: \`角色配音\` button no longer overflows on narrow containers; row layout aligned with 配音模式 / 妈妈配音 widths