### PR TITLE
feat(images): 增强画质 preserves seed — same image, just better; 重新生成 still re-rolls

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -458,6 +458,7 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
             character_manifest=req.character_manifest,
             image_prompts=req.image_prompts,
             video_provider=req.video_provider,
+            preserve_seed=req.preserve_seed,
         )
         print("[image-review] refresh-scene completed", req.run_id, req.scene_id)
 

--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -271,6 +271,13 @@ class ImageReviewRefreshSceneRequest(BaseModel):
     character_manifest: Dict[str, Any] = Field(default_factory=dict)
     image_prompts: Dict[str, Any] = Field(default_factory=dict)
     video_provider: str = Field(default="mock")
+    # When True, the diffusion seed used by this refresh matches the
+    # seed that produced the candidate currently on disk — same
+    # composition, no time-based jitter. Combined with a higher
+    # quality_tier this becomes "enhance the same image". When False
+    # (default), a fresh time-based seed_jitter is mixed in so the
+    # output is a visibly different roll.
+    preserve_seed: bool = Field(default=False)
 
 
 class ImageReviewRefreshSceneResponse(BaseModel):

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1422,12 +1422,14 @@ class WorkflowRunner:
         outputs: Dict[str, Any],
         scene: Dict[str, Any],
         scene_index: int,
+        preserve_seed: bool = False,
     ) -> Dict[str, Any]:
         return self._single_scene_image_support.run_single_scene_image_asset(
             ctx=ctx,
             outputs=outputs,
             scene=scene,
             scene_index=scene_index,
+            preserve_seed=preserve_seed,
         )
 
     def _apply_manual_image_selection(

--- a/app/services/runner_image_review.py
+++ b/app/services/runner_image_review.py
@@ -410,6 +410,7 @@ class RunnerImageReviewSupport:
         character_manifest: Dict[str, Any] | None = None,
         image_prompts: Dict[str, Any] | None = None,
         video_provider: str = "mock",
+        preserve_seed: bool = False,
     ) -> Dict[str, Any]:
         runner = self._runner
 
@@ -480,6 +481,7 @@ class RunnerImageReviewSupport:
             outputs=outputs,
             scene=target_scene,
             scene_index=scene_index_by_id.get(normalized_scene_id, 1),
+            preserve_seed=preserve_seed,
         )
         outputs["image_assets"] = single_scene_assets
 

--- a/app/services/runner_single_scene_image_support.py
+++ b/app/services/runner_single_scene_image_support.py
@@ -213,6 +213,7 @@ class RunnerSingleSceneImageSupport:
         outputs: Dict[str, Any],
         scene: Dict[str, Any],
         scene_index: int,
+        preserve_seed: bool = False,
     ) -> Dict[str, Any]:
         runner = self._runner
         prompt_by_scene_id, _ = runner._image_prompt_item_maps(outputs)
@@ -274,7 +275,18 @@ class RunnerSingleSceneImageSupport:
                 # Without this, (run_id, scene_index) is the same on every
                 # retry → same seed → byte-identical image → user sees no
                 # change after clicking "重新生成".
-                seed_jitter = time.time_ns() % 10_000_000_000 + candidate_index * 7919
+                #
+                # `preserve_seed=True` (used by 增强画质) deliberately
+                # SKIPS the time-based jitter so the diffusion seed
+                # matches what produced the candidate on disk → same
+                # composition, only the higher quality_tier (Cinematic)
+                # changes the rendered detail. That's the difference
+                # between "enhance the same image" and "re-roll":
+                # 增强画质 keeps the picture, 重新生成 rolls fresh.
+                if preserve_seed:
+                    seed_jitter = candidate_index * 7919
+                else:
+                    seed_jitter = time.time_ns() % 10_000_000_000 + candidate_index * 7919
                 task = ImageGenerationTask(
                     run_id=ctx.run_id,
                     item_id=scene_id,
@@ -422,6 +434,7 @@ class RunnerSingleSceneImageSupport:
         outputs: Dict[str, Any],
         scene: Dict[str, Any],
         scene_index: int,
+        preserve_seed: bool = False,
     ) -> Dict[str, Any]:
         provider = self._runner._image_provider_name()
 
@@ -447,6 +460,7 @@ class RunnerSingleSceneImageSupport:
                     outputs=outputs,
                     scene=scene,
                     scene_index=scene_index,
+                    preserve_seed=preserve_seed,
                 )
                 return {
                     "enabled": True,

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -1952,7 +1952,7 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
   }
 }
 
-async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qualityTierOverride?: string) {
+async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qualityTierOverride?: string, preserveSeed: boolean = false) {
   if (!currentWorkflowResponse.value || !currentWorkflowPayload.value) {
     return
   }
@@ -1992,6 +1992,7 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
       typeof currentWorkflowPayload.value.input?.video_provider === 'string'
         ? currentWorkflowPayload.value.input.video_provider
         : workflowForm.value.videoProvider,
+    preserve_seed: preserveSeed,
   }
 
   let response: Response
@@ -2100,7 +2101,7 @@ async function enhanceImageReviewScene(sceneId: string) {
   imageReviewRefreshAbortController = new AbortController()
 
   try {
-    await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal, 'cinematic')
+    await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal, 'cinematic', true)
     if (workflowForm.value.renderMode === 'auto' && currentWorkflowResponse.value) {
       void renderFinalVideoIfReady(currentWorkflowResponse.value)
     }


### PR DESCRIPTION
## Problem

\`增强画质\` and \`重新生成\` were functionally identical:
- Both routed through \`refreshImageReviewScene\`
- Both unconditionally generated a fresh \`seed_jitter = time.time_ns()\`
- The only real difference was \`quality_tier=cinematic\` vs default — but composition was completely different in both cases

Users reasonably asked "isn't 增强画质 supposed to enhance THIS image, not give me a different one?"

## Fix

End-to-end \`preserve_seed\` flag:

| Button | seed_jitter | quality_tier | Result |
|---|---|---|---|
| **增强画质** | \`candidate_index × 7919\` (matches original seed) | \`cinematic\` | Same composition, higher render detail |
| **重新生成** | \`time.time_ns() + candidate_index × 7919\` (fresh) | default | New composition |

## Files touched

- \`app/schemas/workflow.py\` — \`ImageReviewRefreshSceneRequest.preserve_seed: bool = False\`
- \`app/main.py\` — forward to runner
- \`app/services/runner.py\` — forward to image-review support
- \`app/services/runner_image_review.py\` — forward to single-scene support
- \`app/services/runner_single_scene_image_support.py\` — drop time component from \`seed_jitter\` when \`preserve_seed=True\`
- \`frontend/src/views/StudioView.vue\` — \`refreshImageReviewScene\` gains \`preserveSeed\` param; \`enhanceImageReviewScene\` passes \`true\`

## Backward compatibility

- Schema default is \`False\` so any caller that hasn't been updated still gets the prior fresh-seed behavior
- Initial workflow path is unaffected (it doesn't go through refresh-scene)
- Auto-mode flow unaffected
- 重新生成 button still does exactly what it did before

## Risk

Low. The Kolors seed math is a single addition; the preserve_seed branch just zeroes the time component. Test surface: the two buttons producing semantically distinct outputs.

## Test plan

- [x] py_compile passes for all changed Python files
- [x] Frontend acceptance check passes
- [ ] Initial workflow generates a candidate
- [ ] Click 增强画质 → new candidate has very similar composition, sharper details
- [ ] Click 重新生成 → new candidate has clearly different composition
- [ ] Run multiple 增强画质 in a row → outputs should be similar to each other (same seed)
- [ ] Run multiple 重新生成 in a row → each output should be different (fresh jitter each time)