### PR TITLE
chore(frontend): gitignore .vite/ dep pre-bundle cache

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- Add `.vite` to `frontend/.gitignore`.
- Vite regenerates `frontend/.vite/deps/` (ESM pre-bundle cache, keyed off lockfile hash) on every dev start, so `_metadata.json` + `package.json` kept showing up as untracked. Build artifact — never commit.

## Test plan
- [ ] `git status` after `npm run dev` shows no `.vite/` entries.