### PR TITLE
fix(studio): 本轮生成 card stays active during per-scene retry

### DIFF
--- a/frontend/src/components/studio/StudioPreviewPanel.vue
+++ b/frontend/src/components/studio/StudioPreviewPanel.vue
@@ -433,6 +433,11 @@ const props = defineProps<{
   // step_summaries) and visually claims everything is done — directly
   // contradicting the FinalVideoPanel showing "场景图片生成失败".
   hasImageFailures?: boolean
+  // Set while a per-scene retry is in flight (regardless of whether
+  // hasImageFailures is true — retry is the *recovery* path, so it
+  // should show 'active' image-step state, not the halted failure
+  // chain. Takes priority over hasImageFailures in workflowChain.
+  sceneRefreshingId?: string
   statusLabel?: string
   completedSteps?: number
   totalSteps?: number
@@ -599,6 +604,14 @@ function buildChainWithActive(activeIdx: number) {
 }
 
 const workflowChain = computed<{ id: string; label: string; flowLabel: string; state: FlowState }[]>(() => {
+  // Per-scene retry in flight — takes priority over hasImageFailures
+  // because retry IS the recovery path. Image step is back to
+  // 'active' (pulsing) instead of the halted red 'failed' state.
+  // Downstream stays pending until retry resolves.
+  if (props.sceneRefreshingId) {
+    return buildChainWithActive(2)
+  }
+
   // Image failures halt the pipeline. Story / storyboard are done by
   // definition (image generation can't have failed without those
   // running first), images shows 'failed', downstream stays pending.
@@ -682,7 +695,8 @@ const workInProgress = computed(
     props.isProcessing ||
     props.renderInFlight ||
     props.refreshingImages ||
-    props.awaitingManualRender,
+    props.awaitingManualRender ||
+    props.sceneRefreshingId,
   ),
 )
 const doneCount = computed(

--- a/frontend/src/views/StudioView.vue
+++ b/frontend/src/views/StudioView.vue
@@ -3665,7 +3665,12 @@ async function executeRunWorkflow() {
         :refreshing-images="refreshingImageReview"
         :awaiting-manual-render="awaitingManualRender"
         :has-image-failures="hasImageFailures"
-        :status-label="workflowRunStatusMessage || (refreshingImageReview ? reviewRefreshProgress.text : '')"
+        :scene-refreshing-id="sceneRefreshingId"
+        :status-label="
+          singleSceneRetryActive
+            ? `正在重新生成 ${sceneRefreshingId}`
+            : (workflowRunStatusMessage || (refreshingImageReview ? reviewRefreshProgress.text : ''))
+        "
         :completed-steps="workflowStatusData?.completed_steps ?? 0"
         :total-steps="workflowStatusData?.total_steps ?? 0"
         :cancellable="phaseCancellable"


### PR DESCRIPTION
## Summary
- StudioPreviewPanel 加 `sceneRefreshingId` prop
- `workflowChain` 在 `sceneRefreshingId` 时把 image step 设为 active（脉动），而不是失败态（红）
- `workInProgress` 包含 `sceneRefreshingId` → 模板分支走 A2（active）而不是 A3（静态失败）
- StudioView 给 `:status-label` 加上 `singleSceneRetryActive` 分支，文件名显示"正在重新生成 scene_XX"

## Why
重试是失败的恢复路径，不是失败本身。之前 retry 进行中右侧"本轮生成"卡片定在红 badge + 画面生成红圈点 —— 跟左侧 FinalVideoPanel 的"正在重新生成候选图"对不上。修完两边视觉一致。

## Test plan
- [ ] 失败终态（无 retry）：右侧卡片仍显示红 badge + 画面生成红点
- [ ] 点「重试该场景」→ 红 badge 变成"生成中 · 工作流"金色 pill，画面生成步骤变 active 脉动
- [ ] 卡片文件名行变成"正在重新生成 scene_XX"
- [ ] retry 成功后：badge 回 "生成中"→ assets ready 后回归正常流程
- [ ] retry 失败后：badge 回到失败态