### PR TITLE
ux(landing): align bottom CTA bar to the workflow/cases content rail

### DIFF
--- a/frontend/src/components/landing/LandingPage.vue
+++ b/frontend/src/components/landing/LandingPage.vue
@@ -1882,7 +1882,12 @@ function starStyle(i: number) {
 }
 .foot-content {
   position: relative;
-  max-width: 780px;
+  /* Widened from 780 → 1040 so the CTA bar aligns with the case grid
+     (1080) and workflow rail above. Removes the previous "sudden narrow
+     band" jump that broke the page's vertical rhythm — now all three
+     below-hero sections terminate at roughly the same invisible vertical
+     edges. */
+  max-width: 1040px;
   margin: 0 auto;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Problem
The bottom CTA "开始创作你的故事视频" was capped at `max-width: 780px` while workflow rail (~1020px) and case grid (1080px) above used the full section width. Reading top-down, the CTA suddenly narrowed by ~150px each side and looked like a detached footer clip — breaking the page's vertical rhythm.

## Change
- `.foot-content` max-width: `780px → 1040px`

All three below-hero sections now terminate at roughly the same invisible vertical edge. Hero stays full-bleed by design — the storybook art needs the horizontal real-estate; below-hero content reads denser/more premium when aligned to one rail.

## Test plan
- [ ] Visit landing page on desktop (>1100px) — workflow / case grid / CTA bar share the same left+right alignment line.
- [ ] CTA copy left + "进入 Studio" button right still have comfortable internal padding (no squeeze).
- [ ] On tablet (<640px) CTA still collapses to centered stack via existing media query.