### PR TITLE
fix(studio): block render UI when scenes have persisted failures

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,71 @@
+# ====================== 1. 依赖文件夹（最大Token黑洞，必屏蔽）
+node_modules/
+venv/
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+target/
+*.jar
+*.class
+
+# ====================== 2. 打包构建产物（dist/build内容极多）
+dist/
+build/
+.next/
+out/
+*.generated.*
+
+# ====================== 3. 环境密钥（安全+省token双重作用）
+.env
+.env.local
+.env.*.local
+*.pem
+*.key
+secrets/
+
+# ====================== 4. 日志、缓存文件
+*.log
+npm-debug.log*
+yarn-debug.log*
+.cache/
+.parcel-cache/
+.pytest_cache/
+.mypy_cache/
+
+# ====================== 5. 测试报告、快照
+coverage/
+.nyc_output/
+__snapshots__/
+
+# ====================== 6. Git版本控制目录
+.git/
+.gitignore
+.svn/
+
+# ====================== 7. IDE编辑器配置文件
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# ====================== 8. 图片、视频、大资源文件（完全不需要读）
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.mp4
+*.svg
+assets/
+images/
+
+# ====================== 9. 系统垃圾文件
+.DS_Store
+Thumbs.db
+
+# ====================== 10. Claude自身缓存会话目录（必加）
+.claude/
+.claude-history
+conversation-history/

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -71,6 +71,7 @@
           v-if="
             renderMode === 'manual' &&
             assetsReady &&
+            !hasFailedAssets &&
             !renderInFlight &&
             !finalVideoUrl &&
             audioItemCount > 0 &&
@@ -161,6 +162,33 @@ const imageAssetCount = computed(() => {
   return Array.isArray(assets) ? assets.length : 0
 })
 
+// Scenes whose image generation failed and were persisted as
+// status='failed' placeholders by the backend (B1 in PR #154). When
+// any exist, the panel must short-circuit into a "图片生成失败" state
+// — rendering is blocked until the user clicks per-scene 重试. Without
+// this, length(image_assets.assets) reaches scene_count and assetsReady
+// flips to true, and the panel falsely shows "等待渲染 / 生成视频".
+const failedAssetCount = computed(() => {
+  const n = asNum(imageAssets.value?.failed_count)
+  if (n != null && n >= 0) return n
+  const ids = imageAssets.value?.failed_scene_ids
+  if (Array.isArray(ids)) return ids.length
+  const assets = imageAssets.value?.assets
+  if (Array.isArray(assets)) {
+    return assets.filter((a) => {
+      const status = asStr((a as UnknownRecord | null)?.status).toLowerCase()
+      return status === 'failed'
+    }).length
+  }
+  return 0
+})
+const hasFailedAssets = computed(() => failedAssetCount.value > 0)
+const generatedAssetCount = computed(() => {
+  const n = asNum(imageAssets.value?.generated_count)
+  if (n != null && n >= 0) return n
+  return Math.max(0, imageAssetCount.value - failedAssetCount.value)
+})
+
 // Title of the scene currently being refreshed — appended to the
 // inline progress pill so it matches the top progress bar's
 // "候选图生成中：11/12 · 美好的下午" copy. Without this, the user
@@ -214,7 +242,11 @@ const hasBlockingError = computed(() => {
 })
 
 const assetsReady = computed(() => {
-  return sceneCount.value > 0 && imageAssetCount.value >= sceneCount.value
+  return (
+    sceneCount.value > 0 &&
+    imageAssetCount.value >= sceneCount.value &&
+    !hasFailedAssets.value
+  )
 })
 
 const progressPct = computed(() => {
@@ -224,6 +256,13 @@ const progressPct = computed(() => {
     return Math.max(0, Math.min(100, Math.round(props.workflowStatusProgress)))
   }
   if (!sceneCount.value) return 0
+
+  // Failed scenes count against progress — show only the generated
+  // ratio so the bar visibly stays below the "ready" threshold.
+  if (hasFailedAssets.value) {
+    const ratio = Math.min(1, Math.max(0, generatedAssetCount.value / sceneCount.value))
+    return Math.floor(ratio * 85)
+  }
 
   const ratio = Math.min(1, Math.max(0, imageAssetCount.value / sceneCount.value))
   return Math.floor(ratio * 85)
@@ -237,8 +276,14 @@ const progressLabel = computed(() => {
   // otherwise trip the "失败" branch — but a user-initiated pause is not
   // a failure, and the copy should reflect that.
   if (props.cancelRequested) return '正在取消生成…'
-  if (props.pausedByUser) return `候选图已暂停（${imageAssetCount.value}/${sceneCount.value || '?'}）`
-  if (hasBlockingError.value) return `候选图生成失败（${imageAssetCount.value}/${sceneCount.value || '?'}）`
+  if (props.pausedByUser) return `候选图已暂停（${generatedAssetCount.value}/${sceneCount.value || '?'}）`
+  if (hasBlockingError.value) return `候选图生成失败（${generatedAssetCount.value}/${sceneCount.value || '?'}）`
+  // Persisted per-scene failures (B1). Must come BEFORE any check that
+  // counts asset length, since failed placeholders inflate the length
+  // and would otherwise let the state machine cross into "等待渲染".
+  if (hasFailedAssets.value && !props.refreshingImages && !props.sceneRefreshingId) {
+    return `候选图生成失败（${generatedAssetCount.value}/${sceneCount.value || '?'}）`
+  }
   if (workflowInFlight.value) return '处理中…'
   if (indeterminate.value) return '准备中…'
   if (props.finalVideoUrl) return '已生成'
@@ -249,9 +294,19 @@ const progressLabel = computed(() => {
       const sceneSuffix = currentRefreshingSceneTitle.value
         ? ` · ${currentRefreshingSceneTitle.value}`
         : ''
-      return `候选图生成中（${imageAssetCount.value}/${sceneCount.value}${sceneSuffix}）`
+      // Exclude failed placeholders from the count — a partial bulk
+      // refresh after a prior failure would otherwise show e.g. 12/12.
+      return `候选图生成中（${generatedAssetCount.value}/${sceneCount.value}${sceneSuffix}）`
     }
-    if (imageAssetCount.value > 0) return `候选图已暂停（${imageAssetCount.value}/${sceneCount.value}）`
+    // Per-scene retry triggered from a failed-scene card. Label matches
+    // the title ("正在重新生成候选图") and counts only successful assets.
+    if (props.sceneRefreshingId) {
+      const sceneSuffix = currentRefreshingSceneTitle.value
+        ? ` · ${currentRefreshingSceneTitle.value}`
+        : ''
+      return `正在重新生成（${generatedAssetCount.value}/${sceneCount.value}${sceneSuffix}）`
+    }
+    if (generatedAssetCount.value > 0) return `候选图已暂停（${generatedAssetCount.value}/${sceneCount.value}）`
     return `候选图待生成（0/${sceneCount.value}）`
   }
   return '等待用户触发渲染'
@@ -261,6 +316,9 @@ const placeholderTitle = computed(() => {
   if (props.cancelRequested) return '正在取消生成'
   if (props.pausedByUser) return '候选图已暂停'
   if (hasBlockingError.value) return '候选图生成失败'
+  if (hasFailedAssets.value && !props.refreshingImages && !props.sceneRefreshingId) {
+    return '场景图片生成失败'
+  }
   if (workflowInFlight.value) return '正在生成分镜'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '正在生成视频'
   if (!sceneCount.value) return '等待分镜'
@@ -287,6 +345,9 @@ const placeholderDesc = computed(() => {
   }
   if (hasBlockingError.value) {
     return blockingErrorMessage.value
+  }
+  if (hasFailedAssets.value && !props.refreshingImages && !props.sceneRefreshingId) {
+    return `${failedAssetCount.value} 个场景的候选图生成失败，请点击对应场景的「重试该场景」按钮重新生成；全部成功后会自动继续合成视频。`
   }
   if (workflowInFlight.value) {
     return props.workflowStatusMessage || 'Workflow 已提交，后端正在生成故事与分镜。完成后会自动进入候选图与视频准备阶段。'

--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -205,6 +205,48 @@
         </div>
       </template>
 
+      <!-- ════ A3: Workflow halted by image failures.
+           Sits above B / E so failures dominate the right column even
+           when history exists or the workflow has settled. Without
+           this, a partially-failed run with no video shows either the
+           history grid or an empty illustration on the main tab — the
+           failure is only visible on the 画面审核 tab, which doesn't
+           match how the user navigates. ════ -->
+      <template v-else-if="hasImageFailures">
+        <div class="pp-work">
+          <div class="pp-work-head">
+            <div class="pp-work-head-left">
+              <div class="pp-work-eyebrow">本轮生成</div>
+              <div class="pp-work-filename">部分场景候选图失败，请前往「画面审核」重试</div>
+            </div>
+            <span class="pp-work-badge pp-work-badge--failed">
+              <span class="pp-work-badge-dot" aria-hidden="true"></span>
+              生成失败 · 工作流
+            </span>
+          </div>
+
+          <ol class="pp-work-flow" aria-label="生成链路">
+            <template v-for="(step, idx) in workflowChain" :key="step.id">
+              <li :class="['pp-flow-node', `pp-flow-node--${step.state}`]">
+                <span class="pp-flow-dot" aria-hidden="true"></span>
+                <span class="pp-flow-label">{{ step.label }}</span>
+              </li>
+              <li
+                v-if="idx < workflowChain.length - 1"
+                :class="['pp-flow-link', { 'pp-flow-link--done': step.state === 'done' }]"
+                aria-hidden="true"
+              ></li>
+            </template>
+          </ol>
+
+          <div class="pp-work-foot">
+            <span class="pp-work-foot-text">
+              已完成 {{ doneCount }} / {{ workflowChain.length }} 步骤
+            </span>
+          </div>
+        </div>
+      </template>
+
       <!-- ════ B: Has history but no current — history as main content ════ -->
       <div v-else-if="allVideoUrls.length > 0" class="pp-hist-main">
         <div class="pp-hist-main-header">
@@ -383,6 +425,14 @@ const props = defineProps<{
   // want the workflow chain to STAY visible (video step active) so the
   // page doesn't look frozen during the wait.
   awaitingManualRender?: boolean
+  // True when image_assets has persisted failed-scene placeholders.
+  // Drives the workflow chain into a halted state: images step shows
+  // as 'failed' (red), and the audio/subtitle/video steps stay
+  // pending. Without this, the chain advances past the image step
+  // (since the backend reports image_assets as a completed step in
+  // step_summaries) and visually claims everything is done — directly
+  // contradicting the FinalVideoPanel showing "场景图片生成失败".
+  hasImageFailures?: boolean
   statusLabel?: string
   completedSteps?: number
   totalSteps?: number
@@ -522,7 +572,7 @@ const progressSteps = computed(() => {
 //   • otherwise          → derive from completedSteps / totalSteps
 // Stage indices into STEP_DEFS:
 //   0 story · 1 storyboard · 2 images · 3 voice · 4 subtitles · 5 video
-type FlowState = 'done' | 'active' | 'pending'
+type FlowState = 'done' | 'active' | 'pending' | 'failed'
 
 // During the initial workflow run, the backend's `completed_steps` walks
 // through ~11 internal stages including audio/subtitle/video — but those
@@ -549,6 +599,23 @@ function buildChainWithActive(activeIdx: number) {
 }
 
 const workflowChain = computed<{ id: string; label: string; flowLabel: string; state: FlowState }[]>(() => {
+  // Image failures halt the pipeline. Story / storyboard are done by
+  // definition (image generation can't have failed without those
+  // running first), images shows 'failed', downstream stays pending.
+  // Sits above renderInFlight so a stale prior-render in-flight flag
+  // can't overrule a fresh failure state — but in practice render
+  // wouldn't be in flight when failures are persisted (B2 gate).
+  if (props.hasImageFailures) {
+    return STEP_DEFS.map((step, idx) => ({
+      ...step,
+      state: (
+        idx <= 1 ? 'done'           // story / storyboard
+        : idx === 2 ? 'failed'      // images — halted
+        : 'pending'                 // voice / subtitle / video
+      ) as FlowState,
+    }))
+  }
+
   // Final-video render — every prior step is finished, only "视频合成" is live.
   if (props.renderInFlight) return buildChainWithActive(5)
 
@@ -1235,6 +1302,16 @@ const doneCount = computed(
   animation: ppFlowPulse 1.6s ease-in-out infinite;
 }
 
+.pp-work-badge--failed {
+  border-color: color-mix(in srgb, #f87171 50%, transparent);
+  background: color-mix(in srgb, #f87171 12%, transparent);
+  color: #fca5a5;
+}
+.pp-work-badge--failed .pp-work-badge-dot {
+  background: #f87171;
+  box-shadow: 0 0 6px color-mix(in srgb, #f87171 60%, transparent);
+}
+
 /* ═══════════════════════════════════════════════
    Workflow Timeline — minimalist horizontal rail
    • 6 stops along a continuous 1px gold rail
@@ -1286,6 +1363,14 @@ const doneCount = computed(
   animation: ppFlowPulse 1.8s ease-in-out infinite;
 }
 
+.pp-flow-node--failed .pp-flow-dot {
+  background: #f87171;
+  border-color: #f87171;
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, #f87171 22%, transparent),
+    0 0 10px color-mix(in srgb, #f87171 45%, transparent);
+}
+
 .pp-flow-label {
   position: absolute;
   top: calc(100% + 8px);
@@ -1306,6 +1391,11 @@ const doneCount = computed(
 
 .pp-flow-node--active .pp-flow-label {
   color: var(--arc-200);
+  font-weight: 600;
+}
+
+.pp-flow-node--failed .pp-flow-label {
+  color: #f87171;
   font-weight: 600;
 }
 

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -675,10 +675,44 @@ const isWorkflowReadyForRender = computed(() => {
   const audioEnabled = audioSegments?.enabled === true
   const audioOk = !audioEnabled || audioItems.length > 0
 
+  // image_assets.assets includes status='failed' placeholders (B1), so
+  // length alone can hit scene_count on a partially-failed run. Exclude
+  // those — otherwise the auto-render watcher sees ready=true and the
+  // manual hint banner ("候选图尚未就绪") incorrectly disappears.
+  const failedCountRaw = imageAssets?.failed_count
+  const failedCount = typeof failedCountRaw === 'number' ? failedCountRaw : 0
+  const failedIdsLen = Array.isArray(imageAssets?.failed_scene_ids)
+    ? imageAssets.failed_scene_ids.length
+    : 0
+  const failedFromStatus = imageAssetList.filter(
+    (a: any) => typeof a?.status === 'string' && a.status.toLowerCase() === 'failed',
+  ).length
+  const totalFailed = Math.max(failedCount, failedIdsLen, failedFromStatus)
+  const successfulAssetCount = imageAssetList.length - totalFailed
+
   return (
     scenes.length > 0 &&
-    imageAssetList.length >= scenes.length &&
+    successfulAssetCount >= scenes.length &&
     audioOk
+  )
+})
+
+// Exposed for the manual-mode hint below (and any other consumer that
+// needs to distinguish "still generating" from "stopped with failures").
+const hasImageFailures = computed(() => {
+  const imageAssets = currentWorkflowResponse.value?.outputs?.image_assets as
+    | Record<string, unknown>
+    | undefined
+  if (!imageAssets) return false
+  const failedCount =
+    typeof imageAssets.failed_count === 'number' ? imageAssets.failed_count : 0
+  if (failedCount > 0) return true
+  const ids = imageAssets.failed_scene_ids
+  if (Array.isArray(ids) && ids.length > 0) return true
+  const assets = imageAssets.assets
+  if (!Array.isArray(assets)) return false
+  return assets.some(
+    (a: any) => typeof a?.status === 'string' && a.status.toLowerCase() === 'failed',
   )
 })
 
@@ -2325,6 +2359,22 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
   if (scenes.length === 0) return
   if (imageAssetList.length < scenes.length) return
 
+  // Per-scene failures (B1) inflate imageAssetList.length to scene_count
+  // with status='failed' placeholders. The length check above can't tell
+  // them apart, so check the explicit failure signals here. Without this,
+  // auto-mode would POST /v1/final-video/render on a partially-failed
+  // workflow — the backend would 4xx (B2 gate), but better to short-circuit.
+  const failedCountRaw = imageAssets?.failed_count
+  const failedCount = typeof failedCountRaw === 'number' ? failedCountRaw : 0
+  const failedIds = Array.isArray(imageAssets?.failed_scene_ids)
+    ? (imageAssets.failed_scene_ids as unknown[]).length
+    : 0
+  const hasFailedFromStatus = imageAssetList.some((a) => {
+    const status = (a as Record<string, unknown> | null)?.status
+    return typeof status === 'string' && status.toLowerCase() === 'failed'
+  })
+  if (failedCount > 0 || failedIds > 0 || hasFailedFromStatus) return
+
   // 允许无声视频
   // 只有在 audio_segments 存在且明确 enabled=true 但没有生成时才阻止
   const audioEnabled = audioSegments?.enabled === true
@@ -3371,6 +3421,7 @@ async function runWorkflow() {
         :is-processing="workflowIsProcessing"
         :refreshing-images="refreshingImageReview"
         :awaiting-manual-render="awaitingManualRender"
+        :has-image-failures="hasImageFailures"
         :status-label="workflowRunStatusMessage || (refreshingImageReview ? reviewRefreshProgress.text : '')"
         :completed-steps="workflowStatusData?.completed_steps ?? 0"
         :total-steps="workflowStatusData?.total_steps ?? 0"
@@ -3417,7 +3468,7 @@ async function runWorkflow() {
                 @render="renderFinalVideoIfReady(currentWorkflowResponse || {})"
                 :show-render-button="workflowForm.renderMode === 'auto'"
               />
-              <div v-if="workflowForm.renderMode === 'manual' && !isWorkflowReadyForRender" class="manual-hint" style="text-align:center;padding:0.5rem 0 0;">
+              <div v-if="workflowForm.renderMode === 'manual' && !isWorkflowReadyForRender && !hasImageFailures" class="manual-hint" style="text-align:center;padding:0.5rem 0 0;">
                 等待候选图与音频生成完成…
               </div>
             </div>


### PR DESCRIPTION
## Summary
- 修复 B1 写入 `image_assets` 失败占位后，前端 5 个消费者仍按数组长度判定就绪的回归
- FinalVideoPanel 失败分支：标题/描述/进度/「生成视频」按钮均切到失败语义，count 改用 `generated_count` 而非 `assets.length`
- StudioView.isWorkflowReadyForRender 收紧（排除 failed），renderFinalVideoIfReady 显式短路
- StudioPreviewPanel 链路图新增 `failed` FlowState + halted-state 模板分支，让链路在 settled-failure 下能见

## Why
不变量在 B1 改了：`assets.length === scene_count ⟺ 成功` → `generated_count === scene_count ⟺ 成功`。原本静默丢失败的代码路径下"长度法"恰好可用，B1 让失败显式入数组后全线失真。语义变了但 TS 抓不到，5 个消费者都中招。

## Test plan
- [ ] 伪造 2 个 failed scene：FinalVideoPanel 标题 `场景图片生成失败`，描述要求重试，进度停在 generated 比例，无「生成视频」按钮
- [ ] retry 单 scene：标题 `正在重新生成候选图`，进度 `正在重新生成（10/12 · 场景名）`
- [ ] 主页右栏 StudioPreviewPanel 显示红色 `生成失败` 链路图，定格在 images 步骤
- [ ] retry 全部成功后：manual 出按钮 / auto 自动渲染，链路图正常推进