### PR TITLE
fix(images): persist scene failures + block render + retry re-renders video

### DIFF
--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -240,11 +240,13 @@ class WorkflowRunner:
         run_id: str,
         image_review: Dict[str, Any],
         provider: str,
+        storyboard_scenes: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         return self._image_selection_support.build_image_assets_from_selected_assets(
             run_id=run_id,
             image_review=image_review,
             provider=provider,
+            storyboard_scenes=storyboard_scenes,
         )
 
     def get_real_kling_samples_manifest(self) -> Dict[str, Any]:

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -878,14 +878,53 @@ class RunnerAudioRenderSupport:
         audio_segments = outputs.get("audio_segments") or {}
         subtitles = outputs.get("subtitles") or {}
 
-        image_asset_list = image_assets.get("assets") or []
+        raw_asset_list = image_assets.get("assets") or []
         audio_item_list = audio_segments.get("items") or []
+
+        # Partition assets. Failed placeholders (from B1) have
+        # status='failed' and no relative_path — they must never reach
+        # ffmpeg or it crashes on the missing file.
+        usable_asset_list: List[Dict[str, Any]] = []
+        failed_scene_ids: List[str] = []
+        for asset in raw_asset_list:
+            if not isinstance(asset, dict):
+                continue
+            status = str(asset.get("status") or "").strip().lower()
+            if status == "failed" or not asset.get("relative_path"):
+                scene_id = str(asset.get("scene_id") or "").strip()
+                if scene_id:
+                    failed_scene_ids.append(scene_id)
+                continue
+            usable_asset_list.append(asset)
+
+        # Render gate: if ANY scene failed, refuse to produce a final
+        # video. The previous "render with what we have and mark
+        # degraded" approach silently shipped incomplete videos and
+        # made the review UI think the run was done (videoGenerated =
+        # true → per-scene retry button hidden → user trapped). The
+        # correct invariant is `final_video.public_url exists ⟺ every
+        # scene succeeded`; until the user retries the failed scenes,
+        # there is no final video at all. The blocked status surfaces
+        # missing_scene_ids so the UI can show actionable error copy
+        # ("X 个场景生成失败，请重试后再渲染") instead of a fake "done"
+        # state.
+        if failed_scene_ids:
+            return {
+                "enabled": False,
+                "status": "blocked",
+                "reason": "missing_images",
+                "missing_scene_ids": failed_scene_ids,
+                "rendered_scene_count": 0,
+            }
+
+        image_asset_list = usable_asset_list
 
         if not image_asset_list:
             return {
                 "enabled": False,
                 "status": "skipped",
                 "reason": "missing image_assets",
+                "missing_scene_ids": failed_scene_ids,
             }
 
         # ========= 计算总时长 =========
@@ -909,7 +948,11 @@ class RunnerAudioRenderSupport:
         video_run_dir = self._runner._ensure_video_run_dir(ctx.run_id)
 
         # ========= 生成 base video =========
-        concat_file = self.build_video_concat_file(ctx, image_assets, audio_segments)
+        # Pass a filtered image_assets dict so the concat builder never
+        # sees failed placeholders (their relative_path is None and
+        # would otherwise crash ffmpeg).
+        usable_image_assets = {**image_assets, "assets": image_asset_list}
+        concat_file = self.build_video_concat_file(ctx, usable_image_assets, audio_segments)
 
         base_video_path = video_run_dir / "base_video.mp4"
 
@@ -1206,9 +1249,14 @@ class RunnerAudioRenderSupport:
         final_video_duration_sec = _ffprobe_duration_sec(final_video_path)
 
         # ========= 统一 return =========
+        # The render gate above guarantees we only reach here when
+        # every scene succeeded, so status is unambiguously
+        # 'generated'. rendered_scene_count is still useful as
+        # downstream telemetry / sanity check.
         return {
             "enabled": True,
             "status": "generated",
+            "rendered_scene_count": len(image_asset_list),
             "run_id": ctx.run_id,
             "file_name": "final.mp4",
             "relative_path": f"assets/mock/video/{ctx.run_id}/final.mp4",

--- a/app/services/runner_image_review.py
+++ b/app/services/runner_image_review.py
@@ -371,6 +371,7 @@ class RunnerImageReviewSupport:
             run_id=run_id,
             image_review=updated_image_review,
             provider=str(runner._image_provider_name()),
+            storyboard_scenes=storyboard_scenes,
         )
 
         outputs = {
@@ -515,6 +516,7 @@ class RunnerImageReviewSupport:
             provider=str(
                 single_scene_assets.get("provider") or runner._image_provider_name()
             ),
+            storyboard_scenes=storyboard_scenes,
         )
 
         video_prompts = runner._run_video_prompts(ctx, outputs)

--- a/app/services/runner_image_selection_support.py
+++ b/app/services/runner_image_selection_support.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class RunnerImageSelectionSupport:
@@ -13,10 +13,25 @@ class RunnerImageSelectionSupport:
         run_id: str,
         image_review: Dict[str, Any],
         provider: str,
+        storyboard_scenes: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
+        """Synthesize image_assets from the user's review selections.
+
+        When ``storyboard_scenes`` is provided, any scene that has no
+        successful selected asset is emitted as an explicit
+        ``status='failed'`` placeholder so ``len(assets) == scene_count``
+        is preserved on disk. Without this, scenes whose per-scene
+        refresh API call failed (timeout / 5xx / image provider error)
+        were silently dropped from the persisted outputs — downstream
+        consumers (frontend placeholder builder, render gate) then
+        couldn't tell pending from permanently-failed scenes, and the
+        UI showed "等待生成" for scenes that would never resolve.
+        """
         selected_assets = image_review.get("selected_assets") or []
 
         merged_assets: List[Dict[str, Any]] = []
+        completed_scene_ids: set[str] = set()
+
         if isinstance(selected_assets, list):
             for item in selected_assets:
                 if not isinstance(item, dict):
@@ -64,6 +79,44 @@ class RunnerImageSelectionSupport:
                     }
                 )
 
+                scene_id = str(item.get("scene_id") or "").strip()
+                if scene_id:
+                    completed_scene_ids.add(scene_id)
+
+        # Failed-scene placeholders. Only emitted when the caller passes
+        # the full storyboard.scenes list — older callers (no scenes
+        # arg) keep the legacy behavior so this refactor is safe to land
+        # incrementally.
+        failed_scene_ids: List[str] = []
+        if isinstance(storyboard_scenes, list):
+            for scene in storyboard_scenes:
+                if not isinstance(scene, dict):
+                    continue
+                scene_id = str(scene.get("scene_id") or "").strip()
+                if not scene_id or scene_id in completed_scene_ids:
+                    continue
+                scene_title = str(scene.get("scene_title") or scene_id).strip()
+                merged_assets.append(
+                    {
+                        "scene_id": scene_id,
+                        "scene_title": scene_title,
+                        "status": "failed",
+                        "error_message": (
+                            "image generation failed and was not retried"
+                        ),
+                        "file_name": None,
+                        "relative_path": None,
+                        "public_url": None,
+                        "mime_type": None,
+                        "selected_asset_ref": {},
+                        "candidate_asset_refs": [],
+                        "reference_images": [],
+                    }
+                )
+                failed_scene_ids.append(scene_id)
+
+        generated_count = len(merged_assets) - len(failed_scene_ids)
+
         return {
             "enabled": True,
             "run_id": run_id,
@@ -73,5 +126,8 @@ class RunnerImageSelectionSupport:
                 "reference_image_mode": "metadata_only",
             },
             "asset_count": len(merged_assets),
+            "generated_count": generated_count,
+            "failed_count": len(failed_scene_ids),
+            "failed_scene_ids": failed_scene_ids,
             "assets": merged_assets,
         }

--- a/frontend/src/components/InteractiveImageReview.vue
+++ b/frontend/src/components/InteractiveImageReview.vue
@@ -391,7 +391,12 @@ const renderEntries = computed<ReviewRenderEntry[]>(() => {
     // OLD image unchanged while the background API call runs — there's
     // no visual indication anything's happening, and once the new image
     // arrives it appears to "just change" without any progress feedback.
-    if (matchedItem && placeholder.state !== 'refreshing' && placeholder.state !== 'waiting') {
+    if (
+      matchedItem &&
+      placeholder.state !== 'refreshing' &&
+      placeholder.state !== 'waiting' &&
+      placeholder.state !== 'failed'
+    ) {
       entries.push({
         kind: 'item',
         sceneId,

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2017,14 +2017,75 @@ function buildReviewPlaceholdersFromStoryboard(data: WorkflowRunResponse): Revie
       .filter(Boolean),
   )
 
+  // Scenes the backend already marked as `status: 'failed'` in
+  // image_assets.assets. After B1 (image_provider failures persisted
+  // as placeholders), these are explicit dead scenes and must NOT
+  // render as "waiting" — that copy implies generation is still
+  // pending, which would confuse the user into thinking the workflow
+  // is still working.
+  const imageAssetList = Array.isArray((imageAssets as Record<string, unknown>)?.assets)
+    ? ((imageAssets as Record<string, unknown>).assets as unknown[])
+    : []
+  const failedSceneIds = new Set(
+    imageAssetList
+      .map((item: unknown) => {
+        if (!item || typeof item !== 'object') return ''
+        const rec = item as Record<string, unknown>
+        return String(rec.status || '').toLowerCase() === 'failed'
+          ? String(rec.scene_id || '')
+          : ''
+      })
+      .filter(Boolean),
+  )
+
+  // Legacy outputs (written before B1) silently dropped failed scenes
+  // — image_assets.assets just had fewer entries than storyboard
+  // scenes and no `failed` marker anywhere. In that case the only
+  // signal we have is "the workflow is already done" (final_video is
+  // present): a scene that's missing from selected_assets in a
+  // terminal run can't still be "waiting" — it must be a failure.
+  const finalVideo = data.outputs?.final_video as Record<string, unknown> | undefined
+  const finalVideoStatus = String(finalVideo?.status || '').toLowerCase()
+  const workflowIsTerminal =
+    Boolean(finalVideo?.public_url) ||
+    finalVideoStatus === 'generated' ||
+    finalVideoStatus === 'degraded'
+
+  // The render step now also records `missing_scene_ids` when it
+  // produces a degraded video. Trust that list when present — it's
+  // the authoritative source for "rendered without this scene".
+  const renderMissingSceneIds = new Set(
+    (Array.isArray((finalVideo as Record<string, unknown>)?.missing_scene_ids)
+      ? ((finalVideo as Record<string, unknown>).missing_scene_ids as unknown[])
+      : []
+    )
+      .map((id) => String(id || ''))
+      .filter(Boolean),
+  )
+
   return scenes.map((scene: unknown) => {
     const sceneRecord = scene as Record<string, unknown>
     const sceneId = String(sceneRecord.scene_id || '')
     const sceneTitle = String(sceneRecord.scene_title || sceneId || 'unknown-scene')
+
+    let state: ReviewPlaceholderItem['state']
+    if (doneSceneIds.has(sceneId)) {
+      state = 'done'
+    } else if (failedSceneIds.has(sceneId) || renderMissingSceneIds.has(sceneId)) {
+      state = 'failed'
+    } else if (workflowIsTerminal) {
+      // Legacy / unmarked: workflow ended without this scene's asset
+      state = 'failed'
+    } else {
+      state = 'waiting'
+    }
+
     return {
       scene_id: sceneId,
       scene_title: sceneTitle,
-      state: doneSceneIds.has(sceneId) ? 'done' : 'waiting',
+      state,
+      error_message:
+        state === 'failed' ? '该场景图片生成失败' : undefined,
     }
   })
 }
@@ -2395,13 +2456,25 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
 
   const data: ImageReviewRefreshSceneResponse = await response.json()
 
+  // Strip the stale final_video — a successful per-scene refresh
+  // means the previously-rendered video no longer matches the image
+  // set. If we kept it, applyWorkflowResponse below would restore
+  // finalVideoUrl to the old public_url and undo the retry-clear in
+  // retryImageReviewScene, trapping the user in the same state.
+  const priorOutputs = currentWorkflowResponse.value.outputs || {}
+  const { final_video: _staleVideo, ...priorOutputsSansVideo } = priorOutputs as Record<
+    string,
+    unknown
+  >
+  void _staleVideo
+
   const mergedResponse: WorkflowRunResponse = {
     ...(currentWorkflowResponse.value || {}),
     workflow_id: data.workflow_id || currentWorkflowResponse.value.workflow_id,
     session_id: data.session_id || currentWorkflowResponse.value.session_id,
     run_id: data.run_id || currentWorkflowResponse.value.run_id,
     outputs: {
-      ...(currentWorkflowResponse.value.outputs || {}),
+      ...priorOutputsSansVideo,
       image_assets:
         data.image_assets || currentWorkflowResponse.value.outputs?.image_assets || {},
       image_review:
@@ -2433,6 +2506,26 @@ async function retryImageReviewScene(sceneId: string) {
 
   errorMessage.value = ''
   imageReviewRefreshAbortController = new AbortController()
+
+  // Retrying a failed scene invalidates the existing final video — it
+  // was rendered without this scene (or with a stale version of it).
+  // Clearing finalVideoUrl does three things at once:
+  //   1. FinalVideoPanel falls through to the placeholder branch and
+  //      picks up the existing "正在重新生成候选图" copy + animation,
+  //      so the user no longer sees a frozen old video paired with
+  //      "等待候选图生成完成…".
+  //   2. renderFinalVideoIfReady's `if (finalVideoUrl.value) return`
+  //      guard no longer short-circuits, so a successful retry in
+  //      auto mode immediately kicks off a re-render with the now-
+  //      complete image set.
+  //   3. The 重新生成 (per-scene) button on done cards reappears
+  //      because its `!videoGenerated` guard flips back to truthy —
+  //      the user can keep fixing other scenes too.
+  // localStorage's STORAGE_KEY_VIDEO_URL is intentionally NOT removed
+  // here — that key feeds the history-video list, which should keep
+  // the prior video accessible until a new one writes back via
+  // applyWorkflowResponse on render completion.
+  finalVideoUrl.value = ''
 
   try {
     await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal)


### PR DESCRIPTION
## Summary

Closes the loop on partial-failure image runs. Before this PR, when 2/12 scenes failed to generate their image, the failures were silently dropped from disk, the video rendered anyway with the surviving 10 images, and the review UI ended up trapped: failed scenes showed "等待生成" forever, the (degraded) video locked all retry buttons, and the user had no path forward except deleting everything and starting over.

Four coordinated changes — three layers, one invariant: **`final_video.public_url` exists ⟺ every scene succeeded**.

### B1 · Backend persists per-scene failures
[`runner_image_selection_support.py`](app/services/runner_image_selection_support.py)

`build_image_assets_from_selected_assets()` now accepts a `storyboard_scenes` arg. For every scene not represented in `selected_assets`, it emits an explicit placeholder:

```json
{ "scene_id": "scene_03", "status": "failed", "error_message": "..." }
```

Output also gains `generated_count`, `failed_count`, `failed_scene_ids`. Invariant `len(assets) == scene_count` now holds on disk. The arg is optional, so callers that don't pass it keep legacy behavior — safe to land incrementally.

Wired the two callers in [`runner_image_review.py`](app/services/runner_image_review.py) (manual selection + per-scene refresh) to pass `storyboard_scenes`.

### B2 · Backend render gate
[`runner_audio_render_support.py::run_final_video`](app/services/runner_audio_render_support.py)

Two changes:

1. **Filter failed placeholders before ffmpeg.** They have no `relative_path` and would crash the concat step.
2. **Refuse to render when ANY scene failed.** Returns `{ status: "blocked", reason: "missing_images", missing_scene_ids: [...] }` with no `public_url`.

Previous attempt was to render-but-mark-degraded. Rejected because it created exactly the trap users hit: a video URL existed, `videoGenerated` flipped true, the review UI locked the candidate-retry buttons via `!videoGenerated`, and the user couldn't fix anything. The cleaner invariant is "final video iff all scenes succeeded" — make the data shape match the semantics.

### B3 · Frontend treats missing scenes as failed
[`StudioView.vue::buildReviewPlaceholdersFromStoryboard`](frontend/src/views/StudioView.vue)

Now resolves per-scene state via three signals in priority order:

1. In `selected_assets` → `done`
2. In `image_assets.assets` with `status: 'failed'` OR in `final_video.missing_scene_ids` → `failed`
3. **Legacy fallback**: workflow is terminal (`final_video.public_url` exists) but the scene is missing → `failed`. Covers existing on-disk runs that pre-date B1 — without this, the user's current 10/12 outputs.json would still render the 2 missing scenes as "等待生成".
4. Otherwise → `waiting`

[`InteractiveImageReview.vue`](frontend/src/components/InteractiveImageReview.vue) already had the `failed` copy (`生成失败 / 候选图 A 生成失败` / red `失败` badge) — B3 just lets it activate. Also added `'failed'` to the matched-item bypass guard so a placeholder-trumps-matched-item works correctly for terminal failures.

### B4 · Retry clears stale video + auto re-renders
[`StudioView.vue::retryImageReviewScene`](frontend/src/views/StudioView.vue) + [`refreshImageReviewScene`](frontend/src/views/StudioView.vue)

Retry now clears `finalVideoUrl.value = ''` at the start of the action. Single change unlocks four things at once:

1. [`FinalVideoPanel.vue`](frontend/src/components/FinalVideoPanel.vue) falls through to its placeholder branch (the `<video v-if="finalVideoUrl">` becomes false). Placeholder picks up the existing `正在重新生成候选图` copy + loading animation — no more frozen old video paired with `等待候选图与音频生成完成…`.
2. `renderFinalVideoIfReady`'s `if (finalVideoUrl.value) return` guard no longer short-circuits. Auto mode immediately re-renders on retry success.
3. The per-scene `↻ 重新生成` button on done cards reappears (`!videoGenerated` becomes truthy), letting the user continue fixing scenes.
4. The `重试该场景` button on failed cards keeps working — same path, same effect.

Also strips the stale `final_video` from the merged response inside `refreshImageReviewScene`. Without that, `applyWorkflowResponse(mergedResponse)` would restore `finalVideoUrl` from the (now-invalid) old public_url and undo the clear.

`localStorage.STORAGE_KEY_VIDEO_URL` is intentionally **not** cleared — that key powers the history-video list and the prior render should stay accessible there until a new one replaces it via `applyWorkflowResponse` on render completion.

## Why these four together

Each piece individually fixes a symptom; together they enforce one invariant. The user-reported behavior — playable video + `等待生成` placeholders + `等待候选图与音频生成完成…` — was three states implying three different positions in the pipeline simultaneously. After this PR that's structurally impossible:

| State | Conditions |
|---|---|
| Workflow running | no `final_video.public_url`, some placeholders in `waiting/refreshing` |
| Partial failure | no `final_video.public_url`, some placeholders in `failed`, retry CTAs visible |
| Done | `final_video.public_url` set, ALL placeholders in `done` |

## Test plan

- [ ] Run workflow where 1+ scenes fail (force via mock provider 5xx) — `final_video.status` = `blocked`, no `public_url`, `missing_scene_ids` populated
- [ ] Review tab shows failed scenes with red `失败` badge, `生成失败` copy, `重试该场景` button
- [ ] Click `重试该场景` → final-video card switches to `正在重新生成候选图` placeholder, no frozen old video
- [ ] Retry succeeds → auto mode kicks off re-render → new video appears
- [ ] Manual mode: retry succeeds → `生成视频` CTA reappears, click → re-render
- [ ] Existing legacy outputs.json (10/12) still loads cleanly — missing scenes show as `failed` via B3's terminal fallback