### PR TITLE
fix(studio): block other UI while single-scene retry is in flight

### DIFF
--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2897,11 +2897,11 @@ async function runWorkflow() {
     <div class="studio-tab-content">
     <section v-if="activeTab === 'run'" class="studio-home-grid">
       <StudioCreatePanel
-        :loading="loading || refreshingImageReview || finalVideoRenderInFlight || awaitingManualRender"
+        :loading="loading || refreshingImageReview || finalVideoRenderInFlight || awaitingManualRender || Boolean(sceneRefreshingId)"
         :cancel-requested="cancelRequestedAny"
       >
         <WorkflowRunPanel
-          :loading="loading || refreshingImageReview || finalVideoRenderInFlight || awaitingManualRender"
+          :loading="loading || refreshingImageReview || finalVideoRenderInFlight || awaitingManualRender || Boolean(sceneRefreshingId)"
           :can-submit="canSubmit"
           :error-message="errorMessage"
           :form-state="workflowForm"
@@ -2962,7 +2962,7 @@ async function runWorkflow() {
                 :final-video-text="finalVideoText"
                 :workflow-response="currentWorkflowResponse"
                 :render-in-flight="finalVideoRenderInFlight"
-                :loading="workflowIsProcessing || refreshingImageReview || finalVideoRenderInFlight"
+                :loading="workflowIsProcessing || refreshingImageReview || finalVideoRenderInFlight || Boolean(sceneRefreshingId)"
                 :refreshing-images="refreshingImageReview"
                 :cancel-requested="cancelRequested"
                 :paused-by-user="imageRefreshPausedByUser"
@@ -3015,7 +3015,7 @@ async function runWorkflow() {
                   :story-text="storyText"
                   :placeholders="reviewPlaceholders"
                   :api-base-url="apiBaseUrl"
-                  :loading="loading || refreshingImageReview"
+                  :loading="loading || refreshingImageReview || Boolean(sceneRefreshingId)"
                   :selecting-scene-id="selectingSceneId || sceneRefreshingId"
                   :progress-text="cancelRequested ? cancellingLabel : reviewRefreshProgress.text"
                   :progress-percent="reviewRefreshProgress.percent"


### PR DESCRIPTION
## Problem

When the user clicks **增强画质** or **重新生成** on a scene in 画面审核 (\`sceneRefreshingId\` set), only that scene's row shows the busy state. The rest of the page stays interactive:

- Other scenes' 重新生成 / 增强画质 / 候选切换 buttons → clickable, can fire a second refresh while the first is in flight
- Final video panel's 生成视频 button → still works, will render against a half-refreshed image set
- 创作故事 form's 开始创作 button → clickable, can stomp \`run_id\` of the in-flight retry

User-visible symptom: state goes funny, in-flight regeneration silently drops on the floor, the partly-generated scene gets stuck without a status.

## Fix

Four \`:loading\` prop bindings in \`StudioView.vue\` already block their respective surfaces for the bulk-refresh case (\`refreshingImageReview\`). Single-scene retry needs the same treatment — add \`Boolean(sceneRefreshingId)\` to all four:

\`\`\`vue
<StudioCreatePanel
  :loading="... || awaitingManualRender || Boolean(sceneRefreshingId)"
/>
<WorkflowRunPanel
  :loading="... || awaitingManualRender || Boolean(sceneRefreshingId)"
/>
<FinalVideoPanel
  :loading="... || finalVideoRenderInFlight || Boolean(sceneRefreshingId)"
/>
<InteractiveImageReview
  :loading="loading || refreshingImageReview || Boolean(sceneRefreshingId)"
/>
\`\`\`

That's it — no new state machinery, no new computeds. Just plumbing the existing single-scene flag through the existing disabled-state computeds that already handle the bulk-refresh case correctly.

## Why this is safe

- \`sceneRefreshingId\` already drives status / progress copy on the top bar and FinalVideoPanel (PR #128). This PR just extends the same flag to the \`loading\` / \`disabled\` machinery.
- Existing children already know how to render their disabled state from \`loading\` — no child changes needed.
- \`refreshingImageReview\` (the bulk-refresh case) was always blocking these surfaces correctly. We're just making the per-scene case behave the same way.

## What's NOT changed

- No backend changes
- No new state, no new computeds
- Auto-mode flow, schema, payload, etc. all untouched

## Risk

Trivial. 4 line changes, single file. The 4 surfaces already have a battle-tested disabled state; we're just toggling it for one more flag.

## Test plan

- [x] Frontend acceptance check passes
- [ ] Click 重新生成 on scene_04 → all OTHER scenes' buttons (查看原图 / 增强画质 / 重新生成 / candidate-select) disabled
- [ ] During the retry, 生成视频 button on final-video panel is disabled
- [ ] During the retry, 创作故事 tab's 开始创作 button is disabled
- [ ] When retry completes, everything re-enables
- [ ] Existing bulk-refresh disable behavior unchanged