### PR TITLE
fix(story): keep-head-keep-tail truncation — preserve narrative ending on overlong LLM output

### DIFF
--- a/app/services/story_retry_policy.py
+++ b/app/services/story_retry_policy.py
@@ -502,33 +502,67 @@ def repair_retry_story_text(
 
     cleaned = "".join(lines).strip()
 
-    # If it is still too long, keep complete sentences up to the target max.
+    # Length-based truncation policy.
+    #
+    # Previous policy: any story exceeding target_max was sentence-trimmed
+    # from the BEGINNING — append sentences until the next one would
+    # overshoot, then drop everything after. That destroyed the story's
+    # ending (climax + resolution), producing the "戛然而止" failure
+    # users reported on 5–15% of generations.
+    #
+    # New policy:
+    #   1) Below `hard_threshold` (= duration × 5 chars/sec × 1.5): do NOT
+    #      truncate. The TTS global speedup pass (capped at 1.5×) is
+    #      enough to bring the audio back to target duration without
+    #      cutting any narrative content. The story's complete arc is
+    #      preserved.
+    #   2) Above `hard_threshold`: even maxed-out TTS speedup can't
+    #      compress the audio to target — we have to drop some content.
+    #      Drop the MIDDLE (~15% of sentences) rather than the ENDING,
+    #      so the surviving arc still reads as setup → (compressed
+    #      development) → climax → resolution.
     target_max = int(story_plan.get("target_max_chars") or 0)
     target_min = int(story_plan.get("target_min_chars") or 0)
     target_chars = int(story_plan.get("target_chars") or 0)
+    duration_sec = int(story_plan.get("duration_sec") or 0)
 
-    if target_max > 0 and runner._story_text_char_count(cleaned) > target_max:
-        sentences = re.split(r"(?<=[。！？!?])", cleaned)
-        selected = []
-        for sentence in sentences:
-            item = sentence.strip()
-            if not item:
-                continue
-            candidate = "".join(selected) + item
-            if runner._story_text_char_count(candidate) > target_max:
-                break
-            selected.append(item)
+    # 5.0 chars/sec is the calibrated Chinese TTS rate (see runner_story_text
+    # comments). 1.5× matches the global speedup cap so we only truncate
+    # when speedup alone won't recover the target duration.
+    hard_threshold_chars = int(duration_sec * 5.0 * 1.5) if duration_sec > 0 else 0
+    current_char_count = runner._story_text_char_count(cleaned)
 
-        repaired = "".join(selected).strip()
+    if hard_threshold_chars > 0 and current_char_count > hard_threshold_chars:
+        sentences = [
+            item.strip()
+            for item in re.split(r"(?<=[。！？!?])", cleaned)
+            if item.strip()
+        ]
 
-        # If sentence trimming made it too short, keep a tighter character slice
-        # and close it with a warm ending.
-        if runner._story_text_char_count(repaired) < max(0, target_min - 10):
-            repaired = cleaned[: max(target_min, target_chars)].rstrip("，、；：")
-            if not repaired.endswith(("。", "！", "？")):
-                repaired += "。"
+        # Keep-head-keep-tail only meaningfully helps when there are
+        # enough sentences to drop a middle slice without collapsing the
+        # narrative. With < 5 sentences we accept the overshoot — the
+        # user can regenerate if needed.
+        if len(sentences) >= 5:
+            head_count = max(1, int(len(sentences) * 0.50))
+            tail_count = max(1, int(len(sentences) * 0.35))
 
-        cleaned = repaired
+            # If head + tail covers (or exceeds) the full list there's
+            # no middle to drop. Skip and accept the overshoot.
+            if head_count + tail_count < len(sentences):
+                kept_sentences = sentences[:head_count] + sentences[-tail_count:]
+                repaired = "".join(kept_sentences).strip()
+
+                # Defensive: ensure the surviving last sentence has
+                # terminating punctuation. The re.split lookbehind
+                # preserves punctuation in each sentence, but a
+                # corrupted last sentence could still lack it.
+                if repaired and repaired[-1] not in "。！？!?":
+                    repaired += "。"
+
+                cleaned = repaired
+    # Silence "unused" complaints for variables retained for future tuning.
+    _ = (target_max, target_min, target_chars)
 
     ending_markers = [
         "明白",


### PR DESCRIPTION
## Problem

When the LLM produces a story exceeding \`target_max_chars\` for the chosen duration preset (60s / 120s / 180s), \`repair_retry_story_text\` truncates it by sentence-trimming from the beginning:

\`\`\`python
# OLD
selected = []
for sentence in sentences:
    candidate = "".join(selected) + sentence
    if char_count(candidate) > target_max:
        break  # ← drops everything after this point
    selected.append(sentence)
\`\`\`

Result: the climax and resolution are dropped, the story ends mid-arc, and users see "戛然而止" endings on 5–15% of generations. The cliché "心里暖暖的，明白勇敢尝试就会带来美好的收获。" fallback that fired afterward was related (and was already toned down in a previous fix), but the root issue was the loss of the LLM's own ending.

## Approach

**Two-tier policy keyed on a duration-derived hard threshold:**

\`\`\`
hard_threshold_chars = duration_sec × 5.0 × 1.5
\`\`\`

(5 chars/sec = calibrated Chinese TTS rate; 1.5× = the global TTS speedup cap.)

| Story chars | Old | New |
|---|---|---|
| \`<= hard_threshold\` | Truncated (砍尾) | **Pass through** — TTS speedup brings audio to target |
| \`> hard_threshold\` | Truncated (砍尾) | **Keep-head-keep-tail** — drop middle ~15% of sentences |

Concrete numbers:

| Preset | LLM chars | Action | Audio after speedup |
|---|---|---|---|
| 60s | 280 (target) | pass | ~56s |
| 60s | 400 | pass | 80s → 1.33× → **60s ✓** |
| 120s | 960 (typical LLM) | keep-head-tail to ~810 | 162s → 1.35× → **120s ✓** |
| 180s | 1400 | keep-head-tail to ~1190 | 238s → 1.32× → **180s ✓** |
| 60s | 1000 (extreme) | keep-head-tail to ~850 | 170s → 1.5× cap → 113s (53s over) |

Typical cases land exactly on target. Only extreme LLM overshoot (> 2× target) sees duration drift, and the user can regenerate if needed.

## Safeguards

- Only triggers above \`hard_threshold\` — most generations pass through untouched
- Requires \`>= 5\` sentences before dropping anything (too few = collapsing the narrative)
- Defensive punctuation check on the surviving last sentence

## No fallback to old "trim from end"

If keep-head-keep-tail produces a result still over \`hard_threshold\`, we accept the overshoot instead of falling back to 砍尾. Falling back would re-introduce the exact bug this fix exists to remove.

## What's NOT changed

- Other story-repair stages (whitespace cleanup, blocked tokens, warm-ending append for mid-sentence truncations)
- TTS / image / video / state-machine logic
- The original \`story_retry_policy\`'s LLM compression retry — that still fires earlier in the pipeline (\`evaluate_story_retry_mode\`) and asks the LLM to compress when too_long is detected. This change only governs what happens if the compressed output is STILL too long.

## Risk

LOW. Single file, ~25 lines, localized to one branch of one function. Single \`git revert\` undoes everything if needed.

## Test plan

- [x] py_compile passes
- [x] Mental scenarios across 60s / 120s / 180s presets (see table above)
- [ ] Generate a 120s story; verify ending is complete (no abrupt cut)
- [ ] Generate a 60s story where LLM tends to overshoot; verify ending survives
- [ ] Verify no regression on already-short stories (pass-through path)