### PR TITLE
fix(tts): the actual voice fix — empty schema default + render robustness + cleanup

### DIFF
--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -119,13 +119,18 @@ class WorkflowInput(BaseModel):
     voice_style: str = Field(default="warm_female")
     voiceover_enabled: bool = Field(default=False)
     voice_mode: str = Field(default="single")
-    speaker_profiles: Dict[str, str] = Field(
-        default_factory=lambda: {
-            "narrator": "warm_female",
-            "mother": "warm_female",
-            "child": "gentle_child",
-        }
-    )
+    # Empty default — the previous default `{"narrator": "warm_female", ...}`
+    # silently overrode `voice_style` for single-narrator mode (which does
+    # NOT send speaker_profiles from the frontend). Pydantic filled in
+    # the default, runtime code then did
+    #   profiles.get("narrator", ctx.input.voice_style)
+    # and "narrator" was ALWAYS present (from the default), so the
+    # user-picked voice_style fallback never ran. Net effect: selecting
+    # 温暖男声 in the UI silently rendered as warm_female.
+    #
+    # In multi/character voice modes the frontend explicitly sends
+    # speaker_profiles, so this empty default has no effect there.
+    speaker_profiles: Dict[str, str] = Field(default_factory=dict)
     character_speaker_profiles: Dict[str, str] = Field(
         default_factory=dict,
         description=(

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -647,18 +647,15 @@ class WorkflowRunner:
         style_key = voice_style.strip().upper()
         style_specific = os.getenv(f"TTS_VOICE_STYLE_{style_key}", "").strip()
         if style_specific:
-            print(f"[TTS-voice-resolve] speaker={speaker!r} voice_style={voice_style!r} → style hit: {style_specific}")
             return style_specific
 
         speaker_key = speaker.strip().upper()
         speaker_specific = os.getenv(f"TTS_VOICE_{speaker_key}", "").strip()
         if speaker_specific:
-            print(f"[TTS-voice-resolve] speaker={speaker!r} voice_style={voice_style!r} → speaker hit: {speaker_specific}")
             return speaker_specific
 
         default_voice = os.getenv("TTS_VOICE", "").strip()
         if default_voice:
-            print(f"[TTS-voice-resolve] speaker={speaker!r} voice_style={voice_style!r} → default hit: {default_voice}")
             return default_voice
 
         raise RuntimeError("TTS_VOICE is missing")

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -1114,27 +1114,38 @@ class RunnerAudioRenderSupport:
             if actual_audio_duration > 0:
                 total_duration_sec = max(total_duration_sec, actual_audio_duration) + 0.2
 
-        if has_audio and merged_audio_path:
-            escaped_subtitle_path = (
-                str(subtitle_path)
-                .replace("\\", "\\\\")
-                .replace(":", "\\:")
-                .replace("'", "\\'")
-            )
+        # Subtitle file may be missing (silent or skipped subtitles). The
+        # `-vf subtitles=...` filter fails hard when the .srt path
+        # doesn't exist on disk → ffmpeg exits 254 → render endpoint
+        # returns 500. The no-audio branch below already guards on this;
+        # the audio branch must do the same.
+        subtitle_available = (
+            subtitle_path.exists() and subtitle_path.stat().st_size > 0
+        )
 
-            subtitle_filter = f"subtitles='{escaped_subtitle_path}'"
-            subprocess.run(
+        if has_audio and merged_audio_path:
+            ffmpeg_cmd = [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(base_video_path),
+                "-i",
+                str(merged_audio_path),
+                "-t",
+                f"{total_duration_sec:.3f}",
+            ]
+            if subtitle_available:
+                escaped_subtitle_path = (
+                    str(subtitle_path)
+                    .replace("\\", "\\\\")
+                    .replace(":", "\\:")
+                    .replace("'", "\\'")
+                )
+                ffmpeg_cmd.extend(["-vf", f"subtitles='{escaped_subtitle_path}'"])
+            else:
+                print("[final-video] subtitle file missing or empty, skip subtitles (audio branch)")
+            ffmpeg_cmd.extend(
                 [
-                    "ffmpeg",
-                    "-y",
-                    "-i",
-                    str(base_video_path),
-                    "-i",
-                    str(merged_audio_path),
-                    "-t",
-                    f"{total_duration_sec:.3f}",
-                    "-vf",
-                    subtitle_filter,
                     "-c:v",
                     "libx264",
                     "-pix_fmt",
@@ -1143,9 +1154,9 @@ class RunnerAudioRenderSupport:
                     "aac",
                     "-shortest",
                     str(final_video_path),
-                ],
-                check=True,
+                ]
             )
+            subprocess.run(ffmpeg_cmd, check=True)
         else:
             # 如果字幕文件不存在或为空，就不要加字幕滤镜
             if subtitle_path.exists() and subtitle_path.stat().st_size > 0:


### PR DESCRIPTION
## What's in this PR

The three commits PR #132 should have had. PR #132 merged only the first commit (the \`_tts_voice_for\` priority swap), which **was necessary but not sufficient** — the user still heard the female default when picking 温暖男声. Investigation traced the bug down to a deeper layer.

## 1. Real root cause: schema default overrode user voice

\`app/schemas/workflow.py\`:

\`\`\`python
# OLD
speaker_profiles: Dict[str, str] = Field(
    default_factory=lambda: {"narrator": "warm_female", ...}
)
# NEW
speaker_profiles: Dict[str, str] = Field(default_factory=dict)
\`\`\`

Single-narrator mode does NOT send \`speaker_profiles\` from the frontend (only \`voice_style\`). Pydantic filled the default, so \`speaker_profiles["narrator"]\` was ALWAYS present as "warm_female". Downstream \`profiles.get("narrator", ctx.input.voice_style)\` then never fell back to \`voice_style\` — the user's UI pick was silently overridden.

PR #132's \`_tts_voice_for\` priority swap was upstream of this lookup, so it ran fine but \`voice_style\` had already been replaced by the time it got there.

## 2. Render robustness: skip subtitle filter when .srt is missing

\`app/services/runner_audio_render_support.py\`:

The audio branch of the final render unconditionally added \`-vf subtitles=...\` even if the .srt file didn't exist on disk → ffmpeg exit 254 → render endpoint 500. The no-audio branch already guarded on \`subtitle_path.exists()\`. This PR aligns the audio branch with the same guard.

Triggered by the user hitting "生成视频" in a flow where the subtitle wasn't on disk. Unrelated to the voice fix but folded in here because the 500 blocked all render testing.

## 3. Cleanup: drop diagnostic print from PR #132

The \`[TTS-voice-resolve]\` print added as a diagnostic during the PR #132 debugging landed in dev via the squash-merge. Now that routing is confirmed working, drop the noise.

## Why this isn't on the original PR #132 branch

PR #132 was already merged when the deeper schema bug was found. The followup commits (schema fix, subtitle fix, debug-print cleanup) accumulated on the same branch but the PR was closed. Opening a fresh PR off latest dev is cleaner than reopening the merged one.

## Risk

LOW.
- Schema change: makes a default empty — only affects the single-narrator path that was already broken; multi/character modes explicitly send the field so they're unaffected.
- Subtitle guard: pure defensive check, matches existing logic on the parallel branch.
- Print cleanup: removes 3 lines, no behavior change.

## Test plan

- [x] py_compile passes for all three files
- [ ] UI: select 温暖男声 in single mode → 开始创作 → audio is alex (male)
- [ ] UI: select 温柔女声 → audio is anna (female) — verifies the fallback to voice_style works both directions
- [ ] UI: trigger a render flow that previously 500'd on missing subtitle → completes successfully