### PR TITLE
fix(studio): subject extraction + topic↔characters consistency

### DIFF
--- a/app/services/story_subject_extractor.py
+++ b/app/services/story_subject_extractor.py
@@ -64,6 +64,31 @@ def _clean_piece(value: str) -> str:
     return text.strip(" \t\n\r，。！？、,.!?：:；;“”\"'《》")
 
 
+def _starts_with_verb(text: str) -> bool:
+    """True iff jieba's first POS-tagged token is a verb.
+
+    Used to short-circuit subject extraction on *instruction-style*
+    topics like "讲一个节奏舒缓的睡前儿童故事..." or "写一个奇幻冒险
+    的故事...". Topics that open with a verb have no human-name
+    subject in their preamble — any "name" we'd otherwise extract
+    (e.g. "讲一", "写一") is a false positive that then flows
+    downstream as the protagonist's name, producing nonsense story
+    text like "讲一继续认真尝试".
+
+    Returns False when jieba is unavailable (caller proceeds with the
+    legacy fallback path), and False on empty / whitespace input.
+    """
+    if not _JIEBA_AVAILABLE:
+        return False
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return False
+    tokens = list(_posseg.cut(cleaned))
+    if not tokens:
+        return False
+    return tokens[0].flag.startswith("v")
+
+
 def _cut_at_verb_boundary_jieba(text: str) -> str:
     """遇到动词或第二个非修饰名词（activity noun）就截断，返回角色名部分。"""
     tokens = list(_posseg.cut(text))
@@ -162,6 +187,15 @@ def _extract_open_xiao_subject(piece: str) -> str:
 def _extract_open_leading_subject(piece: str) -> str:
     value = _clean_piece(piece)
     if not value:
+        return ""
+
+    # BUG-001 fix. Instruction-style topics ("讲一个 X 的故事 / 写一段
+    # 关于 Y 的故事") have no real subject name in their preamble; the
+    # regex below would blindly grab the first 2–4 chars (e.g. "讲一",
+    # "讲一个节") and that fake "name" would flow downstream as the
+    # protagonist, producing story text like "讲一继续认真尝试".
+    # Short-circuit when jieba reports the very first token is a verb.
+    if _starts_with_verb(value):
         return ""
 
     value = _cut_at_generic_syntax_boundary(value)

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -754,6 +754,11 @@ function setExampleTopic(topic: string) {
 // to confirm anything happened.
 function onApplyInspiration(item: InspirationItem) {
   workflowForm.value = { ...workflowForm.value, ...item.prefill }
+  // Snapshot the topic-at-fill-time so the "topic changed, characters
+  // may not match" warning doesn't fire immediately after the preset
+  // applied (topic + characters were filled *together*, they're in
+  // sync by construction).
+  topicAtCharacterFill.value = String(workflowForm.value.topic || '')
   activeTab.value = 'run'
   // Defer the scroll until Vue has rendered the run tab, otherwise the
   // form anchor doesn't exist yet.
@@ -763,6 +768,90 @@ function onApplyInspiration(item: InspirationItem) {
       (anchor as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
   })
+}
+
+// ── Topic-changed-but-characters-still-stale warning ────────────────
+//
+// When the user changes the topic significantly after structured
+// character fields are already populated (e.g. they applied the
+// 「波波·小海豹」preset then later changed topic to "讲一个小兔子
+// 的故事"), the form ends up in a self-contradictory state — the
+// generation result will mix species from the preset character with
+// the new topic intent.
+//
+// Detection: compare the live topic against `topicAtCharacterFill`,
+// the snapshot taken either at preset-apply or at the last time the
+// user dismissed this warning. If the first 20 characters differ AND
+// any structured character field is populated, surface a confirmation
+// modal asking the user to either clear or keep.
+
+const topicAtCharacterFill = ref<string>('')
+const topicChangeWarningOpen = ref<boolean>(false)
+let topicChangeDebounce: ReturnType<typeof setTimeout> | null = null
+
+const hasCharacterFields = computed<boolean>(() => {
+  const f = workflowForm.value || {}
+  return Boolean(
+    (f.primaryCharacterDisplayName || '').trim() ||
+      (f.primaryCharacterSpecies || '').trim() ||
+      (f.primaryCharacterVisualTraits || '').trim() ||
+      (f.secondaryCharacterDisplayName || '').trim() ||
+      (f.secondaryCharacterSpecies || '').trim() ||
+      (f.secondaryCharacterVisualTraits || '').trim(),
+  )
+})
+
+/** Two topics are "significantly different" iff their first 20
+ *  characters don't match. Picked 20 because:
+ *  - typo fixes / appended phrases usually keep the prefix intact
+ *  - a full rewrite reliably changes the opening
+ *  - cheap to compute, no Levenshtein nonsense
+ */
+function topicIsSignificantlyDifferent(a: string, b: string): boolean {
+  const sa = String(a || '').trim()
+  const sb = String(b || '').trim()
+  if (sa === sb) return false
+  if (!sa || !sb) return true
+  return sa.slice(0, 20) !== sb.slice(0, 20)
+}
+
+watch(
+  () => workflowForm.value?.topic || '',
+  (newTopic) => {
+    if (topicChangeDebounce) clearTimeout(topicChangeDebounce)
+    // 1s after the user stops typing — long enough to feel "they
+    // committed" but short enough that they remember which edit
+    // we're warning about.
+    topicChangeDebounce = setTimeout(() => {
+      if (!hasCharacterFields.value) return
+      if (!topicIsSignificantlyDifferent(newTopic, topicAtCharacterFill.value)) return
+      topicChangeWarningOpen.value = true
+    }, 1000)
+  },
+)
+
+function clearCharacterFieldsAfterTopicChange() {
+  workflowForm.value = {
+    ...workflowForm.value,
+    structuredCharactersEnabled: false,
+    primaryCharacterDisplayName: '',
+    primaryCharacterSpecies: '',
+    primaryCharacterVisualTraits: '',
+    primaryCharacterForbiddenTraits: '',
+    secondaryCharacterDisplayName: '',
+    secondaryCharacterSpecies: '',
+    secondaryCharacterVisualTraits: '',
+    secondaryCharacterForbiddenTraits: '',
+  }
+  topicAtCharacterFill.value = String(workflowForm.value.topic || '')
+  topicChangeWarningOpen.value = false
+}
+
+function keepCharacterFieldsAfterTopicChange() {
+  // Re-snapshot so we don't keep nagging on every subsequent keystroke.
+  // The user has made a conscious decision; respect it for *this* topic.
+  topicAtCharacterFill.value = String(workflowForm.value.topic || '')
+  topicChangeWarningOpen.value = false
 }
 
 onMounted(() => {
@@ -814,6 +903,12 @@ onMounted(() => {
       workflowForm.value = { ...DEFAULT_WORKFLOW_FORM, ...savedForm }
     } catch { /* ignore malformed */ }
   }
+
+  // Snapshot the restored topic so the watcher's first emit doesn't
+  // immediately trigger the "topic changed" warning. Without this the
+  // baseline starts as empty string, so any saved topic looks like a
+  // dramatic change on first paint and pops the modal.
+  topicAtCharacterFill.value = String(workflowForm.value.topic || '')
 
   const savedSessionId = localStorage.getItem(STORAGE_KEY_SESSION)
   if (savedSessionId) {
@@ -3388,6 +3483,43 @@ async function runWorkflow() {
           <div class="confirm-actions">
             <button class="confirm-btn confirm-btn-ghost" @click="cancelDeleteRecentVideo">取消</button>
             <button class="confirm-btn confirm-btn-primary" @click="performDeleteRecentVideo">删除</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+
+  <!-- Topic-changed-but-characters-stale warning. Fires 1s after the
+       user stops editing the topic IF structured character fields are
+       populated AND the new topic's opening differs significantly
+       from the snapshot. Either action updates the snapshot so we
+       don't keep nagging on this same edit. Own <Transition> wrapper
+       because Vue's <Transition> requires exactly one child. -->
+  <Teleport to="body">
+    <Transition name="confirm-fade">
+      <div
+        v-if="topicChangeWarningOpen"
+        class="confirm-overlay"
+        role="dialog"
+        aria-modal="true"
+        @click.self="keepCharacterFieldsAfterTopicChange"
+      >
+        <div class="confirm-dialog">
+          <h3 class="confirm-title">主题变了，要清空已填的角色配置吗？</h3>
+          <p class="confirm-message">
+            你刚修改了故事主题，但角色名 / 物种 / 外观这些字段还停留在之前的设定。
+            如果新主题里的主角跟原来不同（比如从"小海豹"换成"小兔子"），
+            建议清空让系统按新主题自动推断；如果只是润色文字、主角不变，可以保留。
+          </p>
+          <div class="confirm-actions">
+            <button
+              class="confirm-btn confirm-btn-ghost"
+              @click="keepCharacterFieldsAfterTopicChange"
+            >保留角色</button>
+            <button
+              class="confirm-btn confirm-btn-primary"
+              @click="clearCharacterFieldsAfterTopicChange"
+            >清空角色</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
两个独立的小修复，主题都围绕「topic 和角色字段的一致性」——一起合：

## 1. fix(extractor): 「讲一个 X 的故事」不再被错抓出「讲一」做主角名

**症状**：选「睡前温馨」预设，topic 是 `讲一个节奏舒缓的睡前儿童故事...`，最终故事文本变成「**讲一**继续认真尝试，慢慢找到了解决问题的方法。**讲一**心里暖暖的...」。

**根因**：`story_subject_extractor.py` 的 fallback 正则在 jieba 切词失败时盲抓前 2-4 个汉字。jieba 识别"讲"是动词后直接 break，但函数末尾用 `return accumulated.strip() or text` 兜底返回原文，正则随后抓出"讲一个节" → 末尾的"3字以上截前2字"逻辑把它截成"讲一"。

**修复**：新增 `_starts_with_verb`，jieba 第一个 token 是动词就直接返回空——让 LLM 后续从完整故事内容里推断角色，而不是用错抓的"讲一"。

覆盖 `docs/post_refactor_todo.md` 的 BUG-001。验证：

| 输入 | 修复前 primary | 修复后 primary |
|---|---|---|
| 讲一个节奏舒缓...小白兔... | **讲一** ❌ | **小动物** ✅ |
| 写一个关于小狐狸的冒险故事 | （会是写一）❌ | **小狐狸** ✅ |
| 小白兔和小乌龟赛跑 | 小白兔 ✅ | 小白兔 ✅ |
| 说一个温暖的故事吧 | （会是说一）❌ | **空** ✅（让 LLM 推断） |

## 2. feat(studio): 主题改了但角色字段还旧，弹窗确认

**症状**：用户应用「波波·小海豹」预设后，又把 topic 改成「讲一个小兔子的故事」，但角色名字段还停留在「波波」、物种字段还是「小海豹」。点开始创作就会生成一个角色串味的故事。

**修复**：debounce 1 秒检测 topic 变化，若结构化角色字段已填 + topic 前 20 字与快照不同 → 弹窗问「清空角色 / 保留」。

**避免误报的 3 个守卫**：
- mount 时把快照初始化为当前 topic — 页面刷新不弹
- 应用预设时刷新快照 — 预设的 topic+角色配套填入不弹
- 任何一次确认后刷新快照 — 同一次编辑不会反复弹

## Test plan

- [ ] topic 改成 `讲一个 X` 类指令性句子，生成的故事不再以"讲一"为主角名
- [ ] 应用「波波·小海豹」预设 → 不弹窗
- [ ] 接着把 topic 改成「讲一个小兔子的故事」 → 1 秒后弹窗
- [ ] 选「清空角色」→ 主角字段被清空 + 弹窗关
- [ ] 选「保留角色」→ 字段保留 + 弹窗关，再编辑不立即重复弹
- [ ] 页面刷新 → 不立即弹窗