### PR TITLE
ux(studio): bidirectional sync between 字幕生成 step and 启用字幕 checkbox

### DIFF
--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -256,6 +256,24 @@ function updateVoiceMode(value: string) {
   })
 }
 
+// Toggle the "启用字幕" checkbox in 配音与字幕 panel — also mirror the
+// change into the 字幕生成 step entry in 工作流步骤 panel so the two
+// stay in lock-step (paired with updateSelectedStep's reverse mirror).
+function onToggleSubtitleEnabled(checked: boolean) {
+  emit('update:formState', {
+    ...props.formState,
+    subtitleEnabled: checked,
+  })
+
+  const current = [...props.selectedSteps]
+  const has = current.includes('subtitles')
+  if (checked && !has) {
+    emit('update:selectedSteps', [...current, 'subtitles'])
+  } else if (!checked && has) {
+    emit('update:selectedSteps', current.filter((s) => s !== 'subtitles'))
+  }
+}
+
 function updateSelectedStep(step: StepName, checked: boolean) {
   const current = [...props.selectedSteps]
 
@@ -263,13 +281,25 @@ function updateSelectedStep(step: StepName, checked: boolean) {
     if (!current.includes(step)) {
       emit('update:selectedSteps', [...current, step])
     }
-    return
+  } else {
+    emit('update:selectedSteps', current.filter((item) => item !== step))
   }
 
-  emit(
-    'update:selectedSteps',
-    current.filter((item) => item !== step)
-  )
+  // Bidirectional sync: the "字幕生成" step in the 工作流步骤 panel and
+  // the "启用字幕" checkbox in the 配音与字幕 panel both express the
+  // same intent (do we want subtitles in the final video?) but live
+  // in different panels, which has historically confused users into
+  // ticking only one of them and wondering why subtitles don't show.
+  // When the user toggles the 字幕生成 step we mirror the change into
+  // formState.subtitleEnabled so both checkboxes reflect a single
+  // underlying decision. The reverse direction (启用字幕 → step
+  // selection) is already handled at submission time in runWorkflow.
+  if (step === 'subtitles') {
+    emit('update:formState', {
+      ...props.formState,
+      subtitleEnabled: checked,
+    })
+  }
 }
 
 function applyPresetSingle() {
@@ -880,12 +910,7 @@ function getTopicManualMismatchWarning(): string {
           <input
             :checked="formState.subtitleEnabled"
             type="checkbox"
-            @change="
-              updateFormState(
-                'subtitleEnabled',
-                ($event.target as HTMLInputElement).checked
-              )
-            "
+            @change="onToggleSubtitleEnabled(($event.target as HTMLInputElement).checked)"
           />
           <span>启用字幕</span>
         </label>


### PR DESCRIPTION
## Problem

Two checkboxes in different panels both control whether subtitles end up in the final video:
- **字幕生成** in the 工作流步骤 panel (controls whether the subtitle pipeline step runs)
- **启用字幕** in the 配音与字幕 panel (controls \`subtitle_enabled\` field in the payload)

Users repeatedly checked one and not the other, then wondered why their video had no subtitles — most recently mid-debug-session confusion over a video that came out subtitle-less even though "字幕生成" was clearly ticked. The 启用字幕 checkbox sits below the fold in 配音与字幕 and is easy to miss; the 字幕生成 step name reads like the obvious subtitle toggle.

## Fix

Bidirectional sync so both checkboxes always reflect the same underlying intent:

- Toggling **字幕生成** step (\`updateSelectedStep('subtitles', checked)\`) → also writes \`formState.subtitleEnabled = checked\`
- Toggling **启用字幕** checkbox (\`onToggleSubtitleEnabled(checked)\`) → also writes \`selectedSteps\` array (add/remove 'subtitles')

Either user action now expresses the full intent. Both checkboxes stay visually in sync.

## What was NOT changed

- Schema, backend \`run_subtitles()\` logic, payload shape — no data-flow changes.
- Submission-time fallback (\`if form.subtitleEnabled: stepsSet.add('subtitles')\`) kept as a defensive belt-and-suspenders.
- Quick-mode presets — they already set \`subtitleEnabled: true\`, so no regression there.

## Risk

Very low. Touches one function in one file (~15 lines added/changed). No backend, no schema, no other UI.

## Test plan

- [x] Frontend acceptance check passes
- [ ] Untick 字幕生成 step → 启用字幕 also unticks
- [ ] Re-tick 字幕生成 step → 启用字幕 also ticks
- [ ] Untick 启用字幕 checkbox → 字幕生成 step also unticks
- [ ] Re-tick 启用字幕 checkbox → 字幕生成 step also ticks
- [ ] Submit a workflow with the box ticked → final video has subtitles