### PR TITLE
ux(studio): 旁白配音 is the single source of truth; 配音风格 hidden as dead UI

### DIFF
--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -858,13 +858,16 @@ function getTopicManualMismatchWarning(): string {
           <span class="characterHintText">角色配音将根据角色列表分配声线</span>
         </div>
 
-        <!-- "配音风格" only takes effect in single-narrator mode. In
-             multi and character modes the actual voice assignment is
-             driven by per-speaker dropdowns / character preset values,
-             and this field's value is never read by the backend audio
-             render path — leaving it visible misleads users into
-             thinking it controls 妈妈/宝宝/角色 voices when it doesn't. -->
-        <label v-if="formState.voiceMode === 'single'" class="field">
+        <!-- "配音风格" dropdown is intentionally hidden everywhere:
+             - multi / character modes: voice routes through per-speaker
+               dropdowns / character preset values, voice_style is
+               never read
+             - single mode: voice now routes through speaker_profiles
+               .narrator (driven by the 旁白配音 dropdown above), so
+               voice_style is dead here too
+             The voice_style form field is still sent in the payload
+             for backward compatibility, but is not user-controllable. -->
+        <label v-if="false" class="field">
           <span>配音风格</span>
           <ThemedSelect
             :model-value="formState.voiceStyle"

--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -858,7 +858,13 @@ function getTopicManualMismatchWarning(): string {
           <span class="characterHintText">角色配音将根据角色列表分配声线</span>
         </div>
 
-        <label class="field">
+        <!-- "配音风格" only takes effect in single-narrator mode. In
+             multi and character modes the actual voice assignment is
+             driven by per-speaker dropdowns / character preset values,
+             and this field's value is never read by the backend audio
+             render path — leaving it visible misleads users into
+             thinking it controls 妈妈/宝宝/角色 voices when it doesn't. -->
+        <label v-if="formState.voiceMode === 'single'" class="field">
           <span>配音风格</span>
           <ThemedSelect
             :model-value="formState.voiceStyle"

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2727,6 +2727,20 @@ async function runWorkflow() {
     quality_tier: form.qualityTier || 'quality',
   }
 
+  // Single-narrator mode: send `speaker_profiles.narrator` derived from
+  // the "旁白配音" dropdown so the user's pick controls the narrator
+  // voice. Previously only `voice_style` (the now-hidden "配音风格"
+  // dropdown) reached the backend in single mode, making the "旁白配音"
+  // dropdown a no-op — users picked 温暖男声 there and heard 温柔女声
+  // because the backend's `speaker_profiles.narrator` was filling in
+  // from `voice_style` (or its schema default before #133). Now
+  // 旁白配音 is the single source of truth for single-mode narration.
+  if (form.voiceMode === 'single') {
+    inputPayload.speaker_profiles = {
+      narrator: form.narratorVoiceStyle,
+    }
+  }
+
   if (form.voiceMode === 'multi') {
     inputPayload.speaker_profiles = {
       narrator: form.narratorVoiceStyle,


### PR DESCRIPTION
## What

Consolidates the narrator-voice control into a single dropdown (**旁白配音** in 配音与字幕 panel) and retires **配音风格** as dead UI. Two coupled changes:

### Change 1: Send \`speaker_profiles.narrator\` in single mode

\`frontend/src/views/StudioView.vue\`:

\`\`\`js
if (form.voiceMode === 'single') {
  inputPayload.speaker_profiles = {
    narrator: form.narratorVoiceStyle,  // ← now wired
  }
}
\`\`\`

Previously \`speaker_profiles\` was only sent in multi / character modes, so the 旁白配音 dropdown had **no effect** in single mode. The only thing reaching the backend was \`voice_style\` (from 配音风格), which the backend used as a fallback to fill in \`speaker_profiles.narrator\`.

Now 旁白配音 is the single source of truth for single-mode narration.

### Change 2: Hide 配音风格 dropdown in all modes

\`frontend/src/components/WorkflowRunPanel.vue\`:

| Mode | What controls narrator voice |
|---|---|
| single | **旁白配音** (newly wired) — 配音风格 hidden |
| multi | 妈妈配音 + 宝宝配音 (per-speaker) — 配音风格 was already dead, now hidden |
| character | character preset values + 旁白配音 — 配音风格 was already dead, now hidden |

\`voice_style\` field still exists in form state and ships in the payload for backward compatibility, but it's no longer user-controllable from the UI.

## Why

Two dropdowns appeared to control the same thing in single mode, but only **配音风格** worked while **旁白配音** was a no-op — user picked 温暖男声 in 旁白配音, heard the default female voice, was understandably confused. The fix routes the narrator voice through the more semantically named dropdown.

## Backend

No backend changes needed. \`_speaker_profiles()\` (\`runner_voice_support.py\`) was already correctly reading from \`ctx.input.speaker_profiles\`. The empty-default schema (from #133) lets the new \`speaker_profiles\` value flow through cleanly.

## Risk

Low.
- 单 file frontend payload change + 1 file UI \`v-if\` change.
- Backend behavior identical when frontend sends the new field (verified via \`speaker_profiles.get('narrator', fallback)\`).
- \`voice_style\` field still shipped → any consumer that reads it (logs / debugging / future code) sees the same default value.

## Test plan

- [x] Frontend acceptance check passes
- [ ] Single mode: pick 旁白配音 = 温暖男声 → workflow plays male voice (alex)
- [ ] Single mode: pick 旁白配音 = 温柔女声 → plays female voice (claire / anna)
- [ ] Multi mode: 妈妈/宝宝 voices unchanged
- [ ] Character mode: preset-driven voices unchanged
- [ ] 配音风格 dropdown not visible in any voice mode