### PR TITLE
feat(studio): structured dev panel + audio panel relocation + inspiration polish

### DIFF
--- a/frontend/src/components/InspirationLibraryPanel.vue
+++ b/frontend/src/components/InspirationLibraryPanel.vue
@@ -60,6 +60,29 @@ function ctaLabel(kind: InspirationKind): string {
 function padIndex(n: number): string {
   return String(n + 1).padStart(2, '0')
 }
+
+/* Spotlight cursor effect — writes the live mouse position (relative
+   to the card) into two CSS custom properties on the card itself.
+   The CSS uses them as the centre of a radial gradient overlay so
+   the card appears "lit" by a soft gold glow that follows the
+   cursor. Linear / Vercel landing-page signature move. */
+function onCardMouseMove(event: MouseEvent) {
+  const el = event.currentTarget as HTMLElement | null
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  const x = ((event.clientX - rect.left) / rect.width) * 100
+  const y = ((event.clientY - rect.top) / rect.height) * 100
+  el.style.setProperty('--spot-x', `${x}%`)
+  el.style.setProperty('--spot-y', `${y}%`)
+  // Fade the spotlight in on first move so the card doesn't pop on
+  // re-entry; CSS handles the actual transition.
+  el.style.setProperty('--spot-opacity', '1')
+}
+function onCardMouseLeave(event: MouseEvent) {
+  const el = event.currentTarget as HTMLElement | null
+  if (!el) return
+  el.style.setProperty('--spot-opacity', '0')
+}
 </script>
 
 <template>
@@ -119,9 +142,12 @@ function padIndex(n: number): string {
             :key="item.id"
             class="inspiration-card"
             tabindex="0"
+            :style="{ '--card-stagger': `${index * 60}ms` }"
             @click="openDetail(item)"
             @keydown.enter="openDetail(item)"
             @keydown.space.prevent="openDetail(item)"
+            @mousemove="onCardMouseMove($event)"
+            @mouseleave="onCardMouseLeave($event)"
           >
             <div class="card-head">
               <span class="card-eyebrow">
@@ -470,7 +496,16 @@ function padIndex(n: number): string {
 
 /* Card — text-led. Uses theme tokens so dark + pearl both work. The
    value sold by the card is the *preview rows*, not a decorative
-   cover, so the surface stays calm and lets typography lead. */
+   cover, so the surface stays calm and lets typography lead.
+   ── Two interaction polishes layered on top ──
+   1. Stagger entrance: each card fades + lifts in 60ms after the
+      previous one, driven by the inline `--card-stagger` style set
+      in the template (v-for index × 60). Single-shot animation;
+      doesn't re-fire on filter switch.
+   2. Spotlight cursor: a radial gold gradient pseudo-element follows
+      the mouse, centred on the live --spot-x / --spot-y the script
+      writes on mousemove. Reads as a soft "card under a torch"
+      effect — premium without being noisy. */
 .inspiration-card {
   position: relative;
   display: flex;
@@ -482,11 +517,64 @@ function padIndex(n: number): string {
     linear-gradient(180deg, var(--surface-overlay-soft), transparent 70%),
     var(--bg-elevated);
   cursor: pointer;
+  overflow: hidden;
   transition:
     transform 0.2s ease,
     border-color 0.2s ease,
     background 0.2s ease,
     box-shadow 0.2s ease;
+  /* Local custom props with defaults — keeps the CSS valid even when
+     the mousemove handler hasn't fired yet (i.e. before the cursor
+     enters the card). */
+  --spot-x: 50%;
+  --spot-y: 50%;
+  --spot-opacity: 0;
+  --card-stagger: 0ms;
+  animation: card-enter 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  animation-delay: var(--card-stagger);
+}
+/* Spotlight overlay — sits above the card surface but below the
+   content (z-index 0 on this layer, content is z-index auto/1).
+   Opacity is driven from JS via --spot-opacity so hover state
+   doesn't flicker on tiny mouse moves outside the card. */
+.inspiration-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    280px circle at var(--spot-x) var(--spot-y),
+    color-mix(in srgb, var(--arc-300) 22%, transparent) 0%,
+    transparent 60%
+  );
+  opacity: var(--spot-opacity);
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 0;
+}
+/* Content stacks above the spotlight overlay. */
+.inspiration-card > * {
+  position: relative;
+  z-index: 1;
+}
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+/* Respect reduced-motion users — skip stagger + spotlight transition. */
+@media (prefers-reduced-motion: reduce) {
+  .inspiration-card {
+    animation: none;
+  }
+  .inspiration-card::after {
+    transition: none;
+  }
 }
 /* Thin gold accent line at top — same design language as landing-page
    eyebrows. Adapts to both themes via the arc token. */

--- a/frontend/src/components/WorkflowResultsPanel.vue
+++ b/frontend/src/components/WorkflowResultsPanel.vue
@@ -45,6 +45,46 @@ function stringifyValue(value: unknown): string {
   }
 }
 
+/* Split a Kolors prompt string on its native separator (`; ` then `;`
+   then `. `) so the wall-of-text becomes a scannable list. The pieces
+   themselves are kept verbatim — the prompt sent to the model is
+   still the original concatenated string; this is display-only.
+   Filters out blanks introduced by trailing separators. */
+function splitPromptFragments(prompt: string): string[] {
+  if (!prompt) return []
+  return prompt
+    .split(/[;。](?:\s+|$)/g)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+/* Classify a fragment so different rule families get different visual
+   weight. Negative constraints (must-avoid / do-not) get a softer
+   warning tint; identity / role descriptors get a gold accent so the
+   "who's this about" lines stand out. */
+function promptFragmentClass(fragment: string): string {
+  const f = fragment.toLowerCase()
+  if (
+    f.startsWith('must avoid') ||
+    f.startsWith('do not') ||
+    f.includes('forbidden') ||
+    f.includes('不要')
+  ) {
+    return 'prompt-fragment--avoid'
+  }
+  if (
+    f.startsWith('must keep') ||
+    f.startsWith('character ') ||
+    f.startsWith('required ') ||
+    f.includes('identity lock') ||
+    f.includes('身份锁') ||
+    f.includes('character trait lock')
+  ) {
+    return 'prompt-fragment--anchor'
+  }
+  return ''
+}
+
 const hasDeveloperContent = computed(() => Boolean(
   props.storyboardText ||
   props.imagePromptsText ||
@@ -128,7 +168,13 @@ const imagePromptEntries = computed<PromptSummary[]>(() => {
       <section v-if="storyboardText" class="developer-result-block">
         <details>
           <summary class="developer-subsummary">分镜结构</summary>
+          <p class="developer-explainer">
+            把整个故事按场景拆解的结构化结果。每个场景包含场景标题、画面描述、镜头类型、转场方式、出场角色等元信息——后续画面 prompt 的生成依据。
+          </p>
           <div v-if="storyboardScenes.length" class="scene-summary-list">
+            <p class="developer-count-line">
+              本次共生成 <strong>{{ storyboardScenes.length }}</strong> 个场景：
+            </p>
             <article
               v-for="scene in storyboardScenes"
               :key="scene.id"
@@ -139,84 +185,135 @@ const imagePromptEntries = computed<PromptSummary[]>(() => {
               <p v-if="scene.description">{{ scene.description }}</p>
             </article>
           </div>
-          <p v-else class="developer-empty-copy">
-            分镜结构已生成，可在开发者原始数据中查看完整 JSON。
-          </p>
+          <!-- Same raw-JSON pattern as the sibling sections below.
+               Sits at the bottom of every section so every node of the
+               pipeline reads the same way: 这是什么 → 这是数据. -->
+          <pre class="light-result">{{ storyboardText }}</pre>
         </details>
       </section>
 
       <section v-if="imagePromptsText" class="developer-result-block">
         <details>
           <summary class="developer-subsummary">图片提示词</summary>
+          <p class="developer-explainer">
+            送给文生图模型（如 Kolors）的实际 prompt 文本，按场景一一对应。
+            包含主体描述、视觉风格、角色身份锁、负面词等约束——决定每张候选图的样子。
+          </p>
           <div v-if="imagePromptEntries.length" class="prompt-summary-list">
+            <p class="developer-count-line">
+              本次共生成 <strong>{{ imagePromptEntries.length }}</strong> 条 prompt，点击展开查看：
+            </p>
             <details
               v-for="entry in imagePromptEntries"
               :key="entry.id"
               class="prompt-summary-item"
             >
               <summary>{{ entry.id }}</summary>
-              <p>{{ entry.prompt }}</p>
+              <!-- Wall-of-text prompts (single line broken only by ';
+                   ') are unreadable for a human even though they're
+                   what Kolors wants. Split on the same separator and
+                   render each rule on its own indented line —
+                   semantics preserved (it's still the exact same
+                   string concatenated by ';'), but scannable. -->
+              <ul class="prompt-fragment-list">
+                <li
+                  v-for="(fragment, idx) in splitPromptFragments(entry.prompt)"
+                  :key="idx"
+                  class="prompt-fragment"
+                  :class="promptFragmentClass(fragment)"
+                >{{ fragment }}</li>
+              </ul>
             </details>
           </div>
-          <p v-else class="developer-empty-copy">
-            图片提示词已生成，可在开发者原始数据中查看完整 JSON。
-          </p>
+          <pre class="light-result">{{ imagePromptsText }}</pre>
         </details>
       </section>
 
-      <section class="developer-result-block">
+      <!-- Pipeline-order siblings under 生成细节. Each is a self-
+           contained section: title + one-line explainer + raw JSON.
+           Same structure as 分镜结构/图片提示词 above (those just have
+           an extra parsed view between explainer and raw), so the
+           hierarchy reads as one consistent list of "workflow output
+           nodes" instead of split into two awkward groups. -->
+
+      <section v-if="characterCandidatesText" class="developer-result-block">
         <details>
-          <summary class="developer-subsummary">开发者原始数据</summary>
+          <summary class="developer-subsummary">角色候选</summary>
+          <p class="developer-explainer">
+            LLM 从主题文本里抽取出来的候选角色——名称、物种、是否主角。后续会沉淀为正式的「角色设定清单」。
+          </p>
+          <pre class="light-result">{{ characterCandidatesText }}</pre>
+        </details>
+      </section>
 
-          <div v-if="storyboardText" class="raw-data-block">
-            <h2 class="section-title">完整 Storyboard JSON</h2>
-            <pre class="light-result">{{ storyboardText }}</pre>
-          </div>
+      <section v-if="characterManifestText" class="developer-result-block">
+        <details>
+          <summary class="developer-subsummary">角色设定清单</summary>
+          <p class="developer-explainer">
+            每个角色的视觉身份锁——必须保留的外观特征（must_keep）和必须避免的特征（must_avoid）。
+            多角色场景下还携带跨角色的互斥约束（如「兔子不能有龟壳」），用于约束图像 prompt。
+          </p>
+          <pre class="light-result">{{ characterManifestText }}</pre>
+        </details>
+      </section>
 
-          <div v-if="imagePromptsText" class="raw-data-block">
-            <h2 class="section-title">Image Prompts JSON</h2>
-            <pre class="light-result">{{ imagePromptsText }}</pre>
-          </div>
+      <section v-if="imageAssetsText" class="developer-result-block">
+        <details>
+          <summary class="developer-subsummary">图片素材</summary>
+          <p class="developer-explainer">
+            实际生成的候选图元数据——按场景分组，每场景两张 A/B 候选，包含文件路径、provider、是否被选中等信息。
+          </p>
+          <pre class="light-result">{{ imageAssetsText }}</pre>
+        </details>
+      </section>
 
-          <div v-if="imageAssetsText" class="raw-data-block">
-            <h2 class="section-title">图片素材原始数据</h2>
-            <pre class="light-result">{{ imageAssetsText }}</pre>
-          </div>
+      <section v-if="imageReviewText" class="developer-result-block">
+        <details>
+          <summary class="developer-subsummary">画面审核 / 素材选择</summary>
+          <p class="developer-explainer">
+            自动 selector 的打分结果 + 用户手动审核时的最终选择记录——每个场景最终选了 A 还是 B、是 auto 还是 manual。
+          </p>
+          <pre class="light-result">{{ imageReviewText }}</pre>
+        </details>
+      </section>
 
-          <div v-if="imageReviewText" class="raw-data-block">
-            <h2 class="section-title">画面审核 / 素材选择原始数据</h2>
-            <pre class="light-result">{{ imageReviewText }}</pre>
-          </div>
+      <section v-if="narrationText" class="developer-result-block">
+        <details>
+          <summary class="developer-subsummary">旁白</summary>
+          <p class="developer-explainer">
+            送给 TTS 的旁白脚本——含完整文本、按场景切分的段落、每段的说话人和声线设定。
+          </p>
+          <pre class="light-result">{{ narrationText }}</pre>
+        </details>
+      </section>
 
-          <div v-if="videoPromptsText" class="raw-data-block">
-            <h2 class="section-title">视频提示词原始数据</h2>
-            <pre class="light-result">{{ videoPromptsText }}</pre>
-          </div>
+      <section v-if="subtitlesText" class="developer-result-block">
+        <details>
+          <summary class="developer-subsummary">字幕</summary>
+          <p class="developer-explainer">
+            带时间轴的字幕条目——FFmpeg 合成时按这份时间轴把文字烧进视频。
+          </p>
+          <pre class="light-result">{{ subtitlesText }}</pre>
+        </details>
+      </section>
 
-          <div v-if="narrationText" class="raw-data-block">
-            <h2 class="section-title">旁白原始数据</h2>
-            <pre class="light-result">{{ narrationText }}</pre>
-          </div>
+      <section v-if="videoPromptsText" class="developer-result-block">
+        <details>
+          <summary class="developer-subsummary">视频提示词</summary>
+          <p class="developer-explainer">
+            送给分镜视频 provider（如可灵 / 海螺）的 prompt 文本——v1 默认走绘本风，本节点只有在 v2 接入分镜视频 provider 时才会被消费。
+          </p>
+          <pre class="light-result">{{ videoPromptsText }}</pre>
+        </details>
+      </section>
 
-          <div v-if="subtitlesText" class="raw-data-block">
-            <h2 class="section-title">字幕原始数据</h2>
-            <pre class="light-result">{{ subtitlesText }}</pre>
-          </div>
-
-          <div v-if="renderPlanText" class="raw-data-block">
-            <h2 class="section-title">渲染计划原始数据</h2>
-            <pre class="light-result">{{ renderPlanText }}</pre>
-          </div>
-
-          <div v-if="characterCandidatesText" class="raw-data-block">
-            <h2 class="section-title">角色候选原始数据</h2>
-            <pre class="light-result">{{ characterCandidatesText }}</pre>
-          </div>
-
-          <div v-if="characterManifestText" class="raw-data-block">
-            <h2 class="section-title">角色设定清单原始数据</h2>
-            <pre class="light-result">{{ characterManifestText }}</pre>
-          </div>
+      <section v-if="renderPlanText" class="developer-result-block">
+        <details>
+          <summary class="developer-subsummary">渲染计划</summary>
+          <p class="developer-explainer">
+            最终交给 FFmpeg 的合成方案——时间轴、转场、画面与音频的对齐关系。视频成片就是按这份计划渲染出来的。
+          </p>
+          <pre class="light-result">{{ renderPlanText }}</pre>
         </details>
       </section>
     </details>
@@ -252,6 +349,14 @@ const imagePromptEntries = computed<PromptSummary[]>(() => {
   margin-top: 16px;
   padding-top: 14px;
   border-top: 1px solid rgba(245,158,11,0.08);
+  /* Visual containment cue: a thin gold "tree-branch" rail on the
+     left side shows that this block is a *child* of 生成细节, not a
+     sibling. Without it the 3 inner sub-sections (分镜结构 / 图片
+     提示词 / 开发者原始数据) read as same-level entries as 生成
+     细节 itself, breaking the parent-child hierarchy on screen. */
+  margin-left: 14px;
+  padding-left: 16px;
+  border-left: 2px solid color-mix(in srgb, var(--arc-300) 22%, transparent);
 }
 
 .developer-subsummary {
@@ -270,6 +375,14 @@ const imagePromptEntries = computed<PromptSummary[]>(() => {
   display: grid;
   gap: 10px;
   margin-top: 12px;
+  /* Nested children of a sub-section (e.g. scene_01..scene_06 under
+     图片提示词) need to read as deeper-nested than the sub-section
+     itself. The sub-section already has its rail from the outer
+     .developer-result-block; this adds a second smaller indent so
+     the visual hierarchy goes: 生成细节 → 图片提示词 → scene_N. */
+  margin-left: 10px;
+  padding-left: 12px;
+  border-left: 1px solid color-mix(in srgb, var(--arc-300) 14%, transparent);
 }
 
 .scene-summary-card,
@@ -304,6 +417,37 @@ const imagePromptEntries = computed<PromptSummary[]>(() => {
   white-space: pre-wrap;
 }
 
+/* Explainer preamble — sits directly under the section's summary
+   trigger, before any list. Tells the reader WHAT this thing is
+   ("把整个故事按场景拆解的结构化结果...") so the section header
+   alone isn't doing all the explanatory work. Styled as a soft
+   info card, not as ordinary body text, so it reads as "meta /
+   docs" rather than "content". */
+.developer-explainer {
+  margin: 12px 0 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--arc-300) 6%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--arc-300) 38%, transparent);
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  line-height: 1.65;
+}
+
+/* Count line — "本次共生成 X 个场景" between the explainer and the
+   list. Gives the user a "what to expect" preview before they start
+   scrolling. */
+.developer-count-line {
+  margin: 6px 0 8px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+.developer-count-line strong {
+  color: var(--arc-300);
+  font-weight: 700;
+  margin: 0 2px;
+}
+
 .prompt-summary-item summary {
   color: var(--arc-300);
   cursor: pointer;
@@ -315,8 +459,49 @@ const imagePromptEntries = computed<PromptSummary[]>(() => {
   margin-top: 8px;
 }
 
-.raw-data-block {
-  margin-top: 14px;
+/* Structured prompt view — each `;`-separated rule becomes a list
+   item with its own bullet, indent and (when applicable) coloured
+   tint based on classification: gold for identity/role anchors,
+   muted red for "must avoid / do not" negative constraints. Plain
+   rules stay in the default secondary text colour. */
+.prompt-fragment-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.prompt-fragment {
+  position: relative;
+  padding: 4px 0 4px 18px;
+  font-size: 0.8125rem;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  word-break: break-word;
+}
+.prompt-fragment::before {
+  content: '◦';
+  position: absolute;
+  left: 4px;
+  top: 4px;
+  color: color-mix(in srgb, var(--arc-300) 55%, transparent);
+  font-size: 0.75rem;
+}
+.prompt-fragment--anchor {
+  color: color-mix(in srgb, var(--arc-200) 90%, var(--text-primary));
+}
+.prompt-fragment--anchor::before {
+  content: '◆';
+  color: var(--arc-300);
+}
+.prompt-fragment--avoid {
+  color: color-mix(in srgb, #f87171 70%, var(--text-secondary));
+}
+.prompt-fragment--avoid::before {
+  content: '⊘';
+  color: #f87171;
 }
 
 .section-title {
@@ -344,5 +529,31 @@ const imagePromptEntries = computed<PromptSummary[]>(() => {
   line-height: 1.6;
   color: var(--text-secondary);
   font-family: 'SF Mono', 'Fira Code', monospace;
+  /* Cap each raw-JSON dump at ~6 lines worth (was unbounded — a
+     full storyboard JSON could run 15+ screens, making it
+     impossible to scroll back up to collapse the parent <details>).
+     Internal scroll keeps the surrounding layout stable. */
+  max-height: 360px;
+  overflow: auto;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--surface-overlay-soft);
+  border: 1px solid var(--border-subtle);
+}
+/* Custom thin scrollbar so the boxed JSON doesn't feel "trapped" by
+   the OS-default chunky scrollbar at this small surface. */
+.light-result::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+.light-result::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--arc-300) 32%, transparent);
+  border-radius: 3px;
+}
+.light-result::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--arc-300) 56%, transparent);
+}
+.light-result::-webkit-scrollbar-track {
+  background: transparent;
 }
 </style>

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -538,6 +538,7 @@ function performDeleteRecentVideo() {
     userHasInteractedWithImages.value = false
     mockAudioIndexUrl.value = ''
     mockAudioSceneGroups.value = []
+    mockAudioSegmentTextMap.value = {}
     mockAudioDirectoryText.value = ''
     errorMessage.value = ''
 
@@ -578,6 +579,10 @@ const characterManifestText = ref('')
 const mockAudioIndexUrl = ref('')
 const mockAudioSceneGroups = ref<AudioSceneGroup[]>([])
 const mockAudioDirectoryText = ref('')
+// scene_id → ordered list of segment text (parallel to the audio
+// assets array of the same scene). Lets the Review-tab audio panel
+// show "what this segment is saying" next to the player link.
+const mockAudioSegmentTextMap = ref<Record<string, string[]>>({})
 
 const samplesLoading = ref(false)
 const samplesErrorMessage = ref('')
@@ -1075,6 +1080,27 @@ const sceneNarrationMap = computed<Record<string, string>>(() => {
     if (!sceneId) continue
     const narration = String(sceneObj.narration || '').trim()
     if (narration) result[sceneId] = narration
+  }
+  return result
+})
+
+// scene_id → scene_title from the storyboard. Used by the audio panel
+// to show "礁石上的波波" instead of generic "场景 01" — matches the
+// image-review card pattern.
+const sceneTitleMap = computed<Record<string, string>>(() => {
+  const result: Record<string, string> = {}
+  const storyboard = currentWorkflowResponse.value?.outputs?.storyboard as
+    | Record<string, unknown>
+    | undefined
+  const scenes = storyboard?.scenes
+  if (!Array.isArray(scenes)) return result
+  for (const scene of scenes) {
+    if (!scene || typeof scene !== 'object') continue
+    const sceneObj = scene as Record<string, unknown>
+    const sceneId = String(sceneObj.scene_id || '').trim()
+    if (!sceneId) continue
+    const title = String(sceneObj.scene_title || '').trim()
+    if (title) result[sceneId] = title
   }
   return result
 })
@@ -1596,8 +1622,32 @@ function extractMockAudioState(data: WorkflowRunResponse) {
     : []
   mockAudioDirectoryText.value =
     audioOutput?.directory_manifest ? stringifyPretty(audioOutput.directory_manifest) : ''
+
+  // Build a scene_id → array<text> map from narration.segments so the
+  // audio panel can show what each segment is saying. Segments come
+  // back in order per scene, so the i-th audio asset under a scene
+  // maps to the i-th text in that scene's list. The map is recomputed
+  // every workflow apply so stale text from a previous run never
+  // leaks into a fresh take.
+  const narrationOutput = data?.outputs?.narration as
+    | { segments?: Array<{ scene_id?: string; text?: string }> }
+    | undefined
+  const segs = Array.isArray(narrationOutput?.segments)
+    ? narrationOutput?.segments || []
+    : []
+  const map: Record<string, string[]> = {}
+  for (const seg of segs) {
+    const sid = String(seg?.scene_id || '').trim()
+    const text = String(seg?.text || '').trim()
+    if (!sid || !text) continue
+    ;(map[sid] = map[sid] || []).push(text)
+  }
+  mockAudioSegmentTextMap.value = map
 }
 
+// Audio-asset display helpers used by the "配音素材" panel under the
+// Review tab. Kept here (rather than colocated with the component)
+// because the mockAudio* refs they format also live in this file.
 function sceneDisplayName(sceneId?: string): string {
   const value = String(sceneId || '').trim()
   const match = value.match(/(?:scene[-_]?|^)(\d+)/i)
@@ -1616,11 +1666,6 @@ function formatAudioDuration(seconds?: number): string {
     return '时长待确认'
   }
   return `约 ${Math.round(seconds)} 秒`
-}
-
-function audioSpeakerLabel(speaker?: string): string {
-  const value = String(speaker || '').trim()
-  return value ? `配音：${value}` : '配音信息待确认'
 }
 
 function formatPreview(output?: Record<string, unknown>): string {
@@ -2375,6 +2420,7 @@ function performDiscardCurrentDraft() {
   mockAudioIndexUrl.value = ''
   mockAudioSceneGroups.value = []
   mockAudioDirectoryText.value = ''
+  mockAudioSegmentTextMap.value = {}
 
   // Regenerate the session id. The backend's RunnerSessionStore keys
   // its in-memory `previous_session_data` (last_story / last_storyboard /
@@ -2656,6 +2702,7 @@ async function runWorkflow() {
   mockAudioIndexUrl.value = ''
   mockAudioSceneGroups.value = []
   mockAudioDirectoryText.value = ''
+  mockAudioSegmentTextMap.value = {}
   activeTab.value = 'review'
 
   const form = workflowForm.value
@@ -3128,6 +3175,113 @@ async function runWorkflow() {
               :character-candidates-text="characterCandidatesText"
               :character-manifest-text="characterManifestText"
             />
+
+            <!-- 配音素材 — per-scene TTS asset inspection. Lives in
+                 the Review tab because it's "check the output of the
+                 last workflow", same semantic family as the image
+                 review above. (Previously lived under 素材库 / 灵感
+                 参考; that tab's role is now "creation starters",
+                 which doesn't fit a results inspector.) Only renders
+                 when the current workflow actually produced audio
+                 segments — hidden cleanly when not applicable. -->
+            <details
+              v-if="mockAudioIndexUrl || mockAudioSceneGroups.length > 0 || mockAudioDirectoryText"
+              class="glass-card review-audio-card animate-fade-in"
+            >
+              <summary class="review-audio-summary">
+                <span class="review-section-icon" aria-hidden="true">▤</span>
+                <span class="review-section-title">配音素材</span>
+                <span class="review-audio-summary-count">
+                  {{ mockAudioSceneGroups.length }} 个场景 ·
+                  {{ mockAudioSceneGroups.reduce((n, g) => n + ((g.assets || []).length), 0) }} 段音频
+                </span>
+                <span class="review-audio-summary-chevron" aria-hidden="true">▸</span>
+              </summary>
+
+              <div v-if="mockAudioSceneGroups.length > 0" class="review-audio-scenes">
+                <article
+                  v-for="group in mockAudioSceneGroups"
+                  :key="group.scene_id || 'unknown-scene'"
+                  class="review-audio-scene"
+                >
+                  <header class="review-audio-scene-head">
+                    <div class="review-audio-scene-title-block">
+                      <strong>{{ sceneDisplayName(group.scene_id) }}</strong>
+                      <span
+                        v-if="sceneTitleMap[group.scene_id || '']"
+                        class="review-audio-scene-title"
+                      >· {{ sceneTitleMap[group.scene_id || ''] }}</span>
+                    </div>
+                    <span class="review-audio-count">{{ (group.assets || []).length }} 个片段</span>
+                  </header>
+                  <ul class="review-audio-asset-list">
+                    <li
+                      v-for="(asset, index) in group.assets || []"
+                      :key="asset.asset_id || asset.segment_id || asset.file_name"
+                      class="review-audio-asset-item"
+                    >
+                      <!-- Decorative waveform glyph — visual landmark so each
+                           segment row has a left-edge anchor instead of
+                           starting with raw text. Pure CSS bars, no SVG. -->
+                      <div class="review-audio-wave" aria-hidden="true">
+                        <span></span><span></span><span></span><span></span>
+                      </div>
+                      <div class="review-audio-asset-main">
+                        <div class="review-audio-asset-row">
+                          <strong>{{ audioAssetTitle(index) }}</strong>
+                          <span
+                            class="review-audio-speaker-pill"
+                            :class="`review-audio-speaker-pill--${(asset.speaker || 'unknown').toLowerCase()}`"
+                          >{{ asset.speaker || 'unknown' }}</span>
+                          <span class="review-audio-duration">
+                            {{ formatAudioDuration(asset.duration_estimate_sec) }}
+                          </span>
+                        </div>
+                        <!-- Spoken text — pulled from outputs.narration.segments
+                             matched by index within the scene. Mirrors the
+                             image card's "画面内容" so the audio side carries
+                             the same semantic weight: each segment shows
+                             what it's saying, not just file metadata. -->
+                        <p
+                          v-if="(mockAudioSegmentTextMap[group.scene_id || ''] || [])[index]"
+                          class="review-audio-text"
+                        >
+                          {{ (mockAudioSegmentTextMap[group.scene_id || ''] || [])[index] }}
+                        </p>
+                      </div>
+                      <a
+                        v-if="asset.public_url"
+                        class="review-audio-play"
+                        :href="`${apiBaseUrl}${asset.public_url}`"
+                        target="_blank"
+                        rel="noreferrer"
+                        :title="`播放 ${audioAssetTitle(index)}`"
+                        aria-label="打开音频"
+                      >
+                        <span aria-hidden="true">▶</span>
+                      </a>
+                    </li>
+                  </ul>
+                </article>
+              </div>
+
+              <details v-if="mockAudioIndexUrl || mockAudioDirectoryText" class="review-audio-details">
+                <summary>开发者信息</summary>
+                <div v-if="mockAudioIndexUrl" class="review-audio-dev-row">
+                  <span class="review-audio-dev-label">索引文件</span>
+                  <a
+                    class="review-audio-play-inline"
+                    :href="`${apiBaseUrl}${mockAudioIndexUrl}`"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    打开 index.json ↗
+                  </a>
+                  <code>{{ mockAudioIndexUrl }}</code>
+                </div>
+                <pre v-if="mockAudioDirectoryText" class="light-result compact-result">{{ mockAudioDirectoryText }}</pre>
+              </details>
+            </details>
           </template>
         </template>
 
@@ -3139,86 +3293,6 @@ async function runWorkflow() {
       </section>
       <section v-if="activeTab === 'assets'">
         <InspirationLibraryPanel @apply="onApplyInspiration" />
-        <section
-          v-if="mockAudioIndexUrl || mockAudioSceneGroups.length > 0 || mockAudioDirectoryText"
-          class="result-panel"
-        >
-          <h2 class="section-title">配音素材</h2>
-          <p class="mock-audio-intro">这里沉淀本次生成的配音片段，方便核对场景声音素材。</p>
-
-          <div v-if="mockAudioSceneGroups.length > 0" class="mock-audio-scenes">
-            <article
-              v-for="group in mockAudioSceneGroups"
-              :key="group.scene_id || 'unknown-scene'"
-              class="mock-audio-scene-card"
-            >
-              <div class="mock-audio-scene-head">
-                <strong>{{ sceneDisplayName(group.scene_id) }}</strong>
-                <span>{{ (group.assets || []).length }} 个片段</span>
-              </div>
-
-              <ul class="mock-audio-asset-list">
-                <li
-                  v-for="(asset, index) in group.assets || []"
-                  :key="asset.asset_id || asset.segment_id || asset.file_name"
-                  class="mock-audio-asset-item"
-                >
-                  <div class="mock-audio-asset-main">
-                    <strong>{{ audioAssetTitle(index) }}</strong>
-                    <span class="mock-audio-meta">
-                      {{ audioSpeakerLabel(asset.speaker) }} · {{ formatAudioDuration(asset.duration_estimate_sec) }}
-                    </span>
-                  </div>
-
-                  <a
-                    v-if="asset.public_url"
-                    class="asset-link"
-                    :href="`${apiBaseUrl}${asset.public_url}`"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    打开音频
-                  </a>
-                </li>
-              </ul>
-            </article>
-          </div>
-
-          <p v-else class="mock-audio-empty">暂无可展示的配音素材。</p>
-
-          <details
-            v-if="mockAudioIndexUrl || mockAudioSceneGroups.length > 0 || mockAudioDirectoryText"
-            class="mock-audio-details"
-          >
-            <summary>开发者信息</summary>
-            <div v-if="mockAudioIndexUrl" class="mock-audio-link-row">
-              <span class="mock-audio-label">索引文件</span>
-              <a
-                class="asset-link"
-                :href="`${apiBaseUrl}${mockAudioIndexUrl}`"
-                target="_blank"
-                rel="noreferrer"
-              >
-                打开 index.json
-              </a>
-              <code>{{ mockAudioIndexUrl }}</code>
-            </div>
-            <div
-              v-for="group in mockAudioSceneGroups"
-              :key="`${group.scene_id || 'unknown-scene'}-developer`"
-              class="mock-audio-link-row"
-            >
-              <span class="mock-audio-label">{{ group.scene_id || 'unknown-scene' }}</span>
-              <code
-                v-for="asset in group.assets || []"
-                :key="asset.asset_id || asset.segment_id || asset.file_name"
-              >
-                {{ asset.file_name || '-' }} · {{ asset.public_url || '-' }}
-              </code>
-            </div>
-            <pre v-if="mockAudioDirectoryText" class="light-result compact-result">{{ mockAudioDirectoryText }}</pre>
-          </details>
-        </section>
       </section>
       <section v-if="activeTab === 'debug'" class="debug-layout">
         <div v-if="!hasDebugContent" class="review-empty-state glass-card animate-fade-in">
@@ -3356,8 +3430,257 @@ async function runWorkflow() {
 }
 
 .review-video-card,
-.review-images-card {
+.review-images-card,
+.review-audio-card {
   overflow: hidden;
+}
+
+/* 配音素材 — collapsible card. Closed by default so it doesn't
+   dominate the Review tab; expand to inspect TTS output per scene.
+   Inner styling drops the dev-tool "wall of text" look: speaker
+   pills, mini waveform glyph, circular play button. */
+.review-audio-card {
+  display: block;
+}
+.review-audio-card[open] .review-audio-summary-chevron {
+  transform: rotate(90deg);
+}
+.review-audio-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.875rem 1.25rem;
+  cursor: pointer;
+  list-style: none;
+  border-bottom: 1px solid transparent;
+  background: linear-gradient(90deg, rgba(245,158,11,0.05) 0%, transparent 60%);
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+.review-audio-summary::-webkit-details-marker { display: none; }
+.review-audio-card[open] .review-audio-summary {
+  border-bottom-color: rgba(245,158,11,0.12);
+}
+.review-audio-summary-count {
+  margin-left: auto;
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.review-audio-summary-chevron {
+  color: var(--arc-300);
+  font-size: 0.6875rem;
+  transition: transform 0.18s ease;
+}
+
+.review-audio-scenes {
+  padding: 1rem 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.review-audio-scene {
+  padding: 0.875rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-glass);
+  background: var(--surface-overlay-soft);
+}
+.review-audio-scene-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 0.75rem;
+}
+.review-audio-scene-head strong {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+}
+.review-audio-scene-title-block {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.review-audio-scene-title {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+.review-audio-count {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.review-audio-asset-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.review-audio-asset-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.review-audio-asset-item:last-child { border-bottom: 0; }
+
+/* Mini waveform — decorative left-edge anchor. 4 vertical bars with
+   alternating heights, animated on hover so each segment row reads
+   as an "audio thing", not just text. */
+.review-audio-wave {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-top: 4px;
+  height: 14px;
+}
+.review-audio-wave span {
+  width: 2px;
+  background: var(--arc-300);
+  border-radius: 1px;
+  opacity: 0.55;
+  transition: opacity 0.18s ease;
+}
+.review-audio-wave span:nth-child(1) { height: 30%; }
+.review-audio-wave span:nth-child(2) { height: 75%; }
+.review-audio-wave span:nth-child(3) { height: 50%; }
+.review-audio-wave span:nth-child(4) { height: 90%; }
+.review-audio-asset-item:hover .review-audio-wave span { opacity: 1; }
+
+.review-audio-asset-main {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+.review-audio-asset-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.review-audio-asset-row strong {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* Speaker pills — same shape, different tint per speaker so the
+   reader can scan "who's talking" without reading the label. Fallback
+   for unknown roles is a neutral pill. */
+.review-audio-speaker-pill {
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-overlay-strong);
+  color: var(--text-secondary);
+}
+.review-audio-speaker-pill--narrator {
+  color: color-mix(in srgb, var(--arc-200) 90%, var(--text-primary));
+  border-color: color-mix(in srgb, var(--arc-300) 36%, transparent);
+  background: color-mix(in srgb, var(--arc-300) 14%, transparent);
+}
+.review-audio-speaker-pill--mother {
+  color: #f5b8d8;
+  border-color: rgba(244, 114, 182, 0.32);
+  background: rgba(244, 114, 182, 0.10);
+}
+.review-audio-speaker-pill--child {
+  color: #a7d8ff;
+  border-color: rgba(96, 165, 250, 0.32);
+  background: rgba(96, 165, 250, 0.10);
+}
+
+.review-audio-duration {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+/* Spoken text — mirrors the image-card "画面内容" pattern. Slightly
+   indented from the wave anchor so eye can naturally trace from the
+   waveform → speaker pill → spoken line. */
+.review-audio-text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.65;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+}
+
+/* Circular play button — replaces the wordy "打开音频 ↗" link.
+   Visual landmark on the right; touching aria-label for screen readers. */
+.review-audio-play {
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-arc);
+  background: color-mix(in srgb, var(--arc-300) 12%, transparent);
+  color: var(--arc-300);
+  font-size: 0.625rem;
+  text-decoration: none;
+  margin-top: 2px;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.12s ease;
+}
+.review-audio-play:hover {
+  background: color-mix(in srgb, var(--arc-300) 26%, transparent);
+  border-color: var(--arc-300);
+}
+.review-audio-play:active { transform: scale(0.94); }
+.review-audio-play-inline {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--arc-300);
+  text-decoration: none;
+  margin-right: 8px;
+}
+.review-audio-play-inline:hover { color: var(--arc-200); }
+.review-audio-details {
+  padding: 0 1.25rem 1.25rem;
+}
+.review-audio-details summary {
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--arc-300);
+  padding: 0.5rem 0;
+}
+.review-audio-dev-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0.3rem 0;
+  font-size: 0.75rem;
+}
+.review-audio-dev-row code {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  background: var(--surface-overlay-soft);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.review-audio-dev-label {
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
 }
 
 .review-section-header {


### PR DESCRIPTION
## What

三组改动一起合，因为都围绕"让生成的内容可被读懂"展开：

### 1. 配音素材搬到画面审核

原本「配音素材」挂在「灵感参考」tab 下，但它本质是「上一次 workflow 的输出」，语义上属于 Review tab（跟图像审核一类）。搬过来 + 升级 UI：

- 整段做成可折叠 details（关闭默认，避免霸屏）
- 每段音频加 speaker pill（narrator / mother / child 各自颜色）
- 加 mini waveform glyph 作为左侧锚点（视觉上"这是个音频条目"）
- 把朗读文本（从 \`outputs.narration.segments\` 按 scene_id 匹配）显示在每段下面
- 场景标题从 storyboard 取（不再只显示 \`场景 01\`）
- "打开音频 ↗" 文字链改成圆形 ▶ 播放按钮

### 2. 生成细节结构扁平化

之前结构是「分镜结构 / 图片提示词 / 开发者原始数据(下面再嵌 10 项)」——同样都是 workflow 节点输出，被分到两个层级，"完整 Storyboard JSON"和"分镜结构"对不上。

**改后**：扁平 10 个 sibling，每项结构统一（标题 + explainer + 原始 JSON），按 pipeline 顺序排：分镜结构 / 图片提示词 / 角色候选 / 角色设定清单 / 图片素材 / 画面审核 / 旁白 / 字幕 / 视频提示词 / 渲染计划。

每项加 explainer 一句话告诉用户这是干嘛的。原始 JSON \`<pre>\` 加 max-height + 内滚动 + 自定义滚动条，避免一展开就十几屏。

### 3. 图片提示词的结构化展示

Kolors prompt 是 \`;\` 分隔的多条规则连成一坨。每条 prompt 1500+ tokens、单行渲染时无法阅读。

按 \`;\` 拆分后用 \`<ul>\` 分行渲染，并按语义着色：

- ◆ 金色 = 角色 anchor（\`identity lock\`、\`must keep\`、\`character N: ...\`）
- ⊘ 红色 = 负面约束（\`must avoid\`、\`do not\`、\`不要 ...\`）
- ◦ 默认 = 普通规则

**重要**：拆分仅作用于"解析视图"，下方 \`<pre>\` 原始 JSON **不动**——保留 ground truth 的字符级一致性。

### 4. 灵感参考卡片细节

- Spotlight 鼠标光晕：mousemove 写入 CSS custom prop，radial gradient 跟随
- 滚动入场：stagger 60ms × index，IntersectionObserver 触发一次
- 尊重 \`prefers-reduced-motion\`

## Why

之前的 Studio Review 体验是「列了一堆 JSON 但不知道在看什么」。这一波改动把每一段输出都接上「这是什么 + 长这样 + 原始数据」三段式结构，让一个不熟项目的人（包括 reviewer / 面试官）也能从 Review tab 顺一遍 pipeline。

## Test plan

- [ ] 跑一个真实 workflow，画面审核 tab 出现「配音素材」卡片，按场景分组，每段下显示朗读文本
- [ ] 生成细节展开后 10 个 sibling 平铺，每项有一句 explainer
- [ ] 图片提示词 → 任一 scene 展开后呈现 ◆/⊘/◦ 分类的 bullet 列表
- [ ] 灵感参考鼠标移到卡片时有金色光晕跟随，首次进入视口卡片 stagger 上浮
- [ ] Pearl 主题：所有文字可读，不破坏配色