### PR TITLE
fix(workflow): decouple structured-character payload from voice mode

### DIFF
--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2726,31 +2726,39 @@ async function runWorkflow() {
     }
   }
 
+  // Voice-mode-specific: only character mode needs per-character voice
+  // assignments. This payload is genuinely voice-domain.
   if (form.voiceMode === 'character') {
     inputPayload.character_speaker_profiles = {
       narrator: form.narratorVoiceStyle,
       main_character: form.childVoiceStyle,
       secondary_character: form.motherVoiceStyle,
     }
+  }
 
-    inputPayload.structured_characters_enabled = enableStructuredCharacters
+  // Character-identity payload — flows in EVERY voice mode. Previously
+  // these fields were nested inside the `voiceMode === 'character'`
+  // block, which coupled "who the character is" with "how each character
+  // is voiced". Wrong: character identity (species, name, visual traits)
+  // governs story generation + image-prompt anchoring regardless of
+  // voice configuration. A single-voice narrator can still tell a story
+  // about 波波 the 小海豹 with the structured visual lock attached.
+  if (enableStructuredCharacters) {
+    inputPayload.structured_characters_enabled = true
+    inputPayload.characters = finalCharacters
+  }
 
-    if (enableStructuredCharacters) {
-      inputPayload.characters = finalCharacters
-    }
+  if (mainCharacterDisplay || mainCharacterSpecies) {
+    inputPayload.main_character = mainCharacterSpecies || mainCharacterDisplay
+    inputPayload.main_character_display = mainCharacterDisplay
+    inputPayload.main_character_species = mainCharacterSpecies
+  }
 
-    if (mainCharacterDisplay || mainCharacterSpecies) {
-      inputPayload.main_character = mainCharacterSpecies || mainCharacterDisplay
-      inputPayload.main_character_display = mainCharacterDisplay
-      inputPayload.main_character_species = mainCharacterSpecies
-    }
-
-    if (secondaryCharacterDisplay || secondaryCharacterSpecies) {
-      inputPayload.secondary_character =
-        secondaryCharacterSpecies || secondaryCharacterDisplay
-      inputPayload.secondary_character_display = secondaryCharacterDisplay
-      inputPayload.secondary_character_species = secondaryCharacterSpecies
-    }
+  if (secondaryCharacterDisplay || secondaryCharacterSpecies) {
+    inputPayload.secondary_character =
+      secondaryCharacterSpecies || secondaryCharacterDisplay
+    inputPayload.secondary_character_display = secondaryCharacterDisplay
+    inputPayload.secondary_character_species = secondaryCharacterSpecies
   }
 
   const stepsSet = new Set(selectedSteps.value)

--- a/scripts/acceptance_voice_mode_payload.js
+++ b/scripts/acceptance_voice_mode_payload.js
@@ -170,12 +170,29 @@ function main() {
   }
   ok('App.vue: character-mode block does not assign inputPayload.speaker_profiles')
 
+  // Structured characters payload MUST NOT be coupled to voice mode.
+  // The character-mode brace block carries voice-domain concerns only
+  // (character_speaker_profiles); identity-domain fields (structured
+  // characters, main_character_*, secondary_character_*) flow in every
+  // voice mode so a single-narrator story about a structured character
+  // still gets the visual identity lock at story + image-prompt layer.
+  if (/structured_characters_enabled/.test(characterBlock)) {
+    fail(
+      'App.vue: structured_characters_enabled is assigned inside the character-mode block. ' +
+        'It must live in the top-level payload assembly so identity flows in single / multi modes too.',
+    )
+  }
+  ok('App.vue: structured_characters_enabled is not coupled to character voice mode')
+
+  // It still has to be wired SOMEWHERE — the top-level assembly should
+  // gate it on enableStructuredCharacters (the derived flag from the
+  // structured-character form section), not on voiceMode.
   mustInclude(
-    characterBlock,
-    'inputPayload.structured_characters_enabled = enableStructuredCharacters',
-    'Expected structured characters toggle to be wired in character mode.',
+    appVue,
+    'inputPayload.structured_characters_enabled = true',
+    'Expected structured_characters_enabled to be assigned at top-level payload assembly (gated by enableStructuredCharacters).',
   )
-  ok('App.vue: structured_characters_enabled wired in character mode')
+  ok('App.vue: structured_characters_enabled wired at top-level payload assembly')
 
   // ------------------------------------------------------------
   // WorkflowRunPanel.vue mode switching invariants


### PR DESCRIPTION
## Problem

`structured_characters_enabled` + `characters` + `main_character_*` + `secondary_character_*` were all nested inside the `voiceMode === 'character'` branch. With the default `voiceMode = 'single'`, the structured character payload was silently dropped — even when the user filled out 角色形象 explicitly, or applied a preset from the Inspiration tab.

Direct user impact: clicking 波波·小海豹 in Inspiration would set:
```
primaryCharacterDisplayName: '波波'
primaryCharacterSpecies: '小海豹'
primaryCharacterVisualTraits: '银灰色光滑皮肤、圆圆胖胖、圆圆大眼睛...'
primaryCharacterForbiddenTraits: '不要尖牙、不要瘦削、不要黑色'
```
…but the backend never saw any of it. It just topic-infer'd `海豹` keyword and used the generic English fallback (`cute baby seal, round face, big eyes, smooth gray fur, short flippers`). The rich preset description was wasted.

## Fix

Two concerns are now correctly separated:

| Field | Domain | New gating |
|---|---|---|
| `character_speaker_profiles` | Voice (per-character TTS assignment) | Still gated by `voiceMode === 'character'` ✓ |
| `structured_characters_enabled` + `characters` | Identity (story + image anchor) | Now flows in every voice mode ✓ |
| `main_character` / `main_character_display` / `main_character_species` | Identity | Now flows in every voice mode ✓ |
| `secondary_character_*` | Identity | Now flows in every voice mode ✓ |

## Scope honesty

This narrows species-level identity loss for the *single-character* case. Multi-character image-gen contamination (rabbit with turtle shell, missing secondary character, etc.) is a separate ceiling at the image-gen layer — not fixed here. See README "已知问题" §2 and `docs/post_refactor_todo.md` BUG-004/005/006.

## Test plan

- [ ] Open Studio, leave voiceMode as 'single' (default), click 波波·小海豹 from Inspiration → apply → submit. Check the network payload: `characters` array + `main_character_species = '小海豹'` + visual_traits with my rich Chinese description should now be present.
- [ ] voiceMode='character' still works (no regression — the speaker_profiles payload remains gated correctly).
- [ ] voiceMode='multi' (the third mode) still works.
- [ ] Generated story image prompts for 波波 should include 银灰色 / 圆圆胖胖 / 礁石间 instead of only the generic English seal description.