### PR TITLE
fix(history): first-write-wins on video metadata; inspiration 90s → 60s

### DIFF
--- a/frontend/src/data/inspirationLibrary.ts
+++ b/frontend/src/data/inspirationLibrary.ts
@@ -274,13 +274,13 @@ const TEMPLATES: InspirationItem[] = [
     icon: '🌙',
     preview: [
       { label: '故事种子', value: '夜幕降临，小动物各自回家，星星眨眼' },
-      { label: '时长', value: '90 秒' },
+      { label: '时长', value: '60 秒' },
       { label: '旁白配音', value: '故事妈妈' },
     ],
     prefill: {
       topic:
         '讲一个节奏舒缓的睡前儿童故事。夜幕降临，小动物们各自回到温暖的家。月亮升起，星星眨眼，整片森林安静下来，小白兔依偎着妈妈轻轻闭上眼睛。',
-      durationSec: 90,
+      durationSec: 60,
       voiceStyle: 'warm_mother',
       narratorVoiceStyle: 'warm_mother',
     },

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -329,13 +329,17 @@ function pushRecentFinalVideoUrl(url: string, meta?: RecentVideoMeta) {
     ...recentFinalVideoUrls.value.filter((item) => item !== u),
   ].slice(0, 10)
 
-  // Merge new metadata over any existing entry (so a later push with
-  // richer info upgrades the previous record rather than wiping it).
-  if (meta) {
-    const existing = recentVideoMetadata.value[u] || {}
+  // First-write-wins: metadata is set ONLY when a URL is brand new in
+  // the map. Re-applies of the same workflow (e.g. tab nav, SPA mount
+  // restoration) must not overwrite the topic with whatever the form
+  // currently holds — otherwise a user who generated 「小海豹」then
+  // edited the form to 「小兔子」would see the seal card's tooltip
+  // suddenly say "rabbit". The topic-at-time-of-generation is what
+  // history wants to preserve, not the live form value.
+  if (meta && !recentVideoMetadata.value[u]) {
     recentVideoMetadata.value = {
       ...recentVideoMetadata.value,
-      [u]: { ...existing, ...meta },
+      [u]: meta,
     }
   }
   // Drop metadata entries whose URL is no longer in the list so the


### PR DESCRIPTION
## What

两个独立的小 bug，一起合：

### 1. 历史视频 tooltip 显示错误的主题

**重现路径**：
1. 用某个主题（如「波波·小海豹」）生成一个视频 → 历史卡 tooltip 正确
2. 在表单里改主题（甚至什么都不点，只是切到「灵感参考」预设、再切回创作 tab）
3. 移到那张历史卡 → tooltip 变成**当前**表单的主题，不是当时生成时的主题

**根因**：

`pushRecentFinalVideoUrl(url, meta)` 用了 **merge** 模式：

```ts
recentVideoMetadata.value = {
  ...recentVideoMetadata.value,
  [u]: { ...existing, ...meta },  // ← meta 覆盖 existing 同名字段
}
```

每次 `applyWorkflowResponse` 重跑（mount 恢复 / SPA 内 nav / 切 tab 回来），都会用 \`deriveCurrentVideoMeta()\` 算一份 meta 重新 push。而 \`deriveCurrentVideoMeta\` 里的 topic 是从**当前** \`workflowForm.value.topic\` 读的——不是从 workflow response 拿的。

**修复**：metadata **只在 URL 第一次入库时写入，后续永不覆盖**。

```ts
if (meta && !recentVideoMetadata.value[u]) {
  recentVideoMetadata.value = {
    ...recentVideoMetadata.value,
    [u]: meta,
  }
}
```

**Scope honesty**：这个修复只防未来。**localStorage 里已经被污染的存量数据不会自动修复**——用户可以手动用 × 按钮删除错的卡片，新生成的视频则永远正确。

### 2. 「睡前温馨」预设时长 90s 超出表单合法值

\`durationSec: 90\` 不在表单 dropdown 的选项里（只有 60 / 120 / 180）。应用预设后，dropdown 显示空白。

**修复**：改成 \`durationSec: 60\`（睡前故事本来就短）。preview 行的"时长 90 秒"也同步成 60 秒。

## Test plan

- [ ] 生成一个 A 主题的视频 → 改 form 为 B 主题 → 不点开始 → hover 历史卡，tooltip 仍是 A 主题
- [ ] 应用「睡前温馨」预设 → 表单时长 dropdown 显示 60 秒（不再空白）
- [ ] 既有错乱 tooltip 的历史卡可以通过 hover 时右上角 × 删除