### PR TITLE
feat(studio): per-role voice dropdowns in character mode

### DIFF
--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -182,6 +182,15 @@ const CHILD_VOICE_OPTS: EnumOption[] = [
   { value: 'bright_child', label: '活泼童声' },
   { value: 'soft_child',   label: '温柔童声' },
 ]
+/* Character mode lets the user assign voices to 主角 / 配角 / 旁白
+   independently. Both characters (typically two animals/people) can be
+   any voice type; the dropdown therefore exposes the three values that
+   have explicit TTS_VOICE_STYLE_* mappings in .env. */
+const CHARACTER_VOICE_OPTS: EnumOption[] = [
+  { value: 'warm_female',  label: '温柔女声' },
+  { value: 'warm_male',    label: '温暖男声' },
+  { value: 'gentle_child', label: '儿童声线' },
+]
 
 function withFallback(opts: EnumOption[], current: string): EnumOption[] {
   if (!current || opts.some((o) => o.value === current)) return opts
@@ -853,10 +862,41 @@ function getTopicManualMismatchWarning(): string {
           </label>
         </template>
 
-        <div v-if="formState.voiceMode === 'character'" class="field-wide characterHint">
-          <span class="characterHintIcon">🎭</span>
-          <span class="characterHintText">角色配音将根据角色列表分配声线</span>
-        </div>
+        <!-- Character mode: per-role voice dropdowns. The form fields
+             are reused from multi mode (childVoiceStyle / motherVoiceStyle
+             / narratorVoiceStyle) — see runWorkflow() in StudioView.vue
+             which maps them to character_speaker_profiles.main_character /
+             secondary_character / narrator respectively. The labels here
+             reflect the character semantics, not the underlying field
+             names, so the dropdowns read naturally in the UI. -->
+        <template v-if="formState.voiceMode === 'character'">
+          <label class="field">
+            <span>主角声音</span>
+            <ThemedSelect
+              :model-value="formState.childVoiceStyle"
+              :options="withFallback(CHARACTER_VOICE_OPTS, formState.childVoiceStyle)"
+              @update:model-value="(v: string) => updateFormState('childVoiceStyle', v)"
+            />
+          </label>
+
+          <label class="field">
+            <span>配角声音</span>
+            <ThemedSelect
+              :model-value="formState.motherVoiceStyle"
+              :options="withFallback(CHARACTER_VOICE_OPTS, formState.motherVoiceStyle)"
+              @update:model-value="(v: string) => updateFormState('motherVoiceStyle', v)"
+            />
+          </label>
+
+          <label class="field">
+            <span>旁白声音</span>
+            <ThemedSelect
+              :model-value="formState.narratorVoiceStyle"
+              :options="withFallback(CHARACTER_VOICE_OPTS, formState.narratorVoiceStyle)"
+              @update:model-value="(v: string) => updateFormState('narratorVoiceStyle', v)"
+            />
+          </label>
+        </template>
 
         <label class="field">
           <span>配音风格</span>


### PR DESCRIPTION
## What

Adds three voice dropdowns to character mode (角色配音):

- **主角声音** — controls the main character's voice (兔子 in the user's recent test)
- **配角声音** — controls the secondary character's voice (乌龟)
- **旁白声音** — controls the narrator's voice

Replaces the previous static hint "角色配音将根据角色列表分配声线" which left users no visible way to configure character voices.

## Why

Character mode silently sourced voices from multi-mode form fields (\`childVoiceStyle\`, \`motherVoiceStyle\`, \`narratorVoiceStyle\`), which were only settable via the "角色配音" preset button. Users had no idea how to change individual character voices, and the recent question "选了温暖男声为什么兔子和乌龟都没变" surfaced this gap.

## Implementation

- New \`CHARACTER_VOICE_OPTS\` constant exposing the three voice styles that have explicit \`TTS_VOICE_STYLE_*\` mappings in \`.env\` (温柔女声 / 温暖男声 / 儿童声线) — guarantees every selection resolves to a real voice.
- Three labeled dropdowns inside the character-mode block in \`WorkflowRunPanel.vue\`. Each binds to an existing form field; labels reflect character semantics, field names are unchanged.

## What's NOT changed

- **Form field names** stay as \`childVoiceStyle\` / \`motherVoiceStyle\` / \`narratorVoiceStyle\`. Renaming to \`mainCharacterVoiceStyle\` / \`secondaryCharacterVoiceStyle\` would touch every preset + the StudioView payload mapping + localStorage migration — that's a cosmetic refactor for another PR.
- **Backend payload shape** — character_speaker_profiles still has the same three keys; the new dropdowns just let the user populate them directly instead of via preset defaults.
- **Voice resolution code path** in \`runner_voice_support.py\` — unchanged.

## Risk

LOW. Three new dropdowns bound to fields that already existed and already flowed end-to-end via presets. Test surface: visual rendering + dropdown change events.

## Test plan

- [x] Frontend acceptance check passes
- [ ] Switch to 角色配音 mode → three dropdowns appear (主角 / 配角 / 旁白声音)
- [ ] Change 主角声音 to 温暖男声 → run a workflow → main character speaks male
- [ ] Change 配角声音 to 温柔女声 → secondary character speaks female
- [ ] Change 旁白声音 to 儿童声线 → narrator is child voice
- [ ] Switch back to single / multi modes → respective dropdowns unchanged