### PR TITLE
fix(images): explicit failed-scene tracking + settled-failure top bar

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -487,29 +487,68 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         print("[image-review] refresh-scene runtime error", repr(e))
-        # Persist the failure into image_assets BEFORE re-raising so the
-        # caller can rely on outputs.json reflecting all terminal failures
-        # even if this call is the last in a bulk-refresh loop (no
-        # follow-up API call would otherwise commit this scene's failure).
+        # On terminal failure we need to write outputs.json such that the
+        # FE can see this scene as failed even if it had a *prior*
+        # successful selection (i.e. user retried an already-generated
+        # scene and the retry blew up). Steps:
+        #   1. drop the current scene from image_review.selected_assets
+        #      so the helper doesn't emit a stale `generated` entry for
+        #      it (which would mask the failure)
+        #   2. add the current scene to known_failed_scene_ids so the
+        #      helper emits a `failed` placeholder
+        #   3. patch BOTH image_assets and (if modified) image_review to
+        #      disk so a page reload sees the same state
+        #   4. embed the rebuilt assets+review in the 502 detail so the
+        #      FE can update its in-memory state without a reload
+        rebuilt_image_assets = None
+        rebuilt_image_review: dict | None = None
         try:
             failed_ids = list(req.known_failed_scene_ids or [])
             current_scene = str(req.scene_id or "").strip()
             if current_scene and current_scene not in failed_ids:
                 failed_ids.append(current_scene)
+
+            review_for_fallback: dict = dict(req.image_review or {})
+            prior_selected = review_for_fallback.get("selected_assets") or []
+            review_changed = False
+            if isinstance(prior_selected, list) and current_scene:
+                kept = [
+                    s for s in prior_selected
+                    if not (
+                        isinstance(s, dict)
+                        and str(s.get("scene_id") or "").strip() == current_scene
+                    )
+                ]
+                if len(kept) != len(prior_selected):
+                    review_for_fallback["selected_assets"] = kept
+                    review_for_fallback["selected_count"] = len(kept)
+                    review_changed = True
+
             storyboard_scenes = (req.storyboard or {}).get("scenes") or []
-            rebuilt = _runner.build_image_assets_from_selected_assets(
+            rebuilt_image_assets = _runner.build_image_assets_from_selected_assets(
                 run_id=req.run_id,
-                image_review=req.image_review or {},
+                image_review=review_for_fallback,
                 provider=str(_runner._image_provider_name()),
                 storyboard_scenes=storyboard_scenes,
                 known_failed_scene_ids=failed_ids,
             )
-            _patch_workflow_outputs(req.workflow_id, {"image_assets": rebuilt})
+
+            patch: dict = {"image_assets": rebuilt_image_assets}
+            if review_changed:
+                rebuilt_image_review = review_for_fallback
+                patch["image_review"] = review_for_fallback
+            _patch_workflow_outputs(req.workflow_id, patch)
         except Exception as persist_err:
             print("[image-review] failed to persist failure", repr(persist_err))
+
+        detail = _refresh_scene_error_detail(req, e)
+        if rebuilt_image_assets is not None:
+            detail["image_assets"] = rebuilt_image_assets
+        if rebuilt_image_review is not None:
+            detail["image_review"] = rebuilt_image_review
         raise HTTPException(
             status_code=502,
-            detail=_refresh_scene_error_detail(req, e),
+            detail=detail,
         ) from e
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -459,6 +459,7 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
             image_prompts=req.image_prompts,
             video_provider=req.video_provider,
             preserve_seed=req.preserve_seed,
+            known_failed_scene_ids=list(req.known_failed_scene_ids or []),
         )
         print("[image-review] refresh-scene completed", req.run_id, req.scene_id)
 
@@ -486,6 +487,26 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         print("[image-review] refresh-scene runtime error", repr(e))
+        # Persist the failure into image_assets BEFORE re-raising so the
+        # caller can rely on outputs.json reflecting all terminal failures
+        # even if this call is the last in a bulk-refresh loop (no
+        # follow-up API call would otherwise commit this scene's failure).
+        try:
+            failed_ids = list(req.known_failed_scene_ids or [])
+            current_scene = str(req.scene_id or "").strip()
+            if current_scene and current_scene not in failed_ids:
+                failed_ids.append(current_scene)
+            storyboard_scenes = (req.storyboard or {}).get("scenes") or []
+            rebuilt = _runner.build_image_assets_from_selected_assets(
+                run_id=req.run_id,
+                image_review=req.image_review or {},
+                provider=str(_runner._image_provider_name()),
+                storyboard_scenes=storyboard_scenes,
+                known_failed_scene_ids=failed_ids,
+            )
+            _patch_workflow_outputs(req.workflow_id, {"image_assets": rebuilt})
+        except Exception as persist_err:
+            print("[image-review] failed to persist failure", repr(persist_err))
         raise HTTPException(
             status_code=502,
             detail=_refresh_scene_error_detail(req, e),

--- a/app/main.py
+++ b/app/main.py
@@ -487,65 +487,63 @@ def refresh_image_review_scene(req: ImageReviewRefreshSceneRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         print("[image-review] refresh-scene runtime error", repr(e))
-        # On terminal failure we need to write outputs.json such that the
-        # FE can see this scene as failed even if it had a *prior*
-        # successful selection (i.e. user retried an already-generated
-        # scene and the retry blew up). Steps:
-        #   1. drop the current scene from image_review.selected_assets
-        #      so the helper doesn't emit a stale `generated` entry for
-        #      it (which would mask the failure)
-        #   2. add the current scene to known_failed_scene_ids so the
-        #      helper emits a `failed` placeholder
-        #   3. patch BOTH image_assets and (if modified) image_review to
-        #      disk so a page reload sees the same state
-        #   4. embed the rebuilt assets+review in the 502 detail so the
-        #      FE can update its in-memory state without a reload
+        # Two failure semantics, discriminated by whether the current
+        # scene was already in image_review.selected_assets:
+        #
+        #   had_prior_success=True (重新生成 case):
+        #     The scene already had a valid generated image. The retry
+        #     blew up but the workflow state is *unchanged* — old
+        #     selection still wins. Do NOT strip selected_assets, do
+        #     NOT mark the scene failed, do NOT patch outputs.json.
+        #     The FE shows a non-blocking toast and the pipeline keeps
+        #     its assets-ready state.
+        #
+        #   had_prior_success=False (重试该场景 case):
+        #     The scene had no valid image. Persist this failure so the
+        #     FE's failure-aware UI engages:
+        #       1. add current scene to known_failed_scene_ids so the
+        #          helper emits a `failed` placeholder
+        #       2. patch image_assets to disk
+        #       3. embed rebuilt assets in the 502 detail so the FE
+        #          updates in-memory state without a reload
+        current_scene = str(req.scene_id or "").strip()
+        prior_selected_raw = (req.image_review or {}).get("selected_assets") or []
+        had_prior_success = bool(current_scene) and isinstance(
+            prior_selected_raw, list
+        ) and any(
+            isinstance(s, dict)
+            and str(s.get("scene_id") or "").strip() == current_scene
+            for s in prior_selected_raw
+        )
+
         rebuilt_image_assets = None
-        rebuilt_image_review: dict | None = None
-        try:
-            failed_ids = list(req.known_failed_scene_ids or [])
-            current_scene = str(req.scene_id or "").strip()
-            if current_scene and current_scene not in failed_ids:
-                failed_ids.append(current_scene)
-
-            review_for_fallback: dict = dict(req.image_review or {})
-            prior_selected = review_for_fallback.get("selected_assets") or []
-            review_changed = False
-            if isinstance(prior_selected, list) and current_scene:
-                kept = [
-                    s for s in prior_selected
-                    if not (
-                        isinstance(s, dict)
-                        and str(s.get("scene_id") or "").strip() == current_scene
+        if not had_prior_success:
+            try:
+                failed_ids = list(req.known_failed_scene_ids or [])
+                if current_scene and current_scene not in failed_ids:
+                    failed_ids.append(current_scene)
+                storyboard_scenes = (req.storyboard or {}).get("scenes") or []
+                rebuilt_image_assets = (
+                    _runner.build_image_assets_from_selected_assets(
+                        run_id=req.run_id,
+                        image_review=req.image_review or {},
+                        provider=str(_runner._image_provider_name()),
+                        storyboard_scenes=storyboard_scenes,
+                        known_failed_scene_ids=failed_ids,
                     )
-                ]
-                if len(kept) != len(prior_selected):
-                    review_for_fallback["selected_assets"] = kept
-                    review_for_fallback["selected_count"] = len(kept)
-                    review_changed = True
-
-            storyboard_scenes = (req.storyboard or {}).get("scenes") or []
-            rebuilt_image_assets = _runner.build_image_assets_from_selected_assets(
-                run_id=req.run_id,
-                image_review=review_for_fallback,
-                provider=str(_runner._image_provider_name()),
-                storyboard_scenes=storyboard_scenes,
-                known_failed_scene_ids=failed_ids,
-            )
-
-            patch: dict = {"image_assets": rebuilt_image_assets}
-            if review_changed:
-                rebuilt_image_review = review_for_fallback
-                patch["image_review"] = review_for_fallback
-            _patch_workflow_outputs(req.workflow_id, patch)
-        except Exception as persist_err:
-            print("[image-review] failed to persist failure", repr(persist_err))
+                )
+                _patch_workflow_outputs(
+                    req.workflow_id, {"image_assets": rebuilt_image_assets}
+                )
+            except Exception as persist_err:
+                print(
+                    "[image-review] failed to persist failure",
+                    repr(persist_err),
+                )
 
         detail = _refresh_scene_error_detail(req, e)
         if rebuilt_image_assets is not None:
             detail["image_assets"] = rebuilt_image_assets
-        if rebuilt_image_review is not None:
-            detail["image_review"] = rebuilt_image_review
         raise HTTPException(
             status_code=502,
             detail=detail,

--- a/app/schemas/workflow.py
+++ b/app/schemas/workflow.py
@@ -278,6 +278,13 @@ class ImageReviewRefreshSceneRequest(BaseModel):
     # (default), a fresh time-based seed_jitter is mixed in so the
     # output is a visibly different roll.
     preserve_seed: bool = Field(default=False)
+    # IDs of scenes whose image generation has already been attempted
+    # and definitively failed (all provider+quality retries exhausted)
+    # during the caller's current run. Used by the image_assets writer
+    # to emit explicit `status='failed'` placeholders only for these
+    # scenes — not for scenes that just happen to be missing from
+    # selected_assets because they're still queued.
+    known_failed_scene_ids: List[str] = Field(default_factory=list)
 
 
 class ImageReviewRefreshSceneResponse(BaseModel):

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -1485,6 +1485,7 @@ class WorkflowRunner:
         image_prompts: Optional[Dict[str, Any]] = None,
         video_provider: str = "mock",
         preserve_seed: bool = False,
+        known_failed_scene_ids: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         return self._image_review.refresh_image_review_scene(
             workflow_id=workflow_id,
@@ -1498,6 +1499,7 @@ class WorkflowRunner:
             image_prompts=image_prompts,
             video_provider=video_provider,
             preserve_seed=preserve_seed,
+            known_failed_scene_ids=known_failed_scene_ids,
         )
 
     def refresh_image_review(

--- a/app/services/runner.py
+++ b/app/services/runner.py
@@ -241,12 +241,14 @@ class WorkflowRunner:
         image_review: Dict[str, Any],
         provider: str,
         storyboard_scenes: Optional[List[Dict[str, Any]]] = None,
+        known_failed_scene_ids: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         return self._image_selection_support.build_image_assets_from_selected_assets(
             run_id=run_id,
             image_review=image_review,
             provider=provider,
             storyboard_scenes=storyboard_scenes,
+            known_failed_scene_ids=known_failed_scene_ids,
         )
 
     def get_real_kling_samples_manifest(self) -> Dict[str, Any]:

--- a/app/services/runner_audio_render_support.py
+++ b/app/services/runner_audio_render_support.py
@@ -29,27 +29,21 @@ class RunnerAudioRenderSupport:
         self._runner = runner
 
     def _effective_voice_mode(self, ctx: Any) -> str:
-        voice_mode = self._runner._normalized_voice_mode(ctx.input.voice_mode)
-        if voice_mode != "single":
-            return voice_mode
-
-        has_character_input = any(
-            bool(str(getattr(ctx.input, field, "") or "").strip())
-            for field in (
-                "main_character",
-                "main_character_display",
-                "secondary_character",
-                "secondary_character_display",
-            )
-        )
-        has_character_profiles = bool(
-            getattr(ctx.input, "character_speaker_profiles", {}) or {}
-        )
-
-        if has_character_input or has_character_profiles:
-            return "character"
-
-        return voice_mode
+        # Strictly honor the UI-selected voice_mode. An earlier revision
+        # auto-upgraded 'single' to 'character' when any character input
+        # (main_character_display / main_character / secondary_*) was
+        # present, on the theory that the user "forgot" to switch modes.
+        # That coupling broke packages where character identity is set
+        # for *image-generation* lock (primaryCharacterDisplayName) but
+        # the user genuinely wants single-narrator audio — Studio
+        # showed "单人旁白" while audio rendered 童音+女声 because the
+        # upgrade silently rerouted dialogue through character speakers.
+        #
+        # voice_mode and structured-character info are orthogonal axes:
+        #   - structured characters → cross-scene visual identity lock
+        #   - voice_mode → how many voices in audio output
+        # We no longer infer one from the other.
+        return self._runner._normalized_voice_mode(ctx.input.voice_mode)
 
     def run_dialogue_script(self, ctx: Any, outputs: Dict[str, Any]) -> Dict[str, Any]:
         sentence_shots = outputs.get("sentence_shots") or {}

--- a/app/services/runner_image_review.py
+++ b/app/services/runner_image_review.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class RunnerImageReviewSupport:
@@ -412,6 +412,7 @@ class RunnerImageReviewSupport:
         image_prompts: Dict[str, Any] | None = None,
         video_provider: str = "mock",
         preserve_seed: bool = False,
+        known_failed_scene_ids: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         runner = self._runner
 
@@ -517,6 +518,7 @@ class RunnerImageReviewSupport:
                 single_scene_assets.get("provider") or runner._image_provider_name()
             ),
             storyboard_scenes=storyboard_scenes,
+            known_failed_scene_ids=known_failed_scene_ids,
         )
 
         video_prompts = runner._run_video_prompts(ctx, outputs)

--- a/app/services/runner_image_selection_support.py
+++ b/app/services/runner_image_selection_support.py
@@ -14,18 +14,31 @@ class RunnerImageSelectionSupport:
         image_review: Dict[str, Any],
         provider: str,
         storyboard_scenes: Optional[List[Dict[str, Any]]] = None,
+        known_failed_scene_ids: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Synthesize image_assets from the user's review selections.
 
-        When ``storyboard_scenes`` is provided, any scene that has no
-        successful selected asset is emitted as an explicit
-        ``status='failed'`` placeholder so ``len(assets) == scene_count``
-        is preserved on disk. Without this, scenes whose per-scene
-        refresh API call failed (timeout / 5xx / image provider error)
-        were silently dropped from the persisted outputs — downstream
-        consumers (frontend placeholder builder, render gate) then
-        couldn't tell pending from permanently-failed scenes, and the
-        UI showed "等待生成" for scenes that would never resolve.
+        Failed-scene placeholders are emitted ONLY for scenes whose IDs
+        are explicitly listed in ``known_failed_scene_ids``. Earlier
+        revisions inferred "failed" from "absence in selected_assets",
+        but during bulk refresh that wrongly marked scenes still queued
+        for processing as failed — counts on the FE diverged from the
+        FE's own placeholder state, and the user briefly saw red 失败
+        cards for scenes that would generate successfully a moment
+        later. The caller is now responsible for tracking which scenes
+        truly failed (after the provider+quality retry layers inside
+        one /v1/image-review/refresh-scene call exhausted) and passing
+        that set in.
+
+        Not-yet-attempted scenes intentionally do NOT appear in the
+        output array. The FE's placeholder builder treats missing
+        scenes as 'waiting' (the workflow is still running) unless the
+        workflow has terminated, in which case they degrade to failed
+        via the legacy-terminal heuristic.
+
+        ``storyboard_scenes`` is still used to look up scene titles for
+        the failed-placeholder records; without it the placeholder
+        falls back to scene_id as its title.
         """
         selected_assets = image_review.get("selected_assets") or []
 
@@ -83,18 +96,31 @@ class RunnerImageSelectionSupport:
                 if scene_id:
                     completed_scene_ids.add(scene_id)
 
-        # Failed-scene placeholders. Only emitted when the caller passes
-        # the full storyboard.scenes list — older callers (no scenes
-        # arg) keep the legacy behavior so this refactor is safe to land
-        # incrementally.
+        # Failed-scene placeholders. Only emitted for scenes the caller
+        # has *explicitly* told us failed. Scenes absent from both
+        # ``selected_assets`` AND ``known_failed_scene_ids`` are treated
+        # as not-yet-attempted and intentionally omitted from the output.
         failed_scene_ids: List[str] = []
+        scenes_by_id: Dict[str, Dict[str, Any]] = {}
         if isinstance(storyboard_scenes, list):
             for scene in storyboard_scenes:
                 if not isinstance(scene, dict):
                     continue
-                scene_id = str(scene.get("scene_id") or "").strip()
-                if not scene_id or scene_id in completed_scene_ids:
+                sid = str(scene.get("scene_id") or "").strip()
+                if sid:
+                    scenes_by_id[sid] = scene
+
+        if known_failed_scene_ids:
+            for raw_id in known_failed_scene_ids:
+                scene_id = str(raw_id or "").strip()
+                if not scene_id:
                     continue
+                if scene_id in completed_scene_ids:
+                    # Caller marked it failed earlier but it has since
+                    # succeeded (e.g. retry-then-success) — selected_assets
+                    # wins, no failure placeholder.
+                    continue
+                scene = scenes_by_id.get(scene_id, {})
                 scene_title = str(scene.get("scene_title") or scene_id).strip()
                 merged_assets.append(
                     {
@@ -102,7 +128,7 @@ class RunnerImageSelectionSupport:
                         "scene_title": scene_title,
                         "status": "failed",
                         "error_message": (
-                            "image generation failed and was not retried"
+                            "image generation failed after all retries"
                         ),
                         "file_name": None,
                         "relative_path": None,

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -302,6 +302,20 @@ const progressLabel = computed(() => {
   if (props.finalVideoUrl) return '已生成'
   if (props.renderInFlight || finalStatus.value === 'rendering') return '视频渲染中'
   if (!sceneCount.value) return '等待 Storyboard'
+  // Per-scene retry — applies whether or not assetsReady is true:
+  //   - assetsReady=false (重试该场景 on a failed scene): retry to repair
+  //   - assetsReady=true  (重新生成 on a done scene): retry to swap a
+  //     candidate while the workflow is otherwise settled
+  // Both want the label to reflect the active retry, not the surrounding
+  // settled state. Counts are dropped because they don't move during a
+  // single-scene retry (stays e.g. 5/6 throughout) and would just add
+  // noise — the scene title alone tells the user what's in flight.
+  if (props.sceneRefreshingId && !props.refreshingImages) {
+    const sceneSuffix = currentRefreshingSceneTitle.value
+      ? ` · ${currentRefreshingSceneTitle.value}`
+      : ''
+    return `正在重新生成${sceneSuffix}`
+  }
   if (!assetsReady.value) {
     if (props.refreshingImages) {
       const sceneSuffix = currentRefreshingSceneTitle.value
@@ -310,14 +324,6 @@ const progressLabel = computed(() => {
       // Exclude failed placeholders from the count — a partial bulk
       // refresh after a prior failure would otherwise show e.g. 12/12.
       return `候选图生成中（${generatedAssetCount.value}/${sceneCount.value}${sceneSuffix}）`
-    }
-    // Per-scene retry triggered from a failed-scene card. Label matches
-    // the title ("正在重新生成候选图") and counts only successful assets.
-    if (props.sceneRefreshingId) {
-      const sceneSuffix = currentRefreshingSceneTitle.value
-        ? ` · ${currentRefreshingSceneTitle.value}`
-        : ''
-      return `正在重新生成（${generatedAssetCount.value}/${sceneCount.value}${sceneSuffix}）`
     }
     if (generatedAssetCount.value > 0) return `候选图已暂停（${generatedAssetCount.value}/${sceneCount.value}）`
     return `候选图待生成（0/${sceneCount.value}）`

--- a/frontend/src/components/FinalVideoPanel.vue
+++ b/frontend/src/components/FinalVideoPanel.vue
@@ -47,13 +47,25 @@
               <span>{{ progressPct }}%</span>
               <span class="ph-dot">·</span>
             </template>
-            <span>{{ progressLabel }}</span>
+            <!-- During any in-flight phase, use InlineStatusPulse so the
+                 label gets the same left-pulse + trailing 3-dot ellipsis
+                 animation as the top global progress bar. Outside in-flight
+                 (e.g. settled-failure, 等待用户触发渲染), render the plain
+                 label so we don't imply ongoing work. -->
+            <InlineStatusPulse
+              v-if="isAnyLoading"
+              :text="progressLabel"
+              variant="running"
+            />
+            <span v-else>{{ progressLabel }}</span>
           </div>
         </div>
-        <!-- Global bar is active → just a pulsing status chip -->
+        <!-- Global bar is active → pulsing status chip. Uses the same
+             InlineStatusPulse component the top bar uses, so the chip
+             carries the same left pulse dot + trailing 3-dot ellipsis
+             animation. -->
         <div v-else class="ph-status-chip">
-          <span class="ph-status-dot"/>
-          {{ progressLabel }}
+          <InlineStatusPulse :text="progressLabel" variant="running" />
         </div>
 
         <!-- Manual-mode render CTA. Shows in the BODY of the placeholder
@@ -93,6 +105,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import GenerationLoadingAnimation from './studio/GenerationLoadingAnimation.vue'
+import InlineStatusPulse from './studio/InlineStatusPulse.vue'
 
 type UnknownRecord = Record<string, unknown>
 
@@ -597,32 +610,19 @@ const placeholderDesc = computed(() => {
 }
 .ph-render-cta:active { transform: translateY(0); }
 
-/* Minimal status chip shown when global bar is covering the progress */
+/* Status chip shown when global bar is covering the progress. The
+   left pulse dot + trailing 3-dot ellipsis come from the embedded
+   InlineStatusPulse component, so the chip only owns the pill
+   container styling here. */
 .ph-status-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
   padding: 5px 12px;
   border-radius: 999px;
   border: 1px solid rgba(245,158,11,0.20);
   background: rgba(245,158,11,0.07);
   font-size: 12px;
-  color: var(--text-muted);
   margin: 0 auto;
-}
-
-.ph-status-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--arc-400);
-  box-shadow: 0 0 6px rgba(245,158,11,0.70);
-  animation: dotPulse 1.4s ease-in-out infinite;
-}
-
-@keyframes dotPulse {
-  0%,100% { opacity: 1; transform: scale(1); }
-  50%      { opacity: 0.5; transform: scale(0.75); }
 }
 
 .render-button {

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -839,19 +839,33 @@ function syncDevModeToUrl(enabled: boolean) {
 const devModeToast = ref('')
 let devModeToastTimer: ReturnType<typeof setTimeout> | null = null
 
-// Generic non-blocking notice toast (mirrors devModeToast). Used for
-// outcomes that the user should be informed of but that don't change
-// the UI state machine — e.g. 重新生成 failure where the prior image
-// is still valid and the workflow is unchanged.
-const inlineNotice = ref('')
+// Generic non-blocking notice toast (mirrors devModeToast pattern but
+// styled distinctly). Used for outcomes that should be highly visible
+// but don't change the UI state machine — e.g. 重新生成 failure where
+// the prior image is still valid and the workflow is unchanged.
+//
+// Position is TOP-CENTER (not bottom-right) so it sits in the user's
+// active reading zone rather than under floating action buttons. The
+// `tone` field tints the border + leading icon — 'warn' covers
+// soft-error cases like "retry failed but state preserved". Duration
+// default is generous (8s) and the user can dismiss any time by
+// clicking the toast.
+const inlineNotice = ref<{ text: string; tone: 'info' | 'warn' } | null>(null)
 let inlineNoticeTimer: ReturnType<typeof setTimeout> | null = null
-function showInlineNotice(text: string, durationMs = 3500) {
-  inlineNotice.value = text
+function showInlineNotice(text: string, tone: 'info' | 'warn' = 'info', durationMs = 8000) {
+  inlineNotice.value = { text, tone }
   if (inlineNoticeTimer) clearTimeout(inlineNoticeTimer)
   inlineNoticeTimer = setTimeout(() => {
-    inlineNotice.value = ''
+    inlineNotice.value = null
     inlineNoticeTimer = null
   }, durationMs)
+}
+function dismissInlineNotice() {
+  inlineNotice.value = null
+  if (inlineNoticeTimer) {
+    clearTimeout(inlineNoticeTimer)
+    inlineNoticeTimer = null
+  }
 }
 
 function toggleDevMode() {
@@ -2724,7 +2738,10 @@ async function retryImageReviewScene(sceneId: string) {
       // placeholder back to 'done' so the card returns to its prior
       // visual, and surface the failure via a non-blocking toast.
       markPlaceholderState(sceneId, 'done')
-      showInlineNotice(`${sceneId} 重新生成失败，已保留原图。请稍后再试。`)
+      showInlineNotice(
+        `${sceneId} 重新生成失败，已保留原图。${message}`,
+        'warn',
+      )
     } else {
       markPlaceholderState(sceneId, 'failed', message)
       errorMessage.value = message
@@ -4014,14 +4031,29 @@ async function runWorkflow() {
     </Transition>
   </Teleport>
 
-  <!-- Generic non-blocking notice toast — bottom-right so it doesn't
-       collide with the dev-mode toast (top-left). Used for outcomes
-       that the user should know about but that don't change the UI
-       state machine (e.g. 重新生成 failed but original image preserved). -->
+  <!-- Generic non-blocking notice toast — top-center, prominent, click
+       to dismiss. Used for outcomes that the user should clearly know
+       about but that don't change the UI state machine (e.g. 重新生成
+       failed but original image preserved). -->
   <Teleport to="body">
     <Transition name="confirm-fade">
-      <div v-if="inlineNotice" class="inline-notice" role="status">
-        {{ inlineNotice }}
+      <div
+        v-if="inlineNotice"
+        class="inline-notice"
+        :class="`inline-notice--${inlineNotice.tone}`"
+        role="alert"
+        @click="dismissInlineNotice"
+      >
+        <span class="inline-notice__icon" aria-hidden="true">
+          {{ inlineNotice.tone === 'warn' ? '⚠' : 'ℹ' }}
+        </span>
+        <span class="inline-notice__text">{{ inlineNotice.text }}</span>
+        <button
+          type="button"
+          class="inline-notice__close"
+          aria-label="关闭提示"
+          @click.stop="dismissInlineNotice"
+        >×</button>
       </div>
     </Transition>
   </Teleport>
@@ -5144,31 +5176,90 @@ details.summary-item[open] > summary .summary-chevron { transform: rotate(90deg)
   .dev-mode-toast { left: 76px; }
 }
 
-/* Generic notice toast — mirrors .dev-mode-toast styling but anchored
-   bottom-right so the two never overlap, and uses a softer (non-gold)
-   border so users don't conflate it with the dev-mode indicator. */
+/* Generic notice toast — top-center, prominent, click to dismiss.
+   Distinct shape from dev-mode-toast (which is a tiny corner pill) so
+   the user reads this as a real notification rather than a passive
+   status chip. `tone` variants tint the border + leading icon. */
 .inline-notice {
   position: fixed;
-  bottom: 24px;
-  right: 24px;
-  z-index: 1400;
-  padding: 9px 14px;
-  border-radius: 8px;
-  background: rgba(20, 16, 8, 0.94);
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1500;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px 12px 16px;
+  border-radius: 12px;
+  background: rgba(18, 14, 8, 0.96);
   color: var(--text-primary);
   border: 1px solid color-mix(in srgb, var(--text-secondary) 30%, transparent);
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-weight: 500;
   letter-spacing: 0.01em;
-  line-height: 1.4;
-  max-width: 360px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.42);
-  pointer-events: none;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  line-height: 1.5;
+  max-width: min(560px, calc(100vw - 32px));
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.50),
+              0 4px 12px rgba(0, 0, 0, 0.30);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  cursor: pointer;
+}
+.inline-notice--info {
+  border-color: color-mix(in srgb, var(--arc-300) 50%, transparent);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.50),
+              0 0 0 1px color-mix(in srgb, var(--arc-300) 20%, transparent);
+}
+.inline-notice--warn {
+  border-color: color-mix(in srgb, #f59e0b 65%, transparent);
+  background: rgba(28, 18, 8, 0.96);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.55),
+              0 0 0 1px color-mix(in srgb, #f59e0b 30%, transparent);
+}
+.inline-notice__icon {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+.inline-notice--info .inline-notice__icon {
+  color: var(--arc-200);
+  background: color-mix(in srgb, var(--arc-300) 18%, transparent);
+}
+.inline-notice--warn .inline-notice__icon {
+  color: #fbbf24;
+  background: color-mix(in srgb, #f59e0b 20%, transparent);
+}
+.inline-notice__text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.inline-notice__close {
+  flex: 0 0 auto;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.25rem;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0 4px;
+  margin-left: 4px;
+  border-radius: 4px;
+  line-height: 1;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.inline-notice__close:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
 }
 @media (max-width: 720px) {
-  .inline-notice { right: 16px; bottom: 16px; max-width: calc(100vw - 32px); }
+  .inline-notice { top: 64px; padding: 10px 12px; font-size: 0.8125rem; }
 }
 
 .confirm-overlay {

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -2525,8 +2525,9 @@ async function refreshImageReviewScene(
 
   if (!response.ok) {
     let message = ''
+    let errorBody: any = null
     try {
-      const errorBody = await response.json()
+      errorBody = await response.json()
       console.warn('[image-review] refresh-scene failed', sceneId, response.status, errorBody)
       message = formatImageReviewUserError(sceneId, response.status, errorBody)
     } catch {
@@ -2536,6 +2537,40 @@ async function refreshImageReviewScene(
         response.status >= 500
           ? `${sceneId} 候选图生成失败：图片服务暂时不可用，请稍后重试。`
           : `${sceneId} 候选图生成失败：请稍后重试。`
+    }
+
+    // On 502 the backend has already persisted the failure into
+    // outputs.json (main.py fallback) and embeds the rebuilt
+    // image_assets / image_review in the error detail. Merge them into
+    // the in-memory workflow response so the failure-aware UI (top bar
+    // failure label, hidden 生成视频 button, FinalVideoPanel failure
+    // branch) all reflect the new state immediately — without needing
+    // a page reload to re-fetch outputs.json.
+    if (errorBody && currentWorkflowResponse.value) {
+      const detail: Record<string, unknown> | undefined =
+        errorBody.detail && typeof errorBody.detail === 'object'
+          ? (errorBody.detail as Record<string, unknown>)
+          : (errorBody as Record<string, unknown>)
+      const detailImageAssets = detail?.image_assets
+      const detailImageReview = detail?.image_review
+      if (detailImageAssets || detailImageReview) {
+        const priorOutputs = (currentWorkflowResponse.value.outputs || {}) as Record<
+          string,
+          unknown
+        >
+        // Drop stale final_video here too — same reason as the success
+        // path below: a previously-rendered video no longer matches the
+        // image set after a failed retry of one of its scenes.
+        const { final_video: _staleVideo, ...priorOutputsSansVideo } = priorOutputs
+        void _staleVideo
+        const mergedOutputs: Record<string, unknown> = { ...priorOutputsSansVideo }
+        if (detailImageAssets) mergedOutputs.image_assets = detailImageAssets
+        if (detailImageReview) mergedOutputs.image_review = detailImageReview
+        applyWorkflowResponse({
+          ...currentWorkflowResponse.value,
+          outputs: mergedOutputs,
+        })
+      }
     }
 
     throw new Error(message)

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -697,6 +697,31 @@ const isWorkflowReadyForRender = computed(() => {
   )
 })
 
+// Label for the settled-failure top progress bar — "候选图生成失败 5/6".
+// Reads image_assets.generated_count / failed_count when present (B1
+// writes both), falls back to scanning the assets array. Distinct from
+// reviewRefreshProgress.text (which is only meaningful during an
+// in-flight refresh loop).
+const settledFailureLabel = computed(() => {
+  const imageAssets = currentWorkflowResponse.value?.outputs?.image_assets as
+    | Record<string, unknown>
+    | undefined
+  const storyboard = currentWorkflowResponse.value?.outputs?.storyboard as
+    | Record<string, unknown>
+    | undefined
+  const scenes = Array.isArray(storyboard?.scenes) ? storyboard.scenes : []
+  const total = scenes.length
+  const assets = Array.isArray(imageAssets?.assets) ? imageAssets.assets : []
+  const generatedRaw = imageAssets?.generated_count
+  const generated =
+    typeof generatedRaw === 'number'
+      ? generatedRaw
+      : assets.filter(
+          (a: any) => typeof a?.status === 'string' && a.status.toLowerCase() !== 'failed',
+        ).length
+  return `候选图生成失败（${generated}/${total || '?'}）— 在「画面审核」重试`
+})
+
 // Exposed for the manual-mode hint below (and any other consumer that
 // needs to distinguish "still generating" from "stopped with failures").
 const hasImageFailures = computed(() => {
@@ -2425,7 +2450,18 @@ async function renderFinalVideoIfReady(baseResponse: WorkflowRunResponse) {
   }
 }
 
-async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qualityTierOverride?: string, preserveSeed: boolean = false) {
+async function refreshImageReviewScene(
+  sceneId: string,
+  signal?: AbortSignal,
+  qualityTierOverride?: string,
+  preserveSeed: boolean = false,
+  // IDs of scenes that have *terminally* failed during the caller's
+  // current activity (bulk refresh loop OR all previously-recorded
+  // failures from outputs.json on a single-scene retry). Forwarded
+  // to the backend so image_assets only writes failed placeholders
+  // for these — not for scenes still queued for processing.
+  knownFailedSceneIds?: string[],
+) {
   if (!currentWorkflowResponse.value || !currentWorkflowPayload.value) {
     return
   }
@@ -2466,6 +2502,7 @@ async function refreshImageReviewScene(sceneId: string, signal?: AbortSignal, qu
         ? currentWorkflowPayload.value.input.video_provider
         : workflowForm.value.videoProvider,
     preserve_seed: preserveSeed,
+    known_failed_scene_ids: knownFailedSceneIds ?? [],
   }
 
   let response: Response
@@ -2577,8 +2614,30 @@ async function retryImageReviewScene(sceneId: string) {
   // applyWorkflowResponse on render completion.
   finalVideoUrl.value = ''
 
+  // Carry forward the prior failed-scene list so the backend keeps
+  // those marked as failed during this retry's image_assets rebuild.
+  // EXCLUDE the current scene — if its retry succeeds, the backend's
+  // selected_assets check naturally drops it from failures anyway, but
+  // sending it would also work; if it fails again, main.py's failure
+  // handler will add it back.
+  const priorImageAssets = currentWorkflowResponse.value?.outputs?.image_assets as
+    | Record<string, unknown>
+    | undefined
+  const priorFailedIds = priorImageAssets?.failed_scene_ids
+  const knownFailed: string[] = Array.isArray(priorFailedIds)
+    ? (priorFailedIds as unknown[])
+        .map((id) => String(id || '').trim())
+        .filter((id) => Boolean(id) && id !== sceneId)
+    : []
+
   try {
-    await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal)
+    await refreshImageReviewScene(
+      sceneId,
+      imageReviewRefreshAbortController.signal,
+      undefined,
+      false,
+      knownFailed,
+    )
     if (workflowForm.value.renderMode === 'auto' && currentWorkflowResponse.value) {
       void renderFinalVideoIfReady(currentWorkflowResponse.value)
     }
@@ -2855,6 +2914,24 @@ async function refreshImageReview() {
   const failures: string[] = []
   const refreshTotal = sceneRefreshQueue.value.length
 
+  // Failed scene_ids accumulated during *this* loop. Forwarded to the
+  // backend on each refresh-scene call so image_assets only writes
+  // 'failed' placeholders for scenes that genuinely terminally failed
+  // (not for scenes still queued for processing). Seeded from the
+  // current outputs in case a prior partial-failure run left some
+  // failed scenes that we're resuming over.
+  const failedSceneIds = new Set<string>()
+  const priorImageAssets = currentWorkflowResponse.value?.outputs?.image_assets as
+    | Record<string, unknown>
+    | undefined
+  const priorFailedIds = priorImageAssets?.failed_scene_ids
+  if (Array.isArray(priorFailedIds)) {
+    for (const id of priorFailedIds) {
+      const sid = String(id || '').trim()
+      if (sid) failedSceneIds.add(sid)
+    }
+  }
+
   try {
     for (const sceneId of sceneRefreshQueue.value) {
       if (imageReviewRefreshCancelled.value) {
@@ -2863,7 +2940,17 @@ async function refreshImageReview() {
 
       imageReviewRefreshAbortController = new AbortController()
       try {
-        await refreshImageReviewScene(sceneId, imageReviewRefreshAbortController.signal)
+        await refreshImageReviewScene(
+          sceneId,
+          imageReviewRefreshAbortController.signal,
+          undefined,
+          false,
+          Array.from(failedSceneIds),
+        )
+        // Success path — if this scene was previously failed (resumed
+        // partial run), drop it from the failed set so subsequent
+        // calls don't re-mark it.
+        failedSceneIds.delete(sceneId)
       } catch (error) {
         if (
           imageReviewRefreshCancelled.value ||
@@ -2875,6 +2962,7 @@ async function refreshImageReview() {
 
         const message = error instanceof Error ? error.message : '候选图分场景刷新失败'
         failures.push(message)
+        failedSceneIds.add(sceneId)
         markPlaceholderState(sceneId, 'failed', message)
       } finally {
         imageReviewRefreshAbortController = null
@@ -3361,7 +3449,8 @@ async function runWorkflow() {
           refreshingImageReview ||
           awaitingManualRender ||
           finalVideoRenderInFlight ||
-          Boolean(sceneRefreshingId)
+          Boolean(sceneRefreshingId) ||
+          hasImageFailures
         "
         :percent="
           singleSceneRetryActive
@@ -3370,7 +3459,9 @@ async function runWorkflow() {
               ? 92
               : awaitingManualRender
                 ? 85
-                : (workflowStatusProgress ?? (refreshingImageReview ? reviewRefreshProgress.percent : 0))
+                : hasImageFailures
+                  ? 70
+                  : (workflowStatusProgress ?? (refreshingImageReview ? reviewRefreshProgress.percent : 0))
         "
         :label="
           singleSceneRetryActive
@@ -3379,9 +3470,11 @@ async function runWorkflow() {
               ? '正在合成视频（音频、字幕、画面拼接中）'
               : awaitingManualRender
                 ? '候选图已就绪，等待你点击「生成视频」'
-                : (workflowIsProcessing ? workflowRunStatusMessage : reviewRefreshProgress.text)
+                : hasImageFailures
+                  ? settledFailureLabel
+                  : (workflowIsProcessing ? workflowRunStatusMessage : reviewRefreshProgress.text)
         "
-        :cancellable="phaseCancellable && !awaitingManualRender && !singleSceneRetryActive"
+        :cancellable="phaseCancellable && !awaitingManualRender && !singleSceneRetryActive && !hasImageFailures"
         :cancel-requested="cancelRequestedAny"
         @cancel="cancelActivePhase"
       />

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -839,6 +839,21 @@ function syncDevModeToUrl(enabled: boolean) {
 const devModeToast = ref('')
 let devModeToastTimer: ReturnType<typeof setTimeout> | null = null
 
+// Generic non-blocking notice toast (mirrors devModeToast). Used for
+// outcomes that the user should be informed of but that don't change
+// the UI state machine — e.g. 重新生成 failure where the prior image
+// is still valid and the workflow is unchanged.
+const inlineNotice = ref('')
+let inlineNoticeTimer: ReturnType<typeof setTimeout> | null = null
+function showInlineNotice(text: string, durationMs = 3500) {
+  inlineNotice.value = text
+  if (inlineNoticeTimer) clearTimeout(inlineNoticeTimer)
+  inlineNoticeTimer = setTimeout(() => {
+    inlineNotice.value = ''
+    inlineNoticeTimer = null
+  }, durationMs)
+}
+
 function toggleDevMode() {
   devMode.value = !devMode.value
   devModeToast.value = devMode.value ? 'Dev mode 已开启' : 'Dev mode 已关闭'
@@ -867,6 +882,10 @@ onBeforeUnmount(() => {
   if (devModeToastTimer) {
     clearTimeout(devModeToastTimer)
     devModeToastTimer = null
+  }
+  if (inlineNoticeTimer) {
+    clearTimeout(inlineNoticeTimer)
+    inlineNoticeTimer = null
   }
 })
 
@@ -2629,25 +2648,40 @@ async function retryImageReviewScene(sceneId: string) {
   errorMessage.value = ''
   imageReviewRefreshAbortController = new AbortController()
 
-  // Retrying a failed scene invalidates the existing final video — it
-  // was rendered without this scene (or with a stale version of it).
-  // Clearing finalVideoUrl does three things at once:
-  //   1. FinalVideoPanel falls through to the placeholder branch and
-  //      picks up the existing "正在重新生成候选图" copy + animation,
-  //      so the user no longer sees a frozen old video paired with
-  //      "等待候选图生成完成…".
-  //   2. renderFinalVideoIfReady's `if (finalVideoUrl.value) return`
-  //      guard no longer short-circuits, so a successful retry in
-  //      auto mode immediately kicks off a re-render with the now-
-  //      complete image set.
-  //   3. The 重新生成 (per-scene) button on done cards reappears
-  //      because its `!videoGenerated` guard flips back to truthy —
-  //      the user can keep fixing other scenes too.
-  // localStorage's STORAGE_KEY_VIDEO_URL is intentionally NOT removed
-  // here — that key feeds the history-video list, which should keep
-  // the prior video accessible until a new one writes back via
-  // applyWorkflowResponse on render completion.
-  finalVideoUrl.value = ''
+  // ── Intent detection ────────────────────────────────────────────
+  // Two callers, two semantics:
+  //   • 重试该场景 (failed-card button)  → scene has NO valid image;
+  //     failure here is bad, must propagate through the failure UI.
+  //   • 重新生成 (done-card ↻ button)   → scene already has a valid
+  //     image (still in selected_assets); failure here is harmless,
+  //     old image preserved, state unchanged.
+  // Discriminator: presence in image_review.selected_assets.
+  const priorOutputsSnapshot = currentWorkflowResponse.value?.outputs || {}
+  const priorReview = priorOutputsSnapshot.image_review as
+    | Record<string, unknown>
+    | undefined
+  const priorSelected = Array.isArray(priorReview?.selected_assets)
+    ? priorReview.selected_assets
+    : []
+  const hadPriorSuccess = priorSelected.some(
+    (s: any) =>
+      s && typeof s === 'object' && String(s.scene_id || '').trim() === sceneId,
+  )
+
+  // ── finalVideoUrl handling ──────────────────────────────────────
+  // Clear ONLY in the 重试该场景 case. The 重新生成 button only shows
+  // when no video exists yet (so finalVideoUrl is already empty), but
+  // making the conditional explicit prevents a future state shift from
+  // accidentally wiping a valid video. Original side-effects of the
+  // clear were:
+  //   1. FinalVideoPanel falls through to placeholder + animation
+  //   2. renderFinalVideoIfReady's URL guard no longer short-circuits
+  //   3. per-scene 重新生成 button reappears
+  // All three only matter when the workflow was previously blocked by
+  // a missing scene — i.e. !hadPriorSuccess.
+  if (!hadPriorSuccess) {
+    finalVideoUrl.value = ''
+  }
 
   // Carry forward the prior failed-scene list so the backend keeps
   // those marked as failed during this retry's image_assets rebuild.
@@ -2655,7 +2689,7 @@ async function retryImageReviewScene(sceneId: string) {
   // selected_assets check naturally drops it from failures anyway, but
   // sending it would also work; if it fails again, main.py's failure
   // handler will add it back.
-  const priorImageAssets = currentWorkflowResponse.value?.outputs?.image_assets as
+  const priorImageAssets = priorOutputsSnapshot.image_assets as
     | Record<string, unknown>
     | undefined
   const priorFailedIds = priorImageAssets?.failed_scene_ids
@@ -2683,8 +2717,18 @@ async function retryImageReviewScene(sceneId: string) {
     }
 
     const message = error instanceof Error ? error.message : '候选图场景重试失败'
-    markPlaceholderState(sceneId, 'failed', message)
-    errorMessage.value = message
+    if (hadPriorSuccess) {
+      // 重新生成 failed: original image still in selected_assets, all
+      // pipeline state is intact (assetsReady stays true, 生成视频 button
+      // stays visible, no failure cascade). Revert the 'refreshing'
+      // placeholder back to 'done' so the card returns to its prior
+      // visual, and surface the failure via a non-blocking toast.
+      markPlaceholderState(sceneId, 'done')
+      showInlineNotice(`${sceneId} 重新生成失败，已保留原图。请稍后再试。`)
+    } else {
+      markPlaceholderState(sceneId, 'failed', message)
+      errorMessage.value = message
+    }
   } finally {
     sceneRefreshingId.value = ''
     imageReviewRefreshAbortController = null
@@ -3969,6 +4013,18 @@ async function runWorkflow() {
       </div>
     </Transition>
   </Teleport>
+
+  <!-- Generic non-blocking notice toast — bottom-right so it doesn't
+       collide with the dev-mode toast (top-left). Used for outcomes
+       that the user should know about but that don't change the UI
+       state machine (e.g. 重新生成 failed but original image preserved). -->
+  <Teleport to="body">
+    <Transition name="confirm-fade">
+      <div v-if="inlineNotice" class="inline-notice" role="status">
+        {{ inlineNotice }}
+      </div>
+    </Transition>
+  </Teleport>
 </template>
 
 <style scoped>
@@ -5086,6 +5142,33 @@ details.summary-item[open] > summary .summary-chevron { transform: rotate(90deg)
 }
 @media (max-width: 720px) {
   .dev-mode-toast { left: 76px; }
+}
+
+/* Generic notice toast — mirrors .dev-mode-toast styling but anchored
+   bottom-right so the two never overlap, and uses a softer (non-gold)
+   border so users don't conflate it with the dev-mode indicator. */
+.inline-notice {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1400;
+  padding: 9px 14px;
+  border-radius: 8px;
+  background: rgba(20, 16, 8, 0.94);
+  color: var(--text-primary);
+  border: 1px solid color-mix(in srgb, var(--text-secondary) 30%, transparent);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1.4;
+  max-width: 360px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.42);
+  pointer-events: none;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+@media (max-width: 720px) {
+  .inline-notice { right: 16px; bottom: 16px; max-width: calc(100vw - 32px); }
 }
 
 .confirm-overlay {


### PR DESCRIPTION
## Summary
- Bulk refresh 中间态不再把"还没轮到的场景"错误标 failed —— B1 helper 改成只为 caller 显式传入的 `known_failed_scene_ids` 写 failed 占位
- FE 在 bulk refresh 循环里维护 failed 集合，每次 refresh-scene 调用都把累计的失败列表带给后端
- 单场景重试也带上现有 `failed_scene_ids`（除当前正在重试的）
- main.py 在 refresh-scene 抛 502 时也把当前场景写进 image_assets failed —— 防止 bulk 循环最后一个场景失败时无后续调用提交
- StudioProgress visibility/label 加 `hasImageFailures` 分支 —— 失败终态顶部条不再消失

## Why
- **Issue 1（5/6 vs 1/6 不一致）**：B1 之前的 helper 用"不在 selected_assets = 失败"推断，bulk refresh 中间态把待处理的场景一并标 failed。FE 顶部条用自己维护的 placeholder（5/6 正确），FinalVideoPanel 读后端 image_assets（被错误标 failed 拉高 failed_count → "1/6"）
- **Issue 2（失败显示出现太早）**：同一根因。还没 retry 完的场景被提前显示红色失败卡，"自己恢复"实际是后端刚轮到它做生成
- **Issue 3（失败终态顶部条消失）**：原 visibility 4 个条件全 false，bar 隐藏，用户需要滚下去看 FinalVideoPanel 才知道状态

## Test plan
- [ ] 模拟部分场景失败的 bulk refresh：顶部 `5/6` 与 FinalVideoPanel `5/6` 一致（不再 `1/6`）
- [ ] 中间态没有过早出现 red 失败卡（只有真正失败的会出）
- [ ] 失败终态顶部 StudioProgress 显示 `候选图生成失败（5/6）— 在「画面审核」重试`，70% bar
- [ ] 单场景重试成功后该场景从 failed_scene_ids 移除；image_assets generated_count +1, failed_count -1
- [ ] 单场景重试再次失败：image_assets failed_scene_ids 保持不变（已含该 scene），不丢
- [ ] bulk 循环最后一个场景失败：refresh page，outputs.json 里 image_assets.failed_scene_ids 包含它