### PR TITLE
ux(studio): make 角色设置 panel collapsible (default closed)

### DIFF
--- a/frontend/src/components/WorkflowRunPanel.vue
+++ b/frontend/src/components/WorkflowRunPanel.vue
@@ -83,9 +83,10 @@ function formatElapsedLabel(seconds: number): string {
 }
 
 // Local-only collapse state — does NOT affect payload, just UI grouping.
-const voiceCollapsed  = ref(true)   // 配音与字幕 — default collapsed for clean first paint
-const renderCollapsed = ref(true)   // 渲染与输出 — advanced settings, default collapsed
-const stepsCollapsed  = ref(true)   // Workflow Steps — engineering view, default collapsed
+const voiceCollapsed     = ref(true)   // 配音与字幕 — default collapsed for clean first paint
+const renderCollapsed    = ref(true)   // 渲染与输出 — advanced settings, default collapsed
+const stepsCollapsed     = ref(true)   // Workflow Steps — engineering view, default collapsed
+const characterCollapsed = ref(true)   // 角色设置 — only shown in character mode, default collapsed
 
 /* ─────────────────────────────────────────────────────────────
    Display-only enum option lists.
@@ -967,8 +968,35 @@ function getTopicManualMismatchWarning(): string {
       </div>
     </section>
 
-    <section v-if="formState.voiceMode === 'character'" class="config-panel">
-      <h2 class="section-title">角色设置</h2>
+    <!-- ═══════════ 角色设置 (collapsible, default closed) ═══════════
+         Only rendered in character voice mode. Wrapped in the same
+         collapsible pattern as 渲染与输出 / 配音与字幕 / 工作流步骤 so
+         the panel doesn't dominate the page just because the user
+         happened to leave voiceMode='character' in localStorage from
+         a previous session. -->
+    <section
+      v-if="formState.voiceMode === 'character'"
+      class="config-panel collapse-section"
+    >
+      <button
+        type="button"
+        class="collapse-head"
+        :aria-expanded="!characterCollapsed"
+        @click="characterCollapsed = !characterCollapsed"
+      >
+        <span class="collapse-title-block">
+          <span class="collapse-title">角色设置</span>
+          <span class="collapse-desc">主角 / 配角名称与外观特征</span>
+        </span>
+        <svg
+          :class="['collapse-chevron', { 'is-open': !characterCollapsed }]"
+          width="12" height="8" viewBox="0 0 12 8" fill="none"
+        >
+          <path d="M1 1 L6 6 L11 1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+
+      <div v-show="!characterCollapsed" class="collapse-body">
 
       <label class="checkbox-field">
         <input
@@ -1109,6 +1137,7 @@ function getTopicManualMismatchWarning(): string {
           />
         </label>
       </div>
+      </div>  <!-- /collapse-body -->
     </section>
 
     <!-- ═══════════ Workflow Steps (collapsible, default closed) ═══════════ -->


### PR DESCRIPTION
## Problem

The "角色设置" panel was an always-expanded \`<section>\` that took over the create-story page whenever \`voiceMode='character'\` was persisted in localStorage. Users who landed on the page after a previous character-mode session saw a wall of character config fields (主角名称 / 主角物种 / 主角外观特征 / 主角禁用特征 / 配角名称 / ...) on every paint, even when they were just trying to write a new story topic.

## Fix

Wrap the section in the same \`collapse-section\` / \`collapse-head\` / \`collapse-body\` pattern already used by **渲染与输出**, **配音与字幕**, and **工作流步骤**.

- New ref \`characterCollapsed\` (default \`true\`) parallel to \`voiceCollapsed\` / \`renderCollapsed\` / \`stepsCollapsed\`
- Header shows "角色设置 — 主角 / 配角名称与外观特征" with the same chevron
- Body folds behind \`v-show="!characterCollapsed"\`
- The \`v-if="formState.voiceMode === 'character'"\` gate on the outer \`<section>\` stays — the panel is still completely hidden when not in character mode

## What's NOT changed

- No content, no field bindings, no payload changes
- \`structuredCharactersEnabled\`, character display name / species / traits — all wired identically
- Backend untouched

## Risk

Trivial. Pure visual folding using a pattern that already exists 3 times in the same file.

## Test plan

- [x] Frontend acceptance check passes
- [ ] First paint in character mode: 角色设置 header visible, body collapsed
- [ ] Click header → body expands; click again → collapses
- [ ] Switch voiceMode to single / multi → section disappears entirely (existing \`v-if\` still works)
- [ ] Switch back to character mode → header reappears, body collapsed by default